### PR TITLE
Linter

### DIFF
--- a/.ci/gitlab/make_env_file.py
+++ b/.ci/gitlab/make_env_file.py
@@ -15,6 +15,7 @@
 import os
 from os.path import expanduser
 from shlex import quote
+
 home = expanduser("~")
 
 prefixes = os.environ.get('ENV_PREFIXES', 'BUILD SYSTEM GITLAB CODECOV CI encrypt TOKEN TESTS').split(' ')

--- a/.ci/gitlab/make_env_file.py
+++ b/.ci/gitlab/make_env_file.py
@@ -25,7 +25,7 @@ blacklist = [
     'CI_COMMIT_DESCRIPTION',
 ]
 env_file = os.environ.get('DOCKER_ENVFILE', os.path.join(home, 'env'))
-with open(env_file, 'wt') as env:
+with open(env_file, "w") as env:
     for k, v in os.environ.items():
         for pref in prefixes:
             if k.startswith(pref) and k not in blacklist:

--- a/.cmake_format.py
+++ b/.cmake_format.py
@@ -20,7 +20,11 @@ with section("parse"):  # noqa: F821
     additional_commands = {
         "foo": {
             "flags": ["BAR", "BAZ"],
-            "kwargs": {"DEPENDS": "*", "HEADERS": "*", "SOURCES": "*"},
+            "kwargs": {
+                "DEPENDS": "*",
+                "HEADERS": "*",
+                "SOURCES": "*"
+            },
         }
     }
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	url = https://github.com/dune-mirrors/dune-typetree.git
 [submodule "scripts"]
 	path = deps/scripts
-	url = https://github.com/wwu-numerik/scripts.git
+	url = https://github.com/dune-gdt/scripts.git
 [submodule "dune-testtools"]
 	path = deps/dune-testtools
 	url = https://github.com/dune-community/dune-testtools.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,9 +29,9 @@ repos:
         additional_dependencies: [pyyaml>=5.1] # see https://github.com/cheshirekow/cmake-format-precommit/pull/4#issuecomment-943444582
         exclude: "config.h.cmake|pybind11"
         args: ["--config-files=.cmake_format.py"]
--   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-    -   id: flake8
-        exclude: "^pybind11"
-        args: ["--config=./python/xt/setup.cfg"]
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.208'
+  hooks:
+      - id: ruff
+          # Respect `exclude` and `extend-exclude` settings.
+        args: ["--force-exclude", "--config=./python/ruff.toml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: 'v0.32.0'
     hooks:
     -   id: yapf
-        args: ["--style=.vcsetup/.style.yapf"]
+        args: ["--in-place", "--style=.vcsetup/.style.yapf"]
 -   repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: 'v0.6.13'
     hooks:

--- a/.pylicense-cpp.py
+++ b/.pylicense-cpp.py
@@ -19,10 +19,8 @@ license = '''Dual licensed as BSD 2-Clause License (http://opensource.org/licens
           with "runtime exception" (http://www.dune-project.org/license.html)'''
 prefix = '//'
 
-include_patterns = ('*.cc', '*.cxx', '*.hh', '*.hxx', '*cmake_config.h.in',
-                    '*headercheck.cpp.in', '*config.h.cmake', '*version.hh.in',
-                    '*.pbh', '*.tpl')
-exclude_patterns = ('*mathexpr.*', '*gtest-all.cc', '*.vcsetup*',
-                    '*gtest-all.cxx', '*.ci/shared/*', '*/deps/*', '*/wheelhouse/*',
-                    '*dune/xt/functions/expression/mathexpr.cc',
+include_patterns = ('*.cc', '*.cxx', '*.hh', '*.hxx', '*cmake_config.h.in', '*headercheck.cpp.in', '*config.h.cmake',
+                    '*version.hh.in', '*.pbh', '*.tpl')
+exclude_patterns = ('*mathexpr.*', '*gtest-all.cc', '*.vcsetup*', '*gtest-all.cxx', '*.ci/shared/*', '*/deps/*',
+                    '*/wheelhouse/*', '*dune/xt/functions/expression/mathexpr.cc',
                     '*dune/xt/functions/expression/mathexpr.hh')

--- a/.pylicense-md.py
+++ b/.pylicense-md.py
@@ -23,4 +23,7 @@ lead_in = '```'
 lead_out = '```'
 
 include_patterns = ('*.md', )
-exclude_patterns = ('*/deps/*', '*/wheelhouse/*',)
+exclude_patterns = (
+    '*/deps/*',
+    '*/wheelhouse/*',
+)

--- a/.pylicense-other.py
+++ b/.pylicense-other.py
@@ -21,14 +21,9 @@ prefix = '#'
 lead_in = '# ~~~'
 lead_out = '# ~~~'
 
-include_patterns = ('*.txt', '*.cmake', '*.py', '*.py.in', '*.pc.in', '*.sh',
-                    '*.bash', '*.dgf', '*.msh', '*.gdb', '*.cfg', '*.travis.*',
-                    '*.gitignore', '*.mailmap', '*.gitattributes',
-                    '*gitignore-*', '*stamp-vc', '*dune.module', '*Doxylocal',
-                    '*.clang-format', '*COPYING-CMAKE-SCRIPTS', '*README',
-                    '*LICENSE', '*mainpage', '*switch-build_dir',
-                    '*dune-xt.pc.in', '*CMakeLists.txt', '*.cmake.in',
-                    '*.py.in*')
-exclude_patterns = ('*config.h.cmake', '*.vcsetup*', 'FindEigen3.cmake',
-                    '*.dgf', '*builder_definitions.cmake', '*/deps/*', '*/wheelhouse/*',
-                    '*builder_definitions.cmake', '*.ci/shared/*')
+include_patterns = ('*.txt', '*.cmake', '*.py', '*.py.in', '*.pc.in', '*.sh', '*.bash', '*.dgf', '*.msh', '*.gdb',
+                    '*.cfg', '*.travis.*', '*.gitignore', '*.mailmap', '*.gitattributes', '*gitignore-*', '*stamp-vc',
+                    '*dune.module', '*Doxylocal', '*.clang-format', '*COPYING-CMAKE-SCRIPTS', '*README', '*LICENSE',
+                    '*mainpage', '*switch-build_dir', '*dune-xt.pc.in', '*CMakeLists.txt', '*.cmake.in', '*.py.in*')
+exclude_patterns = ('*config.h.cmake', '*.vcsetup*', 'FindEigen3.cmake', '*.dgf', '*builder_definitions.cmake',
+                    '*/deps/*', '*/wheelhouse/*', '*builder_definitions.cmake', '*.ci/shared/*')

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,2 @@
+pybind11/*
+deps/*

--- a/cmake/modules/versioneer.py
+++ b/cmake/modules/versioneer.py
@@ -88,7 +88,7 @@ def get_config_from_root(root):
     # the top of versioneer.py for instructions on writing your setup.cfg .
     parser = configparser.ConfigParser()
     parser.read_string(CONFIG)
-    VCS = parser.get("versioneer", "VCS")     # mandatory
+    VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):
         if parser.has_option("versioneer", name):
@@ -117,7 +117,7 @@ LONG_VERSION_PY = {}
 HANDLERS = {}
 
 
-def register_vcs_handler(vcs, method):     # decorator
+def register_vcs_handler(vcs, method):  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
 
     def decorate(f):
@@ -154,7 +154,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried %s" % (commands, ))
         return None, None
     stdout = p.communicate()[0].strip().decode()
     if p.returncode != 0:
@@ -294,7 +294,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     pieces = {}
     pieces["long"] = full_out
-    pieces["short"] = full_out[:7]     # maybe improved later
+    pieces["short"] = full_out[:7]  # maybe improved later
     pieces["error"] = None
 
     # parse describe_out. It will be like TAG-NUM-gHEX[-dirty] or HEX[-dirty]
@@ -337,7 +337,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         # HEX: no tags
         pieces["closest-tag"] = None
         count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
-        pieces["distance"] = int(count_out)     # total number of commits
+        pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
     date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[0].strip()
@@ -363,7 +363,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     """
     rootdirs = []
 
-    for i in range(3):
+    for _i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
             return {
@@ -375,7 +375,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
             }
         else:
             rootdirs.append(root)
-            root = os.path.dirname(root)     # up a level
+            root = os.path.dirname(root)  # up a level
 
     if verbose:
         print("Tried directories %s but none started with prefix %s" % (str(rootdirs), parentdir_prefix))
@@ -405,8 +405,8 @@ def versions_from_file(filename):
     try:
         with open(filename) as f:
             contents = f.read()
-    except OSError:
-        raise NotThisMethod("unable to read _version.py")
+    except OSError as oe:
+        raise NotThisMethod("unable to read _version.py") from oe
     mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S)
     if not mo:
         mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S)
@@ -568,7 +568,7 @@ def render(pieces, style):
         }
 
     if not style or style == "default":
-        style = "pep440"     # the default
+        style = "pep440"  # the default
 
     if style == "pep440":
         rendered = render_pep440(pieces)

--- a/cmake/modules/versioneer.py
+++ b/cmake/modules/versioneer.py
@@ -144,7 +144,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
                                  stdout=subprocess.PIPE,
                                  stderr=(subprocess.PIPE if hide_stderr else None))
             break
-        except EnvironmentError:
+        except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ENOENT:
                 continue
@@ -174,7 +174,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        f = open(versionfile_abs, "r")
+        f = open(versionfile_abs)
         for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
@@ -189,7 +189,7 @@ def git_get_keywords(versionfile_abs):
                 if mo:
                     keywords["date"] = mo.group(1)
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     return keywords
 
@@ -405,7 +405,7 @@ def versions_from_file(filename):
     try:
         with open(filename) as f:
             contents = f.read()
-    except EnvironmentError:
+    except OSError:
         raise NotThisMethod("unable to read _version.py")
     mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S)
     if not mo:

--- a/cmake/modules/versioneer.py
+++ b/cmake/modules/versioneer.py
@@ -34,6 +34,7 @@ https://img.shields.io/travis/com/python-versioneer/python-versioneer.svg
 
 """
 
+import ast
 import configparser
 import errno
 import json
@@ -41,7 +42,6 @@ import os
 import re
 import subprocess
 import sys
-import ast
 
 
 class VersioneerConfig:

--- a/dune/gdt/test/grids.py
+++ b/dune/gdt/test/grids.py
@@ -11,7 +11,7 @@
 # ~~~
 
 
-class Grids(object):
+class Grids:
 
     def __init__(self, cache):
         try:
@@ -36,7 +36,7 @@ class LeafGrids(Grids):
     yasp_view_fmt = 'Yasp{}dLeafGridViewType'
 
     def __init__(self, cache):
-        super(LeafGrids, self).__init__(cache)
+        super().__init__(cache)
 
 
 class LevelGrids(Grids):
@@ -51,4 +51,4 @@ class LevelGrids(Grids):
     yasp_view_fmt = 'Yasp{}dLevelGridViewType'
 
     def __init__(self, cache):
-        super(LevelGrids, self).__init__(cache)
+        super().__init__(cache)

--- a/dune/xt/test/common/vector.py
+++ b/dune/xt/test/common/vector.py
@@ -12,7 +12,9 @@
 # ~~~
 
 from itertools import product
-from vectors import vectortype, vectors, fieldtypes, vector_filter
+
+from vectors import fieldtypes, vector_filter, vectors, vectortype
+
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}'.format(mv, f)), vectortype(mv, f))

--- a/dune/xt/test/common/vector.py
+++ b/dune/xt/test/common/vector.py
@@ -17,6 +17,8 @@ from vectors import fieldtypes, vector_filter, vectors, vectortype
 
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
-testtypes = [(safe_name('{}_{}'.format(mv, f)), vectortype(mv, f))
-             for mv, f in product(vectors(cache), fieldtypes(cache))  # noqa: F821
-             if vector_filter(mv, f)]
+testtypes = [
+    (safe_name('{}_{}'.format(mv, f)), vectortype(mv, f))
+    for mv, f in product(vectors(cache), fieldtypes(cache))  # noqa: F821
+    if vector_filter(mv, f)
+]

--- a/dune/xt/test/common/vector.py
+++ b/dune/xt/test/common/vector.py
@@ -16,5 +16,5 @@ from vectors import vectortype, vectors, fieldtypes, vector_filter
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}'.format(mv, f)), vectortype(mv, f))
-             for mv, f in product(vectors(cache), fieldtypes(cache))
+             for mv, f in product(vectors(cache), fieldtypes(cache))  # noqa: F821
              if vector_filter(mv, f)]

--- a/dune/xt/test/functions/ESV2007_cutoff_1d.py
+++ b/dune/xt/test/functions/ESV2007_cutoff_1d.py
@@ -12,8 +12,6 @@
 # ~~~
 
 import grids
-import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dimDomain = [1]
 

--- a/dune/xt/test/functions/ESV2007_cutoff_1d.py
+++ b/dune/xt/test/functions/ESV2007_cutoff_1d.py
@@ -15,6 +15,6 @@ import grids
 
 dimDomain = [1]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {filename + '.cc': {'types': [(filename, grid)]} for filename, grid in multi_out.items()}

--- a/dune/xt/test/functions/ESV2007_cutoff_2d_3d.py
+++ b/dune/xt/test/functions/ESV2007_cutoff_2d_3d.py
@@ -12,8 +12,6 @@
 # ~~~
 
 import grids
-import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dimDomain = [2, 3]
 

--- a/dune/xt/test/functions/ESV2007_cutoff_2d_3d.py
+++ b/dune/xt/test/functions/ESV2007_cutoff_2d_3d.py
@@ -15,6 +15,6 @@ import grids
 
 dimDomain = [2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {filename + '.cc': {'types': [(filename, grid)]} for filename, grid in multi_out.items()}

--- a/dune/xt/test/functions/ESV2007_exact_solution.py
+++ b/dune/xt/test/functions/ESV2007_exact_solution.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/ESV2007_exact_solution.py
+++ b/dune/xt/test/functions/ESV2007_exact_solution.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/ESV2007_exact_solution.py
+++ b/dune/xt/test/functions/ESV2007_exact_solution.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/ESV2007_exact_solution.py
+++ b/dune/xt/test/functions/ESV2007_exact_solution.py
@@ -18,7 +18,7 @@ dim_range = [1]
 dim_range_cols = [1]
 dimDomain = [2]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/ESV2007_force.py
+++ b/dune/xt/test/functions/ESV2007_force.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/ESV2007_force.py
+++ b/dune/xt/test/functions/ESV2007_force.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/ESV2007_force.py
+++ b/dune/xt/test/functions/ESV2007_force.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/ESV2007_force.py
+++ b/dune/xt/test/functions/ESV2007_force.py
@@ -18,7 +18,7 @@ dim_range = [1]
 dim_range_cols = [1]
 dimDomain = [2]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/checkerboard.py
+++ b/dune/xt/test/functions/checkerboard.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/checkerboard.py
+++ b/dune/xt/test/functions/checkerboard.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/checkerboard.py
+++ b/dune/xt/test/functions/checkerboard.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/checkerboard.py
+++ b/dune/xt/test/functions/checkerboard.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/constant.py
+++ b/dune/xt/test/functions/constant.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/constant.py
+++ b/dune/xt/test/functions/constant.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/constant.py
+++ b/dune/xt/test/functions/constant.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/constant.py
+++ b/dune/xt/test/functions/constant.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/difference.py
+++ b/dune/xt/test/functions/difference.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/difference.py
+++ b/dune/xt/test/functions/difference.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/difference.py
+++ b/dune/xt/test/functions/difference.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/difference.py
+++ b/dune/xt/test/functions/difference.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/expression_matrix_valued.py
+++ b/dune/xt/test/functions/expression_matrix_valued.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/expression_matrix_valued.py
+++ b/dune/xt/test/functions/expression_matrix_valued.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/expression_matrix_valued.py
+++ b/dune/xt/test/functions/expression_matrix_valued.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [3]

--- a/dune/xt/test/functions/expression_matrix_valued.py
+++ b/dune/xt/test/functions/expression_matrix_valued.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [3]

--- a/dune/xt/test/functions/expression_parametric.py
+++ b/dune/xt/test/functions/expression_parametric.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/expression_parametric.py
+++ b/dune/xt/test/functions/expression_parametric.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/expression_parametric.py
+++ b/dune/xt/test/functions/expression_parametric.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/expression_parametric.py
+++ b/dune/xt/test/functions/expression_parametric.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/expression_vector_valued.py
+++ b/dune/xt/test/functions/expression_vector_valued.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/expression_vector_valued.py
+++ b/dune/xt/test/functions/expression_vector_valued.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/expression_vector_valued.py
+++ b/dune/xt/test/functions/expression_vector_valued.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/expression_vector_valued.py
+++ b/dune/xt/test/functions/expression_vector_valued.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/flattop.py
+++ b/dune/xt/test/functions/flattop.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/flattop.py
+++ b/dune/xt/test/functions/flattop.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/flattop.py
+++ b/dune/xt/test/functions/flattop.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/flattop.py
+++ b/dune/xt/test/functions/flattop.py
@@ -18,7 +18,7 @@ dim_range = [1]
 dim_range_cols = [1]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/generic_flux_function.py
+++ b/dune/xt/test/functions/generic_flux_function.py
@@ -19,7 +19,7 @@ dim_state = [1, 2]
 dim_range_cols = [1, 3]
 dimDomain = [1, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/generic_flux_function.py
+++ b/dune/xt/test/functions/generic_flux_function.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_state = [1, 2]

--- a/dune/xt/test/functions/generic_flux_function.py
+++ b/dune/xt/test/functions/generic_flux_function.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_state = [1, 2]

--- a/dune/xt/test/functions/generic_flux_function.py
+++ b/dune/xt/test/functions/generic_flux_function.py
@@ -25,5 +25,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, s, r, rC) for s, r, rC in itertools.product(dim_state, dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/generic_function.py
+++ b/dune/xt/test/functions/generic_function.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/generic_function.py
+++ b/dune/xt/test/functions/generic_function.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/generic_function.py
+++ b/dune/xt/test/functions/generic_function.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/generic_function.py
+++ b/dune/xt/test/functions/generic_function.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/generic_grid_function.py
+++ b/dune/xt/test/functions/generic_grid_function.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/generic_grid_function.py
+++ b/dune/xt/test/functions/generic_grid_function.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/generic_grid_function.py
+++ b/dune/xt/test/functions/generic_grid_function.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/generic_grid_function.py
+++ b/dune/xt/test/functions/generic_grid_function.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/grids.py
+++ b/dune/xt/test/functions/grids.py
@@ -39,9 +39,8 @@ def is_found(cache, name):
 
 def type_and_dim(cache, dimDomain):
     grid_alu = _if_active(_make_alu(dimDomain), 'dune-alugrid', cache)
-    grid_yasp = [
-        ('Dune::YaspGrid<{d},Dune::EquidistantOffsetCoordinates<double,{d}>>'.format(d=d), d) for d in dimDomain
-    ]
+    grid_yasp = [('Dune::YaspGrid<{d},Dune::EquidistantOffsetCoordinates<double,{d}>>'.format(d=d), d)
+                 for d in dimDomain]
     grid_ug = _if_active([('Dune::UGGrid<{}>'.format(d), d) for d in dimDomain if d != 1], 'dune-uggrid', cache)
     grid_alberta = _if_active([('Dune::AlbertaGrid<{d},{d}>'.format(d=d), d) for d in dimDomain if d != 1],
                               'ALBERTA_FOUND', cache)

--- a/dune/xt/test/functions/indicator_function.py
+++ b/dune/xt/test/functions/indicator_function.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/indicator_function.py
+++ b/dune/xt/test/functions/indicator_function.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/indicator_function.py
+++ b/dune/xt/test/functions/indicator_function.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/indicator_function.py
+++ b/dune/xt/test/functions/indicator_function.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/indicator_grid_function.py
+++ b/dune/xt/test/functions/indicator_grid_function.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/indicator_grid_function.py
+++ b/dune/xt/test/functions/indicator_grid_function.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/indicator_grid_function.py
+++ b/dune/xt/test/functions/indicator_grid_function.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/indicator_grid_function.py
+++ b/dune/xt/test/functions/indicator_grid_function.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/product.py
+++ b/dune/xt/test/functions/product.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/product.py
+++ b/dune/xt/test/functions/product.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/product.py
+++ b/dune/xt/test/functions/product.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/product.py
+++ b/dune/xt/test/functions/product.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/spe10_model1.py
+++ b/dune/xt/test/functions/spe10_model1.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/spe10_model1.py
+++ b/dune/xt/test/functions/spe10_model1.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/spe10_model1.py
+++ b/dune/xt/test/functions/spe10_model1.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/spe10_model1.py
+++ b/dune/xt/test/functions/spe10_model1.py
@@ -18,7 +18,7 @@ dim_range = [1]
 dim_range_cols = [1]
 dimDomain = [2]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/spe10_model2.py
+++ b/dune/xt/test/functions/spe10_model2.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/spe10_model2.py
+++ b/dune/xt/test/functions/spe10_model2.py
@@ -18,7 +18,7 @@ dim_range = [3]
 dim_range_cols = [3]
 dimDomain = [3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/spe10_model2.py
+++ b/dune/xt/test/functions/spe10_model2.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [3]
 dim_range_cols = [3]

--- a/dune/xt/test/functions/spe10_model2.py
+++ b/dune/xt/test/functions/spe10_model2.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [3]
 dim_range_cols = [3]

--- a/dune/xt/test/functions/sum_for_functions.py
+++ b/dune/xt/test/functions/sum_for_functions.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/sum_for_functions.py
+++ b/dune/xt/test/functions/sum_for_functions.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/sum_for_functions.py
+++ b/dune/xt/test/functions/sum_for_functions.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/sum_for_functions.py
+++ b/dune/xt/test/functions/sum_for_functions.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/sum_for_grid_functions.py
+++ b/dune/xt/test/functions/sum_for_grid_functions.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/sum_for_grid_functions.py
+++ b/dune/xt/test/functions/sum_for_grid_functions.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/sum_for_grid_functions.py
+++ b/dune/xt/test/functions/sum_for_grid_functions.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1, 3]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/functions/sum_for_grid_functions.py
+++ b/dune/xt/test/functions/sum_for_grid_functions.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1, 3]

--- a/dune/xt/test/functions/visualization.py
+++ b/dune/xt/test/functions/visualization.py
@@ -24,5 +24,6 @@ multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(ca
 multi_out = {
     filename + '.cc': {
         'types': [(filename, grid, r, rC) for r, rC in itertools.product(dim_range, dim_range_cols)]
-    } for filename, grid in multi_out.items()
+    }
+    for filename, grid in multi_out.items()
 }

--- a/dune/xt/test/functions/visualization.py
+++ b/dune/xt/test/functions/visualization.py
@@ -13,7 +13,6 @@
 
 import grids
 import itertools
-from dune.xt.codegen import typeid_to_typedef_name
 
 dim_range = [1, 3]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/visualization.py
+++ b/dune/xt/test/functions/visualization.py
@@ -11,8 +11,9 @@
 #   Tobias Leibner (2019 - 2020)
 # ~~~
 
-import grids
 import itertools
+
+import grids
 
 dim_range = [1, 3]
 dim_range_cols = [1]

--- a/dune/xt/test/functions/visualization.py
+++ b/dune/xt/test/functions/visualization.py
@@ -18,7 +18,7 @@ dim_range = [1, 3]
 dim_range_cols = [1]
 dimDomain = [1, 2, 3]
 
-multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}
+multi_out = {grids.pretty_print(g[0], g[1]): g[0] for g in grids.type_and_dim(cache, dimDomain)}  # noqa: F821
 
 multi_out = {
     filename + '.cc': {

--- a/dune/xt/test/grid/eoc_gridprovider.py
+++ b/dune/xt/test/grid/eoc_gridprovider.py
@@ -15,4 +15,8 @@ import dune.xt.test.grid_types as grid_types
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 # alberta needs manual flag adding in cmake, so we skip it here
-all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)  # noqa: F821
+all_grids = (
+    (safe_name(g), g)
+    for g in grid_types.all_types(cache, list(range(1, 4)))  # noqa: F821
+    if "Alberta" not in g
+)

--- a/dune/xt/test/grid/eoc_gridprovider.py
+++ b/dune/xt/test/grid/eoc_gridprovider.py
@@ -15,4 +15,4 @@ import dune.xt.test.grid_types as grid_types
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 # alberta needs manual flag adding in cmake, so we skip it here
-all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)
+all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)  # noqa: F821

--- a/dune/xt/test/grid/eoc_gridprovider.py
+++ b/dune/xt/test/grid/eoc_gridprovider.py
@@ -18,5 +18,4 @@ from dune.xt.codegen import typeid_to_typedef_name as safe_name
 all_grids = (
     (safe_name(g), g)
     for g in grid_types.all_types(cache, list(range(1, 4)))  # noqa: F821
-    if "Alberta" not in g
-)
+    if "Alberta" not in g)

--- a/dune/xt/test/grid/mpi_grid.py
+++ b/dune/xt/test/grid/mpi_grid.py
@@ -15,4 +15,8 @@ import dune.xt.test.grid_types as grid_types
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 # alberta needs manual flag adding in cmake, so we skip it here
-all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)  # noqa: F821
+all_grids = (
+    (safe_name(g), g)
+    for g in grid_types.all_types(cache, list(range(1, 4)))  # noqa: F821
+    if "Alberta" not in g
+)

--- a/dune/xt/test/grid/mpi_grid.py
+++ b/dune/xt/test/grid/mpi_grid.py
@@ -15,4 +15,4 @@ import dune.xt.test.grid_types as grid_types
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 # alberta needs manual flag adding in cmake, so we skip it here
-all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)
+all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)  # noqa: F821

--- a/dune/xt/test/grid/mpi_grid.py
+++ b/dune/xt/test/grid/mpi_grid.py
@@ -18,5 +18,4 @@ from dune.xt.codegen import typeid_to_typedef_name as safe_name
 all_grids = (
     (safe_name(g), g)
     for g in grid_types.all_types(cache, list(range(1, 4)))  # noqa: F821
-    if "Alberta" not in g
-)
+    if "Alberta" not in g)

--- a/dune/xt/test/grid/output.py
+++ b/dune/xt/test/grid/output.py
@@ -15,4 +15,8 @@ import dune.xt.test.grid_types as grid_types
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 # alberta needs manual flag adding in cmake, so we skip it here
-all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)  # noqa: F821
+all_grids = (
+    (safe_name(g), g)
+    for g in grid_types.all_types(cache, list(range(1, 4)))  # noqa: F821
+    if "Alberta" not in g
+)

--- a/dune/xt/test/grid/output.py
+++ b/dune/xt/test/grid/output.py
@@ -15,4 +15,4 @@ import dune.xt.test.grid_types as grid_types
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 # alberta needs manual flag adding in cmake, so we skip it here
-all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)
+all_grids = ((safe_name(g), g) for g in grid_types.all_types(cache, list(range(1, 4))) if 'Alberta' not in g)  # noqa: F821

--- a/dune/xt/test/grid/output.py
+++ b/dune/xt/test/grid/output.py
@@ -18,5 +18,4 @@ from dune.xt.codegen import typeid_to_typedef_name as safe_name
 all_grids = (
     (safe_name(g), g)
     for g in grid_types.all_types(cache, list(range(1, 4)))  # noqa: F821
-    if "Alberta" not in g
-)
+    if "Alberta" not in g)

--- a/dune/xt/test/la/algorithms.py
+++ b/dune/xt/test/la/algorithms.py
@@ -10,8 +10,10 @@
 #   Tobias Leibner (2018 - 2020)
 # ~~~
 
-from matrices import latype, commontype, dunetype
-from dune.xt.codegen import have_eigen, have_istl, typeid_to_typedef_name as safe_name
+from matrices import commontype, dunetype, latype
+
+from dune.xt.codegen import have_eigen, have_istl
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 
 def la_types_creator():

--- a/dune/xt/test/la/algorithms.py
+++ b/dune/xt/test/la/algorithms.py
@@ -78,6 +78,6 @@ def type_ok(t, cache):
 
 
 def testtypes_creator(la_types, common_types, dune_types, cache):
-    return [la_test_tuple(item) for item in la_types if type_ok(item, cache)] + [
-        common_test_tuple(item, 'XT_') for item in common_types
-    ] + [common_test_tuple(item, '') for item in dune_types]
+    return [la_test_tuple(item) for item in la_types if type_ok(item, cache)
+            ] + [common_test_tuple(item, 'XT_')
+                 for item in common_types] + [common_test_tuple(item, '') for item in dune_types]

--- a/dune/xt/test/la/algorithms_cholesky.py
+++ b/dune/xt/test/la/algorithms_cholesky.py
@@ -19,4 +19,4 @@ dune_types = [
     for f in ['FieldMatrix_FieldVector_FieldVector_double,5,5', 'DynamicMatrix_DynamicVector_DynamicVector_double']
 ]
 
-testtypes = testtypes_creator(la_types, common_types, dune_types, cache)
+testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/algorithms_qr_5x3.py
+++ b/dune/xt/test/la/algorithms_qr_5x3.py
@@ -19,4 +19,4 @@ dune_types = [
     for f in ['FieldMatrix_FieldVector_FieldVector_double,5,3', 'DynamicMatrix_DynamicVector_DynamicVector_double']
 ]
 
-testtypes = testtypes_creator(la_types, common_types, dune_types, cache)
+testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/algorithms_qr_5x5.py
+++ b/dune/xt/test/la/algorithms_qr_5x5.py
@@ -19,4 +19,4 @@ dune_types = [
     for f in ['FieldMatrix_FieldVector_FieldVector_double,5,5', 'DynamicMatrix_DynamicVector_DynamicVector_double']
 ]
 
-testtypes = testtypes_creator(la_types, common_types, dune_types, cache)
+testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/algorithms_qr_block_2x3x3.py
+++ b/dune/xt/test/la/algorithms_qr_block_2x3x3.py
@@ -24,4 +24,4 @@ dune_types = [
     for f in ['FieldMatrix_FieldVector_FieldVector_double,6,6', 'DynamicMatrix_DynamicVector_DynamicVector_double']
 ]
 
-testtypes = testtypes_creator(la_types, common_types, dune_types, cache)
+testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/algorithms_solve_sym_tridiag_posdef.py
+++ b/dune/xt/test/la/algorithms_solve_sym_tridiag_posdef.py
@@ -19,4 +19,4 @@ dune_types = [
     for f in ['FieldMatrix_FieldVector_FieldVector_double,5,5', 'DynamicMatrix_DynamicVector_DynamicVector_double']
 ]
 
-testtypes = testtypes_creator(la_types, common_types, dune_types, cache)
+testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/algorithms_triangular_solves_2x2.py
+++ b/dune/xt/test/la/algorithms_triangular_solves_2x2.py
@@ -19,4 +19,4 @@ dune_types = [
     for f in ['FieldMatrix_FieldVector_FieldVector_double,2,2', 'DynamicMatrix_DynamicVector_DynamicVector_double']
 ]
 
-testtypes = testtypes_creator(la_types, common_types, dune_types, cache)
+testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/algorithms_triangular_solves_3x3.py
+++ b/dune/xt/test/la/algorithms_triangular_solves_3x3.py
@@ -11,6 +11,6 @@
 #   Tobias Leibner  (2015 - 2018, 2020)
 # ~~~
 
-from algorithms import la_types, common_types, dune_types, testtypes_creator
+from algorithms import common_types, dune_types, la_types, testtypes_creator
 
 testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/algorithms_triangular_solves_3x3.py
+++ b/dune/xt/test/la/algorithms_triangular_solves_3x3.py
@@ -13,4 +13,4 @@
 
 from algorithms import la_types, common_types, dune_types, testtypes_creator
 
-testtypes = testtypes_creator(la_types, common_types, dune_types, cache)
+testtypes = testtypes_creator(la_types, common_types, dune_types, cache)  # noqa: F821

--- a/dune/xt/test/la/container.py
+++ b/dune/xt/test/la/container.py
@@ -15,9 +15,9 @@ from itertools import product
 
 import matrices
 
-conts = matrices.matrices(cache) + matrices.vectors(cache)
+conts = matrices.matrices(cache) + matrices.vectors(cache)  # noqa: F821
 container = [
     matrices.name_type_tuple(c, f)
-    for c, f in product(conts, matrices.fieldtypes(cache))
+    for c, f in product(conts, matrices.fieldtypes(cache))  # noqa: F821
     if matrices.vector_filter(c, f)
 ]

--- a/dune/xt/test/la/container.py
+++ b/dune/xt/test/la/container.py
@@ -12,7 +12,6 @@
 
 from itertools import product
 
-
 import matrices
 
 conts = matrices.matrices(cache) + matrices.vectors(cache)  # noqa: F821

--- a/dune/xt/test/la/container.py
+++ b/dune/xt/test/la/container.py
@@ -12,7 +12,6 @@
 
 from itertools import product
 
-from dune.xt import codegen
 
 import matrices
 

--- a/dune/xt/test/la/container_matrix.py
+++ b/dune/xt/test/la/container_matrix.py
@@ -16,5 +16,5 @@ from matrices import matrices, latype, vectors, fieldtypes, vector_filter
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))
-             for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))
+             for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))  # noqa: F821
              if vector_filter(mv[1], f)]

--- a/dune/xt/test/la/container_matrix.py
+++ b/dune/xt/test/la/container_matrix.py
@@ -12,7 +12,9 @@
 # ~~~
 
 from itertools import product
-from matrices import matrices, latype, vectors, fieldtypes, vector_filter
+
+from matrices import fieldtypes, latype, matrices, vector_filter, vectors
+
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))

--- a/dune/xt/test/la/container_matrix.py
+++ b/dune/xt/test/la/container_matrix.py
@@ -17,6 +17,8 @@ from matrices import fieldtypes, latype, matrices, vector_filter, vectors
 
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
-testtypes = [(safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))
-             for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))  # noqa: F821
-             if vector_filter(mv[1], f)]
+testtypes = [
+    (safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))
+    for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))  # noqa: F821
+    if vector_filter(mv[1], f)
+]

--- a/dune/xt/test/la/container_vector.py
+++ b/dune/xt/test/la/container_vector.py
@@ -12,7 +12,9 @@
 # ~~~
 
 from itertools import product
-from matrices import latype, vectors, fieldtypes, vector_filter
+
+from matrices import fieldtypes, latype, vector_filter, vectors
+
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}'.format(mv, f)), latype(mv, f))

--- a/dune/xt/test/la/container_vector.py
+++ b/dune/xt/test/la/container_vector.py
@@ -17,6 +17,8 @@ from matrices import fieldtypes, latype, vector_filter, vectors
 
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
-testtypes = [(safe_name('{}_{}'.format(mv, f)), latype(mv, f))
-             for mv, f in product(vectors(cache), fieldtypes(cache))  # noqa: F821
-             if vector_filter(mv, f)]
+testtypes = [
+    (safe_name('{}_{}'.format(mv, f)), latype(mv, f))
+    for mv, f in product(vectors(cache), fieldtypes(cache))  # noqa: F821
+    if vector_filter(mv, f)
+]

--- a/dune/xt/test/la/container_vector.py
+++ b/dune/xt/test/la/container_vector.py
@@ -16,5 +16,5 @@ from matrices import latype, vectors, fieldtypes, vector_filter
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}'.format(mv, f)), latype(mv, f))
-             for mv, f in product(vectors(cache), fieldtypes(cache))
+             for mv, f in product(vectors(cache), fieldtypes(cache))  # noqa: F821
              if vector_filter(mv, f)]

--- a/dune/xt/test/la/eigensolver_for_matrix_from_eigens_example.py
+++ b/dune/xt/test/la/eigensolver_for_matrix_from_eigens_example.py
@@ -21,7 +21,7 @@ real_matrix = ['EigenDenseMatrix<double>', 'FieldMatrix<double, 6, 6>']
 
 def _ok(ft):
     if 'Eigen' in ft[0]:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/eigensolver_for_matrix_from_eigens_example.py
+++ b/dune/xt/test/la/eigensolver_for_matrix_from_eigens_example.py
@@ -11,7 +11,8 @@
 #   Tobias Leibner  (2017, 2019 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = ['EigenDenseMatrix<double>', 'FieldMatrix<double, 6, 6>']
 field = ['double', 'double']

--- a/dune/xt/test/la/eigensolver_for_matrix_from_eigens_example.py
+++ b/dune/xt/test/la/eigensolver_for_matrix_from_eigens_example.py
@@ -26,4 +26,6 @@ def _ok(ft):
     return True
 
 
-testtypes = [(safe_name('_'.join(ft)), *ft) for ft in zip(matrix, field, complex_matrix, real_matrix) if _ok(ft)]
+testtypes = [(safe_name('_'.join(ft)), *ft)
+             for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+             if _ok(ft)]

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_complex_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_complex_evs.py
@@ -11,7 +11,8 @@
 #   Tobias Leibner  (2017, 2019 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = ['EigenDenseMatrix<double>', 'FieldMatrix<double, 2, 2>']
 field = ['double', 'double']

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_complex_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_complex_evs.py
@@ -21,7 +21,7 @@ real_matrix = ['EigenDenseMatrix<double>', 'FieldMatrix<double, 2, 2>']
 
 def _ok(ft):
     if 'Eigen' in ft[0]:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_complex_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_complex_evs.py
@@ -26,4 +26,6 @@ def _ok(ft):
     return True
 
 
-testtypes = [(safe_name('_'.join(ft)), *ft) for ft in zip(matrix, field, complex_matrix, real_matrix) if _ok(ft)]
+testtypes = [(safe_name('_'.join(ft)), *ft)
+             for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+             if _ok(ft)]

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_distinct_real_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_distinct_real_evs.py
@@ -11,7 +11,8 @@
 #   Tobias Leibner  (2017 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = [
     'EigenDenseMatrix<double>', 'FieldMatrix<double, 5, 5>', 'CommonDenseMatrix<double>',

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_distinct_real_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_distinct_real_evs.py
@@ -30,7 +30,7 @@ real_matrix = [
 
 def _ok(ft):
     if 'Eigen' in ft[0]:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_distinct_real_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_distinct_real_evs.py
@@ -35,4 +35,6 @@ def _ok(ft):
     return True
 
 
-testtypes = [(safe_name('_'.join(ft)), *ft) for ft in zip(matrix, field, complex_matrix, real_matrix) if _ok(ft)]
+testtypes = [(safe_name('_'.join(ft)), *ft)
+             for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+             if _ok(ft)]

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs.py
@@ -11,7 +11,8 @@
 #   Tobias Leibner  (2017 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = [
     'EigenDenseMatrix<double>', 'FieldMatrix<double, 2, 2>', 'CommonDenseMatrix<double>', 'CommonSparseMatrix<double>'

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs.py
@@ -33,4 +33,6 @@ def _ok(ft):
     return True
 
 
-testtypes = [(safe_name('_'.join(ft)), *ft) for ft in zip(matrix, field, complex_matrix, real_matrix) if _ok(ft)]
+testtypes = [(safe_name('_'.join(ft)), *ft)
+             for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+             if _ok(ft)]

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs.py
@@ -28,7 +28,7 @@ real_matrix = [
 
 def _ok(ft):
     if 'Eigen' in ft[0]:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_2d_euler_equations.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_2d_euler_equations.py
@@ -29,4 +29,6 @@ def _ok(ft):
     return True
 
 
-testtypes = [(safe_name('_'.join(ft)), *ft) for ft in zip(matrix, field, complex_matrix, real_matrix) if _ok(ft)]
+testtypes = [(safe_name('_'.join(ft)), *ft)
+             for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+             if _ok(ft)]

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_2d_euler_equations.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_2d_euler_equations.py
@@ -24,7 +24,7 @@ real_matrix = ['EigenDenseMatrix<double>', 'FieldMatrix<double, 4, 4>', 'CommonD
 
 def _ok(ft):
     if 'Eigen' in ft[0]:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_2d_euler_equations.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_2d_euler_equations.py
@@ -11,7 +11,8 @@
 #   Tobias Leibner  (2017 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = ['EigenDenseMatrix<double>', 'FieldMatrix<double, 4, 4>', 'CommonDenseMatrix<double>']
 field = ['double', 'double', 'double']

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_3d_pointsource.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_3d_pointsource.py
@@ -36,4 +36,6 @@ def _ok(ft):
     return True
 
 
-testtypes = [(safe_name('_'.join(ft)), *ft) for ft in zip(matrix, field, complex_matrix, real_matrix) if _ok(ft)]
+testtypes = [(safe_name('_'.join(ft)), *ft)
+             for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+             if _ok(ft)]

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_3d_pointsource.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_3d_pointsource.py
@@ -31,7 +31,7 @@ real_matrix = [
 
 def _ok(ft):
     if 'Eigen' in ft[0]:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_3d_pointsource.py
+++ b/dune/xt/test/la/eigensolver_for_real_matrix_with_real_evs_from_3d_pointsource.py
@@ -11,7 +11,8 @@
 #   Tobias Leibner  (2017 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = [
     'EigenDenseMatrix<double>', 'FieldMatrix<double, 32, 32>', 'CommonDenseMatrix<double>',

--- a/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.py
+++ b/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.py
@@ -11,7 +11,8 @@
 #   Tobias Leibner  (2017 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = [
     'EigenDenseMatrix<double>', 'FieldMatrix<double, 2, 2>', 'CommonDenseMatrix<double>', 'CommonSparseMatrix<double>'

--- a/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.py
+++ b/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.py
@@ -33,4 +33,6 @@ def _ok(ft):
     return True
 
 
-testtypes = [(safe_name('_'.join(ft)), *ft) for ft in zip(matrix, field, complex_matrix, real_matrix) if _ok(ft)]
+testtypes = [(safe_name('_'.join(ft)), *ft)
+             for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+             if _ok(ft)]

--- a/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.py
+++ b/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.py
@@ -28,7 +28,7 @@ real_matrix = [
 
 def _ok(ft):
     if 'Eigen' in ft[0]:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/matrix-market.py
+++ b/dune/xt/test/la/matrix-market.py
@@ -11,7 +11,9 @@
 # ~~~
 
 from itertools import product
-from matrices import matrices, latype, fieldtypes
+
+from matrices import fieldtypes, latype, matrices
+
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [

--- a/dune/xt/test/la/matrix-market.py
+++ b/dune/xt/test/la/matrix-market.py
@@ -14,4 +14,7 @@ from itertools import product
 from matrices import matrices, latype, fieldtypes
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
-testtypes = [(safe_name('{}_{}'.format(m, f)), latype(m, f)) for m, f in product(matrices(cache), fieldtypes(cache))]  # noqa: F821
+testtypes = [
+    (safe_name("{}_{}".format(m, f)), latype(m, f))
+    for m, f in product(matrices(cache), fieldtypes(cache))  # noqa: F821
+]

--- a/dune/xt/test/la/matrix-market.py
+++ b/dune/xt/test/la/matrix-market.py
@@ -14,4 +14,4 @@ from itertools import product
 from matrices import matrices, latype, fieldtypes
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
-testtypes = [(safe_name('{}_{}'.format(m, f)), latype(m, f)) for m, f in product(matrices(cache), fieldtypes(cache))]
+testtypes = [(safe_name('{}_{}'.format(m, f)), latype(m, f)) for m, f in product(matrices(cache), fieldtypes(cache))]  # noqa: F821

--- a/dune/xt/test/la/matrix_and_vector_view.py
+++ b/dune/xt/test/la/matrix_and_vector_view.py
@@ -16,5 +16,5 @@ from matrices import matrices, latype, vectors, fieldtypes, vector_filter
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))
-             for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))
+             for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))  # noqa: F821
              if vector_filter(mv[1], f)]

--- a/dune/xt/test/la/matrix_and_vector_view.py
+++ b/dune/xt/test/la/matrix_and_vector_view.py
@@ -12,7 +12,9 @@
 # ~~~
 
 from itertools import product
-from matrices import matrices, latype, vectors, fieldtypes, vector_filter
+
+from matrices import fieldtypes, latype, matrices, vector_filter, vectors
+
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 testtypes = [(safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))

--- a/dune/xt/test/la/matrix_and_vector_view.py
+++ b/dune/xt/test/la/matrix_and_vector_view.py
@@ -17,6 +17,8 @@ from matrices import fieldtypes, latype, matrices, vector_filter, vectors
 
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
-testtypes = [(safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))
-             for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))  # noqa: F821
-             if vector_filter(mv[1], f)]
+testtypes = [
+    (safe_name('{}_{}_{}'.format(*mv, f)), latype(mv[0], f), latype(mv[1], f))
+    for mv, f in product(product(matrices(cache), vectors(cache)), fieldtypes(cache))  # noqa: F821
+    if vector_filter(mv[1], f)
+]

--- a/dune/xt/test/la/matrixinverter_for_complex_matrix.py
+++ b/dune/xt/test/la/matrixinverter_for_complex_matrix.py
@@ -22,7 +22,7 @@ matrix = [
 
 def _ok(ft):
     if 'Eigen' in ft:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/matrixinverter_for_complex_matrix.py
+++ b/dune/xt/test/la/matrixinverter_for_complex_matrix.py
@@ -10,7 +10,8 @@
 #   Tobias Leibner (2018 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = [
     'EigenDenseMatrix<std::complex<double>>', 'FieldMatrix<std::complex<double>, 2, 2>',

--- a/dune/xt/test/la/matrixinverter_for_complex_matrix_2.py
+++ b/dune/xt/test/la/matrixinverter_for_complex_matrix_2.py
@@ -22,7 +22,7 @@ matrix = [
 
 def _ok(ft):
     if 'Eigen' in ft:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/matrixinverter_for_complex_matrix_2.py
+++ b/dune/xt/test/la/matrixinverter_for_complex_matrix_2.py
@@ -10,7 +10,8 @@
 #   Tobias Leibner (2018 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = [
     'EigenDenseMatrix<std::complex<double>>', 'FieldMatrix<std::complex<double>, 10, 10>',

--- a/dune/xt/test/la/matrixinverter_for_real_matrix_from_3d_pointsource.py
+++ b/dune/xt/test/la/matrixinverter_for_real_matrix_from_3d_pointsource.py
@@ -20,7 +20,7 @@ matrix = [
 
 def _ok(ft):
     if 'Eigen' in ft:
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     return True
 
 

--- a/dune/xt/test/la/matrixinverter_for_real_matrix_from_3d_pointsource.py
+++ b/dune/xt/test/la/matrixinverter_for_real_matrix_from_3d_pointsource.py
@@ -10,7 +10,8 @@
 #   Tobias Leibner (2018 - 2020)
 # ~~~
 
-from dune.xt.codegen import typeid_to_typedef_name as safe_name, have_eigen
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 matrix = [
     'EigenDenseMatrix<double>', 'FieldMatrix<double, 6, 6>', 'CommonDenseMatrix<double>', 'CommonSparseMatrix<double>',

--- a/dune/xt/test/la/solver.py
+++ b/dune/xt/test/la/solver.py
@@ -12,7 +12,9 @@
 # ~~~
 
 from matrices import commontype, latype
-from dune.xt.codegen import have_eigen, have_istl, typeid_to_typedef_name as safe_name
+
+from dune.xt.codegen import have_eigen, have_istl
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
 types = [
     f.split('_') for f in [

--- a/dune/xt/test/la/solver.py
+++ b/dune/xt/test/la/solver.py
@@ -45,9 +45,9 @@ def test_tuple(args):
 
 def type_ok(t):
     if sum(['Eigen' in x for x in t]):
-        return have_eigen(cache)
+        return have_eigen(cache)  # noqa: F821
     if sum(['Istl' in x for x in t]):
-        return have_istl(cache)
+        return have_istl(cache)  # noqa: F821
     return True
 
 

--- a/examples/gamm_2019_talk_on_conservative_rb_OS2015_academic_example.py
+++ b/examples/gamm_2019_talk_on_conservative_rb_OS2015_academic_example.py
@@ -1,3 +1,5 @@
+
+
 import numpy as np
 
 from pymor.basic import *

--- a/examples/gamm_2019_talk_on_conservative_rb_OS2015_academic_example.py
+++ b/examples/gamm_2019_talk_on_conservative_rb_OS2015_academic_example.py
@@ -45,10 +45,8 @@ from dune.gdt.gamm_2019_talk_on_conservative_rb import (
     assemble_SWIPDG_matrix,
     compute_estimate,
     compute_flux_reconstruction,
-    compute_local_conservation_error,
     make_discrete_function,
     prolong,
-    visualize,
 )
 
 

--- a/examples/gamm_2019_talk_on_conservative_rb_OS2015_academic_example.py
+++ b/examples/gamm_2019_talk_on_conservative_rb_OS2015_academic_example.py
@@ -1,5 +1,3 @@
-
-
 import numpy as np
 
 from pymor.basic import *

--- a/examples/gamm_2019_talk_on_conservative_rb_OS2015_multiscale_example.py
+++ b/examples/gamm_2019_talk_on_conservative_rb_OS2015_multiscale_example.py
@@ -1,3 +1,5 @@
+
+
 import numpy as np
 
 from pymor.basic import *
@@ -127,7 +129,7 @@ diffusion_factor = {
 
 def make_diffusion_factor_mu(mu):
     return (function_to_grid_function(ConstantFunction(1))
-            + function_to_grid_function(ConstantFunction(1 - mu['switch'])) * channel)  # noqa: W503
+            + function_to_grid_function(ConstantFunction(1 - mu['switch'])) * channel)
 
 
 mu_bar = {'switch': 0.1}

--- a/examples/gamm_2019_talk_on_conservative_rb_OS2015_multiscale_example.py
+++ b/examples/gamm_2019_talk_on_conservative_rb_OS2015_multiscale_example.py
@@ -1,5 +1,3 @@
-
-
 import numpy as np
 
 from pymor.basic import *

--- a/examples/gamm_2019_talk_on_conservative_rb_OS2015_multiscale_example.py
+++ b/examples/gamm_2019_talk_on_conservative_rb_OS2015_multiscale_example.py
@@ -7,7 +7,6 @@ from pymor.vectorarrays.list import ListVectorArray
 
 from dune.xt.la import IstlDenseVectorDouble
 from dune.xt.functions import ConstantFunction__2d_to_1x1 as ConstantFunction
-from dune.xt.functions import ExpressionFunction__2d_to_1x1 as ExpressionFunction
 from dune.xt.functions import IndicatorGridFunction__2d_simplex_aluconformgrid_to_1x1 as IndicatorFunction
 from dune.gdt.gamm_2019_talk_on_conservative_rb import function_to_grid_function, Spe10Model1Function
 
@@ -165,10 +164,8 @@ from dune.gdt.gamm_2019_talk_on_conservative_rb import (
     assemble_SWIPDG_matrix,
     compute_estimate,
     compute_flux_reconstruction,
-    compute_local_conservation_error,
     make_discrete_function,
     prolong,
-    visualize,
 )
 
 

--- a/pybind11/docs/benchmark.py
+++ b/pybind11/docs/benchmark.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import random
 import os
-import time
 import datetime as dt
 
 nfns = 4     # Functions per class

--- a/pybind11/docs/conf.py
+++ b/pybind11/docs/conf.py
@@ -15,7 +15,6 @@
 
 import sys
 import os
-import shlex
 import subprocess
 from pathlib import Path
 import re

--- a/pybind11/tests/test_builtin_casters.py
+++ b/pybind11/tests/test_builtin_casters.py
@@ -406,7 +406,7 @@ def test_reference_wrapper():
     a2 = m.refwrap_list(copy=True)
     assert [x.value for x in a1] == [2, 3]
     assert [x.value for x in a2] == [2, 3]
-    assert not a1[0] is a2[0] and not a1[1] is a2[1]
+    assert a1[0] is not a2[0] and a1[1] is not a2[1]
 
     b1 = m.refwrap_list(copy=False)
     b2 = m.refwrap_list(copy=False)

--- a/python/gdt/dune/gdt/basic.py
+++ b/python/gdt/dune/gdt/basic.py
@@ -3,6 +3,8 @@ from dune.xt.common.config import config
 if config.HAVE_K3D:
     from dune.gdt import visualize_function
 
+# flake8: noqa
+
 from dune.gdt._discretefunction_bochner import DiscreteBochnerFunction
 from dune.gdt._discretefunction_discretefunction import DiscreteFunction
 from dune.gdt._functionals_vector_based import VectorFunctional

--- a/python/gdt/setup.cfg
+++ b/python/gdt/setup.cfg
@@ -14,7 +14,7 @@ test = pytest
 
 [pep8]
 max-line-length = 120
-ignore = E221,E226,E241,E242, W0105, N803, N806
+ignore = E221,E226,E241,E242, W105, N803, N806
 # E221 multiple spaces before operator
 # E226 missing whitespace around arithmetic operator  [ignored by default]
 # E241 multiple spaces after ':'                      [ignored by default]
@@ -26,7 +26,7 @@ ignore = E221,E226,E241,E242, W0105, N803, N806
 
 [flake8]
 max-line-length = 120
-ignore = E221,E226,E241,E242, W0105, N803, N806
+ignore = E221,E226,E241,E242, W105, N803, N806
 # The following exclude avoids wrong warnings for unused imports
 exclude = __init__.py
 

--- a/python/gdt/setup.cfg
+++ b/python/gdt/setup.cfg
@@ -12,24 +12,6 @@
 [aliases]
 test = pytest
 
-[pep8]
-max-line-length = 120
-ignore = E221,E226,E241,E242, W105, N803, N806
-# E221 multiple spaces before operator
-# E226 missing whitespace around arithmetic operator  [ignored by default]
-# E241 multiple spaces after ':'                      [ignored by default]
-# E242 tab after `,'                                  [ignored by default]
-# W0105 String statement has no effect (we use triple qoted strings as documentation in some files)
-# N803 argument name should be lowercase (we use single capital letters everywhere for vectorarrays)
-# N806 same for variables in function
-
-
-[flake8]
-max-line-length = 120
-ignore = E221,E226,E241,E242, W105, N803, N806
-# The following exclude avoids wrong warnings for unused imports
-exclude = __init__.py
-
 [tool:pytest]
 testpaths = test/
 python_files = test/*.py
@@ -40,5 +22,5 @@ pep8ignore = E221,E226,E241,E242
 addopts= -p no:warnings
 
 [metadata]
-# this is mandatory to lave license end up in .whl
+# this is mandatory to have license end up in .whl
 license_file = LICENSE.txt

--- a/python/gdt/test/segfault_laplace_integrand.py
+++ b/python/gdt/test/segfault_laplace_integrand.py
@@ -3,6 +3,7 @@
 
 from dune.xt.grid import Dim, Cube, make_cube_grid
 
+
 def test_segfault():
     grid = make_cube_grid(Dim(1), [0], [1], [2])
     d = grid.dimension

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,6 +1,6 @@
 
 # Enable Pyflakes and pycodestyle rules.
-select = ["E", "F", "RUF100"]
+select = ["E", "F", "RUF100", "I001"]
 fix = true
 line-length = 120
 

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -4,4 +4,4 @@ select = ["E", "F", "RUF100"]
 fix = true
 line-length = 120
 
-exclude = ["__init__.py", "deps/", "pybind11/", "examples/gamm*"]
+exclude = ["__init__.py", "deps/*", "pybind11/*", "examples/gamm*"]

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,0 +1,7 @@
+
+# Enable Pyflakes and pycodestyle rules.
+select = ["E", "F", "RUF100"]
+fix = true
+line-length = 120
+
+exclude = ["__init__.py", "deps/", "pybind11/", "examples/gamm*"]

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,6 +1,6 @@
 
 # Enable Pyflakes and pycodestyle rules.
-select = ["E", "F", "RUF100", "I001"]
+select = ["E", "F", "RUF100", "I001", "UP"]
 fix = true
 line-length = 120
 

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,6 +1,7 @@
 
 # Enable Pyflakes and pycodestyle rules.
-select = ["E", "F", "RUF100", "I001", "UP"]
+# see https://github.com/charliermarsh/ruff#supported-rules
+select = ["E", "F", "RUF100", "I001", "UP", "B"]
 fix = true
 line-length = 120
 

--- a/python/xt/dune/xt/__init__.py
+++ b/python/xt/dune/xt/__init__.py
@@ -20,7 +20,7 @@ try:
     import metis
 except ImportError:
     pass
-except RuntimeError:     # metis actually fires a RuntimeError if the module is installed but the system package not
+except RuntimeError:  # metis actually fires a RuntimeError if the module is installed but the system package not
     pass
 
 from importlib import import_module

--- a/python/xt/dune/xt/common/config.py
+++ b/python/xt/dune/xt/common/config.py
@@ -1,8 +1,9 @@
-from importlib import import_module
 import sys
+from importlib import import_module
 
 
 def _can_import(module):
+
     def _can_import_single(m):
         try:
             import_module(m)
@@ -10,6 +11,7 @@ def _can_import(module):
         except ImportError:
             pass
         return False
+
     if not isinstance(module, (list, tuple)):
         module = [module]
     return all((_can_import_single(m) for m in module))
@@ -63,8 +65,10 @@ class Config:
         return list(keys)
 
     def __repr__(self):
-        status = {p: (lambda v: 'missing' if not v else 'present' if v is True else v)(getattr(self, p + '_VERSION'))
-                  for p in _PACKAGES}
+        status = {
+            p: (lambda v: 'missing' if not v else 'present' if v is True else v)(getattr(self, p + '_VERSION'))
+            for p in _PACKAGES
+        }
         key_width = max(len(p) for p in _PACKAGES) + 2
         package_info = [f"{p+':':{key_width}} {v}" for p, v in sorted(status.items())]
         separator = '-' * max(map(len, package_info))

--- a/python/xt/dune/xt/common/timings.py
+++ b/python/xt/dune/xt/common/timings.py
@@ -15,4 +15,4 @@ from dune.xt import guarded_import
 
 guarded_import(globals(), 'dune.xt.common', '_common_timings')
 
-instance()
+instance()  # noqa: F821

--- a/python/xt/dune/xt/common/vtk/plot.py
+++ b/python/xt/dune/xt/common/vtk/plot.py
@@ -15,17 +15,19 @@ from dune.xt.common.config import config
 if config.HAVE_K3D:
     import time
     import warnings
+
     import IPython
-    from ipywidgets import IntSlider, interact, widgets, Play
-    from k3d.helpers import minmax
-    from .reader import read_vtkfile
-    from k3d.plot import Plot as k3dPlot
     import k3d
-    from vtk.util import numpy_support
     import numpy as np
     import vtk
+    from ipywidgets import IntSlider, Play, interact, widgets
+    from k3d.helpers import minmax
+    from k3d.plot import Plot as k3dPlot
     from matplotlib.cm import get_cmap
     from matplotlib.colors import Colormap
+    from vtk.util import numpy_support
+
+    from .reader import read_vtkfile
 
 
     def _transform_to_k3d(timestep, poly_data, color_attribute_name):

--- a/python/xt/dune/xt/common/vtk/plot.py
+++ b/python/xt/dune/xt/common/vtk/plot.py
@@ -29,6 +29,7 @@ if config.HAVE_K3D:
 
     from .reader import read_vtkfile
 
+    DEFAULT_COLOR_MAP = get_cmap('viridis')
 
     def _transform_to_k3d(timestep, poly_data, color_attribute_name):
         '''
@@ -52,13 +53,12 @@ if config.HAVE_K3D:
             color_range = [
                 0,
                 -1,
-            ]     #[-np.inf, np.inf]
+            ]  #[-np.inf, np.inf]
         vertices = numpy_support.vtk_to_numpy(poly_data.GetPoints().GetData())
         indices = numpy_support.vtk_to_numpy(poly_data.GetPolys().GetData()).reshape(-1, 4)[:, 1:4]
 
         return timestep, np.array(attribute, np.float32), color_range[0], color_range[1], \
             np.array(vertices, np.float32), np.array(indices, np.uint32)
-
 
     class VTKPlot(k3dPlot):
 
@@ -106,8 +106,7 @@ if config.HAVE_K3D:
         def inc(self):
             self._goto_idx(self.idx + 1)
 
-
-    def plot(vtkfile_path, color_attribute_name, interactive=False, color_map=get_cmap('viridis')):
+    def plot(vtkfile_path, color_attribute_name, interactive=False, color_map=DEFAULT_COLOR_MAP):
         ''' Generate a k3d Plot and associated controls for VTK data from file
 
         :param vtkfile_path: the path to load vtk data from. Can be a single .vtu or a collection
@@ -148,11 +147,11 @@ if config.HAVE_K3D:
             try:
                 vtkplot.menu_visibility = False
             except AttributeError:
-                pass     # k3d < 2.5.6
+                pass  # k3d < 2.5.6
             # guesstimate
             fov_angle = 30
             absx = np.abs(combined_bounds[0] - combined_bounds[3])
-            c_dist = np.sin((90 - fov_angle) * np.pi / 180) * absx / (2 * np.sin(fov_angle * np.pi / 180))
+            c_dist = np.sin((90-fov_angle) * np.pi / 180) * absx / (2 * np.sin(fov_angle * np.pi / 180))
             xhalf = (combined_bounds[0] + combined_bounds[3]) / 2
             yhalf = (combined_bounds[1] + combined_bounds[4]) / 2
             zhalf = (combined_bounds[2] + combined_bounds[5]) / 2

--- a/python/xt/dune/xt/common/vtk/reader.py
+++ b/python/xt/dune/xt/common/vtk/reader.py
@@ -58,11 +58,11 @@ def _get_vtk_type(path):
     :param path: vtk file to peek into
     :return: None if no VTKFile element found, else the type attribute of the VTKFile element
     '''
-    parser = etree.XMLPullParser(events=('start',))
+    parser = etree.XMLPullParser(events=('start', ))
     with open(path, 'rb') as xml:
         for lines in xml.readlines():
             parser.feed(lines)
-            for action, element in parser.read_events():
+            for _action, element in parser.read_events():
                 if element.tag == 'VTKFile':
                     return element.get('type')
     return None

--- a/python/xt/dune/xt/common/vtk/reader.py
+++ b/python/xt/dune/xt/common/vtk/reader.py
@@ -11,12 +11,13 @@
 #   Tim Keil        (2020)
 # ~~~
 
+from collections import OrderedDict
 from pathlib import Path
 from xml.etree.ElementTree import fromstring
-from collections import OrderedDict
-from xmljson import BadgerFish
+
 import vtk
 from lxml import etree
+from xmljson import BadgerFish
 
 
 def _read_collection(xml):

--- a/python/xt/dune/xt/functions/__init__.py
+++ b/python/xt/dune/xt/functions/__init__.py
@@ -41,24 +41,22 @@ for mod_name in (
 ):
     guarded_import(globals(), 'dune.xt.functions', mod_name)
 
-
 if config.HAVE_K3D:
     import os
     import tempfile
     from dune.xt.common.vtk.plot import plot
     from dune.xt.functions._functions_gridfunction import GridFunction
 
-
     def visualize_function(functions, grid, interactive=False, subsampling=False):
         if not isinstance(functions, (list, tuple)):
-            functions = (functions,)
+            functions = (functions, )
         # this is a (bad) implicit check that these are functions
         dim_domain = functions[0].dim_domain
         dim_range = functions[0].dim_range
         name = functions[0].name
-        assert(all(f.dim_domain == dim_domain for f in functions))
-        assert(all(f.dim_range == dim_range for f in functions))
-        assert(all(f.name == name for f in functions))
+        assert (all(f.dim_domain == dim_domain for f in functions))
+        assert (all(f.dim_range == dim_range for f in functions))
+        assert (all(f.name == name for f in functions))
 
         def visualize_single(func, filename):
             try:
@@ -81,13 +79,12 @@ if config.HAVE_K3D:
                 pvd_file.write('<Collection>\n')
                 for ii, func in enumerate(functions):
                     pvd_file.write(
-            f'<DataSet timestep=\'{ii}\' part=\'1\' name=\'{name}\' file=\'{prefix}_{ii}.{suffix}\'/>\n')
+                        f'<DataSet timestep=\'{ii}\' part=\'1\' name=\'{name}\' file=\'{prefix}_{ii}.{suffix}\'/>\n')
                 pvd_file.write('</Collection>\n')
                 pvd_file.write('</VTKFile>\n')
             filename = f'{prefix}.pvd'
 
         return plot(filename, color_attribute_name=name, interactive=True)
-
 
     def visualize_function_on_dd_grid(function, dd_grid, subdomains=None):
         assert function.dim_domain == 2, f'Not implemented yet for {function.dim_domain}-dimensional grids!'
@@ -108,6 +105,6 @@ if config.HAVE_K3D:
             if 1 < len(subdomains) < dd_grid.num_subdomains:
                 # TODO: fix this error
                 print("For 1 < len(subdomains) < num_subdomains, the generated .pvtu file is known "
-                       + "to be broken. The result for each subdomain can be viewed via paraview")
+                      + "to be broken. The result for each subdomain can be viewed via paraview")
             else:
                 print("Unexpected error")

--- a/python/xt/dune/xt/grid/__init__.py
+++ b/python/xt/dune/xt/grid/__init__.py
@@ -16,7 +16,6 @@ from numbers import Number
 from dune.xt import guarded_import
 from dune.xt.common.config import config
 
-
 for mod_name in (
         '_grid_boundaryinfo_alldirichlet',
         '_grid_boundaryinfo_allneumann',
@@ -29,9 +28,9 @@ for mod_name in (
         '_grid_filters_base',
         '_grid_filters_element',
         '_grid_functors_boundary_detector',
-     # '_grid_functors_bounding_box',
+        # '_grid_functors_bounding_box',
         '_grid_functors_interfaces',
-     # '_grid_functors_refinement',
+        # '_grid_functors_refinement',
         '_grid_gridprovider_cube',
         '_grid_gridprovider_gmsh',
         '_grid_gridprovider_provider',
@@ -78,4 +77,4 @@ def visualize_grid(grid):
         tmpfile = NamedTemporaryFile(mode='wb', delete=False, suffix='.vtu').name
         grid.visualize(tmpfile[:-4])
         return plot(tmpfile,
-                    color_attribute_name='Element index')     # see visualize in python/dune/xt/grid/gridprovider.hh
+                    color_attribute_name='Element index')  # see visualize in python/dune/xt/grid/gridprovider.hh

--- a/python/xt/dune/xt/test/base.py
+++ b/python/xt/dune/xt/test/base.py
@@ -11,8 +11,8 @@
 #   Tobias Leibner  (2019 - 2020)
 # ~~~
 
-import pkgutil
 import logging
+import pkgutil
 import pprint
 
 
@@ -33,6 +33,7 @@ def load_all_submodule(module):
 
 
 def runmodule(filename):
-    import pytest
     import sys
+
+    import pytest
     sys.exit(pytest.main(sys.argv[1:] + [filename]))

--- a/python/xt/dune/xt/test/base.py
+++ b/python/xt/dune/xt/test/base.py
@@ -11,7 +11,6 @@
 #   Tobias Leibner  (2019 - 2020)
 # ~~~
 
-from pkg_resources import resource_filename, resource_stream
 import pkgutil
 import logging
 import pprint

--- a/python/xt/dune/xt/test/grid_types.py
+++ b/python/xt/dune/xt/test/grid_types.py
@@ -48,8 +48,9 @@ def _is_usable(grid, cache):
 def all_args(dims):
     two_and_three = [f for f in dims if 1 < f < 4]
     return {
-        'alu': [arguments['alu'](d, 'simplex', e) for e in ('nonconforming', 'conforming') for d in two_and_three] +
-               [arguments['alu'](d, 'cube', 'nonconforming') for d in two_and_three],
+        'alu': [arguments['alu'](d, 'simplex', e)
+                for e in ('nonconforming', 'conforming')
+                for d in two_and_three] + [arguments['alu'](d, 'cube', 'nonconforming') for d in two_and_three],
         'yasp': [arguments['yasp'](d) for d in dims if d > 0],
         'ug': [arguments['ug'](d) for d in two_and_three],
         'alberta': [arguments['alberta'](d) for d in two_and_three]

--- a/python/xt/dune/xt/test/grid_types.py
+++ b/python/xt/dune/xt/test/grid_types.py
@@ -15,8 +15,8 @@
 try:
     from dune.xt.test._test_grid_types import *  # noqa: F403
 except ImportError as e:
-    import os
     import logging
+    import os
     if os.environ.get('DXT_PYTHON_DEBUG', False):
         raise e
     logging.error('dune-xt-grid bindings not available')

--- a/python/xt/dune/xt/test/grid_types.py
+++ b/python/xt/dune/xt/test/grid_types.py
@@ -13,7 +13,7 @@
 # ~~~
 
 try:
-    from dune.xt.test._test_grid_types import *
+    from dune.xt.test._test_grid_types import *  # noqa: F403
 except ImportError as e:
     import os
     import logging

--- a/python/xt/scripts/dxt_code_generation.py
+++ b/python/xt/scripts/dxt_code_generation.py
@@ -13,11 +13,12 @@
 #   Tobias Leibner  (2019 - 2020)
 # ~~~
 
+import logging
 import os
 import sys
 from runpy import run_path
+
 from jinja2 import Template
-import logging
 
 from dune.xt.cmake import parse_cache
 

--- a/python/xt/scripts/generate_compare_functions.py
+++ b/python/xt/scripts/generate_compare_functions.py
@@ -13,7 +13,6 @@
 #   Tobias Leibner  (2020)
 # ~~~
 
-import sys
 import os
 from string import Template
 

--- a/python/xt/scripts/generate_compare_functions.py
+++ b/python/xt/scripts/generate_compare_functions.py
@@ -16,7 +16,7 @@
 import os
 from string import Template
 
-common_tpl = '''
+common_tpl = """
 template <Style style,
             class FirstType,
             class SecondType,
@@ -44,9 +44,9 @@ template <Style style,
   {
     return ${id}<Style::defaultStyle>(first, second, rtol, atol);
   }
-'''
+"""
 
-test_tpl = '''
+test_tpl = """
   template <Dune::XT::Common::FloatCmp::Style style,
             class FirstType,
             class SecondType,
@@ -82,13 +82,17 @@ test_tpl = '''
   {
     DXTC_EXPECT_FLOAT_${ID}<Dune::XT::Common::FloatCmp::Style::defaultStyle>(first, second, rtol, atol);
   }
-'''
+"""  # noqa: E501
 
 bindir = os.path.dirname(os.path.abspath(__file__))
-fn_test = os.path.join(bindir, '..', 'dune', 'xt', 'common', 'test', 'float_cmp_generated.hxx')
-fn_common = os.path.join(bindir, '..', 'dune', 'xt', 'common', 'float_cmp_generated.hxx')
-cmps = ['eq', 'ne', 'gt', 'lt', 'ge', 'le']
-with open(fn_test, 'wt') as test_header, open(fn_common, 'wt') as common_header:
+fn_test = os.path.join(
+    bindir, "..", "dune", "xt", "common", "test", "float_cmp_generated.hxx"
+)
+fn_common = os.path.join(
+    bindir, "..", "dune", "xt", "common", "float_cmp_generated.hxx"
+)
+cmps = ["eq", "ne", "gt", "lt", "ge", "le"]
+with open(fn_test, "wt") as test_header, open(fn_common, "wt") as common_header:
     for name in cmps:
         common_header.write(Template(common_tpl).substitute(id=name))
         test_header.write(Template(test_tpl).substitute(id=name, ID=name.upper()))

--- a/python/xt/scripts/generate_compare_functions.py
+++ b/python/xt/scripts/generate_compare_functions.py
@@ -92,7 +92,7 @@ fn_common = os.path.join(
     bindir, "..", "dune", "xt", "common", "float_cmp_generated.hxx"
 )
 cmps = ["eq", "ne", "gt", "lt", "ge", "le"]
-with open(fn_test, "wt") as test_header, open(fn_common, "wt") as common_header:
+with open(fn_test, "w") as test_header, open(fn_common, "w") as common_header:
     for name in cmps:
         common_header.write(Template(common_tpl).substitute(id=name))
         test_header.write(Template(test_tpl).substitute(id=name, ID=name.upper()))

--- a/python/xt/scripts/generate_compare_functions.py
+++ b/python/xt/scripts/generate_compare_functions.py
@@ -85,12 +85,8 @@ test_tpl = """
 """  # noqa: E501
 
 bindir = os.path.dirname(os.path.abspath(__file__))
-fn_test = os.path.join(
-    bindir, "..", "dune", "xt", "common", "test", "float_cmp_generated.hxx"
-)
-fn_common = os.path.join(
-    bindir, "..", "dune", "xt", "common", "float_cmp_generated.hxx"
-)
+fn_test = os.path.join(bindir, "..", "dune", "xt", "common", "test", "float_cmp_generated.hxx")
+fn_common = os.path.join(bindir, "..", "dune", "xt", "common", "float_cmp_generated.hxx")
 cmps = ["eq", "ne", "gt", "lt", "ge", "le"]
 with open(fn_test, "w") as test_header, open(fn_common, "w") as common_header:
     for name in cmps:

--- a/python/xt/setup.cfg
+++ b/python/xt/setup.cfg
@@ -14,7 +14,7 @@ test = pytest
 
 [pep8]
 max-line-length = 120
-ignore = E221,E226,E241,E242, W0105, N803, N806
+ignore = E221,E226,E241,E242, W105, N803, N806
 # E221 multiple spaces before operator
 # E226 missing whitespace around arithmetic operator  [ignored by default]
 # E241 multiple spaces after ':'                      [ignored by default]
@@ -26,7 +26,7 @@ ignore = E221,E226,E241,E242, W0105, N803, N806
 
 [flake8]
 max-line-length = 120
-ignore = E221,E226,E241,E242, W0105, N803, N806
+ignore = E221,E226,E241,E242, W105, N803, N806
 # The following exclude avoids wrong warnings for unused imports
 exclude = __init__.py
 

--- a/python/xt/setup.cfg
+++ b/python/xt/setup.cfg
@@ -12,24 +12,6 @@
 [aliases]
 test = pytest
 
-[pep8]
-max-line-length = 120
-ignore = E221,E226,E241,E242, W105, N803, N806
-# E221 multiple spaces before operator
-# E226 missing whitespace around arithmetic operator  [ignored by default]
-# E241 multiple spaces after ':'                      [ignored by default]
-# E242 tab after `,'                                  [ignored by default]
-# W0105 String statement has no effect (we use triple qoted strings as documentation in some files)
-# N803 argument name should be lowercase (we use single capital letters everywhere for vectorarrays)
-# N806 same for variables in function
-
-
-[flake8]
-max-line-length = 120
-ignore = E221,E226,E241,E242, W105, N803, N806
-# The following exclude avoids wrong warnings for unused imports
-exclude = __init__.py
-
 [tool:pytest]
 testpaths = test/
 python_files = test/*.py
@@ -40,5 +22,5 @@ pep8ignore = E221,E226,E241,E242
 addopts= -p no:warnings
 
 [metadata]
-# this is mandatory to lave license end up in .whl
+# this is mandatory to have license end up in .whl
 license_file = LICENSE.txt

--- a/python/xt/setup.py.in
+++ b/python/xt/setup.py.in
@@ -32,7 +32,7 @@ extras_require = {
 }
 
 if '${HAVE_MPI}' == 'TRUE':
-    requires.append ('mpi4py')
+    requires.append('mpi4py')
 
 extras_require['all'] = [p for plist in extras_require.values() for p in plist]
 

--- a/python/xt/test/base.py
+++ b/python/xt/test/base.py
@@ -15,10 +15,7 @@ from dune.xt.test import grid_types as types
 
 
 def test_load_all():
-    import dune.xt.common
-    import dune.xt.la
-    import dune.xt.grid
-    import dune.xt.functions  # noqa:F401
+    pass
 
 
 def test_empty():

--- a/python/xt/test/base.py
+++ b/python/xt/test/base.py
@@ -15,9 +15,9 @@ from dune.xt.test import grid_types as types
 
 
 def test_load_all():
-    import dune.xt.common  # noqa:F401
-    import dune.xt.la  # noqa:F401
-    import dune.xt.grid  # noqa:F401
+    import dune.xt.common
+    import dune.xt.la
+    import dune.xt.grid
     import dune.xt.functions  # noqa:F401
 
 

--- a/python/xt/test/common_mpi.py
+++ b/python/xt/test/common_mpi.py
@@ -38,7 +38,7 @@ def test_wrapper():
         pytest.skip('optional mpi4py is missing')
         return
 
-    mpi_comm = MPI.COMM_WORLD
+    mpi_comm = MPI.COMM_WORLD  # noqa: F841
 
 
 if __name__ == '__main__':

--- a/python/xt/test/common_mpi.py
+++ b/python/xt/test/common_mpi.py
@@ -12,7 +12,6 @@
 # ~~~
 
 import pytest
-from dune.xt.test.base import load_all_submodule
 
 
 def test_mpi4py():

--- a/python/xt/test/functions_constant.py
+++ b/python/xt/test/functions_constant.py
@@ -13,8 +13,9 @@
 # ~~~
 
 import pytest
-from dune.xt.test import grid_types as types
+
 import dune.xt.functions as xtf
+from dune.xt.test import grid_types as types
 
 
 @pytest.fixture(params=types.available_types)

--- a/python/xt/test/grid_boundary_info.py
+++ b/python/xt/test/grid_boundary_info.py
@@ -13,17 +13,17 @@
 
 def test_types():
     from dune.xt.grid import (
-        NoBoundary,
-        UnknownBoundary,
-        DirichletBoundary,
-        NeumannBoundary,
-        RobinBoundary,
-        ReflectingBoundary,
         AbsorbingBoundary,
-        InflowBoundary,
-        OutflowBoundary,
-        InflowOutflowBoundary,
+        DirichletBoundary,
         ImpermeableBoundary,
+        InflowBoundary,
+        InflowOutflowBoundary,
+        NeumannBoundary,
+        NoBoundary,
+        OutflowBoundary,
+        ReflectingBoundary,
+        RobinBoundary,
+        UnknownBoundary,
     )
     NoBoundary()
     UnknownBoundary()
@@ -39,13 +39,14 @@ def test_types():
 
 
 def test_initless_boundary_infos():
+    from grid_provider_cube import init_args as grid_init_args
+
     from dune.xt.grid import (
         AllDirichletBoundaryInfo,
         AllNeumannBoundaryInfo,
         AllReflectingBoundaryInfo,
+        make_cube_grid,
     )
-    from dune.xt.grid import make_cube_grid
-    from grid_provider_cube import init_args as grid_init_args
     for args in grid_init_args:
         grid = make_cube_grid(*args)
         AllDirichletBoundaryInfo(grid)
@@ -54,9 +55,9 @@ def test_initless_boundary_infos():
 
 
 def test_normalbased_boundary_inf():
-    from dune.xt.grid import NormalBasedBoundaryInfo
-    from dune.xt.grid import make_cube_grid, NoBoundary
     from grid_provider_cube import init_args as grid_init_args
+
+    from dune.xt.grid import NoBoundary, NormalBasedBoundaryInfo, make_cube_grid
     for args in grid_init_args:
         grid = make_cube_grid(*args)
         NormalBasedBoundaryInfo(grid_provider=grid,

--- a/python/xt/test/grid_boundary_info.py
+++ b/python/xt/test/grid_boundary_info.py
@@ -9,7 +9,6 @@
 #   Felix Schindler (2020)
 # ~~~
 
-import pytest
 
 
 def test_types():

--- a/python/xt/test/grid_boundary_info.py
+++ b/python/xt/test/grid_boundary_info.py
@@ -10,7 +10,6 @@
 # ~~~
 
 
-
 def test_types():
     from dune.xt.grid import (
         AbsorbingBoundary,

--- a/python/xt/test/grid_intersection.py
+++ b/python/xt/test/grid_intersection.py
@@ -9,7 +9,6 @@
 #   Felix Schindler (2020)
 # ~~~
 
-import pytest
 
 from dune.xt.grid import Dim, Cube, make_cube_grid
 from dune.xt.test._test_grid_intersection import call_on_each_intersection

--- a/python/xt/test/grid_intersection.py
+++ b/python/xt/test/grid_intersection.py
@@ -9,7 +9,6 @@
 #   Felix Schindler (2020)
 # ~~~
 
-
 from dune.xt.grid import Cube, Dim, make_cube_grid
 from dune.xt.test._test_grid_intersection import call_on_each_intersection
 

--- a/python/xt/test/grid_intersection.py
+++ b/python/xt/test/grid_intersection.py
@@ -10,7 +10,7 @@
 # ~~~
 
 
-from dune.xt.grid import Dim, Cube, make_cube_grid
+from dune.xt.grid import Cube, Dim, make_cube_grid
 from dune.xt.test._test_grid_intersection import call_on_each_intersection
 
 

--- a/python/xt/test/grid_provider_cube.py
+++ b/python/xt/test/grid_provider_cube.py
@@ -11,7 +11,6 @@
 #   Tobias Leibner  (2018 - 2019)
 # ~~~
 
-import pytest
 
 from dune.xt.grid import Dim, Cube, Simplex, make_cube_grid
 

--- a/python/xt/test/grid_provider_cube.py
+++ b/python/xt/test/grid_provider_cube.py
@@ -12,7 +12,7 @@
 # ~~~
 
 
-from dune.xt.grid import Dim, Cube, Simplex, make_cube_grid
+from dune.xt.grid import Cube, Dim, Simplex, make_cube_grid
 
 init_args = (
     (Dim(1), [0], [1], [2]),

--- a/python/xt/test/grid_provider_cube.py
+++ b/python/xt/test/grid_provider_cube.py
@@ -11,7 +11,6 @@
 #   Tobias Leibner  (2018 - 2019)
 # ~~~
 
-
 from dune.xt.grid import Cube, Dim, Simplex, make_cube_grid
 
 init_args = (

--- a/python/xt/test/grid_provider_cube.py
+++ b/python/xt/test/grid_provider_cube.py
@@ -25,4 +25,4 @@ init_args = (
 
 def test_init():
     for args in init_args:
-        grid = make_cube_grid(*args)
+        grid = make_cube_grid(*args)  # noqa: F841

--- a/python/xt/test/grid_traits.py
+++ b/python/xt/test/grid_traits.py
@@ -15,11 +15,11 @@
 
 def test_tags():
     from dune.xt.grid import (
-        Simplex,
         Cube,
-        Pyramid,
-        Prism,
         Dim,
+        Prism,
+        Pyramid,
+        Simplex,
     )
     Simplex()
     Cube()

--- a/python/xt/test/grid_traits.py
+++ b/python/xt/test/grid_traits.py
@@ -12,7 +12,6 @@
 # ~~~
 
 
-
 def test_tags():
     from dune.xt.grid import (
         Cube,

--- a/python/xt/test/grid_traits.py
+++ b/python/xt/test/grid_traits.py
@@ -11,7 +11,6 @@
 #   Tobias Leibner  (2018 - 2019)
 # ~~~
 
-import pytest
 
 
 def test_tags():

--- a/python/xt/test/grid_walker.py
+++ b/python/xt/test/grid_walker.py
@@ -11,8 +11,8 @@
 #   Tobias Leibner  (2018 - 2020)
 # ~~~
 
+from dune.xt.grid import Cube, Dim, Simplex, Walker, make_cube_grid
 from dune.xt.test.base import runmodule
-from dune.xt.grid import Dim, Cube, Simplex, make_cube_grid, Walker
 
 init_args = (
     (Dim(1), [0], [1], [2]),

--- a/python/xt/test/grid_walker.py
+++ b/python/xt/test/grid_walker.py
@@ -26,7 +26,7 @@ init_args = (
 def test_init():
     for args in init_args:
         grid = make_cube_grid(*args)
-        walker = Walker(grid)
+        walker = Walker(grid)  # noqa: F841
 
 
 def test_walk():

--- a/python/xt/wrapper/dune_xt_execute.py
+++ b/python/xt/wrapper/dune_xt_execute.py
@@ -21,8 +21,8 @@ import os.path
 import subprocess
 import sys
 
-from dune.testtools.wrapper.argumentparser import get_args
 from dune.testtools.parser import parse_ini_file
+from dune.testtools.wrapper.argumentparser import get_args
 
 
 def call(executable, inifile=None, *additional_args):

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -1,9 +1,11 @@
-import sys
-import os
-import slugify
 import glob
-import sphinx
+import os
+import sys
 from pathlib import Path
+
+import slugify
+import sphinx
+
 import dune.gdt
 
 # Check Sphinx version

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -72,7 +72,6 @@ source_suffix = {
     ".md": "myst-nb",
 }
 
-
 # The master toctree document.
 master_doc = "index"
 
@@ -111,7 +110,6 @@ add_function_parentheses = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "default"
-
 
 # -----------------------------------------------------------------------------
 # HTML output
@@ -193,7 +191,6 @@ htmlhelp_basename = "dune-gdt"
 # Pngmath should try to align formulas properly.
 pngmath_use_preview = True
 
-
 # -----------------------------------------------------------------------------
 # LaTeX output
 # -----------------------------------------------------------------------------
@@ -229,7 +226,6 @@ pngmath_use_preview = True
 
 # If false, no module index is generated.
 latex_use_modindex = False
-
 
 # -----------------------------------------------------------------------------
 # Autosummary
@@ -267,15 +263,12 @@ intersphinx_mapping = {
 
 modindex_common_prefix = ["dune."]
 
-
 # make intersphinx link to pyside2 docs
 qt_documentation = "PySide2"
 
 # this must match GDT_TUTORIALS_ROOT/.ci/gitlab/deploy_docs
 try_on_binder_branch = branch.replace("github/PUSH_", "from_fork__")
-try_on_binder_slug = os.environ.get(
-    "CI_COMMIT_REF_SLUG", slugify.slugify(try_on_binder_branch)
-)
+try_on_binder_slug = os.environ.get("CI_COMMIT_REF_SLUG", slugify.slugify(try_on_binder_branch))
 
 
 def linkcode_resolve(domain, info):

--- a/tutorials/source/discretize_elliptic_cg.py
+++ b/tutorials/source/discretize_elliptic_cg.py
@@ -16,7 +16,6 @@ from dune.xt.grid import AllDirichletBoundaryInfo, Dim, DirichletBoundary, Walke
 
 
 def discretize_elliptic_cg_dirichlet_zero(grid, diffusion, source):
-
     """
     Discretizes the stationary heat equation with homogeneous Dirichlet boundary values everywhere
     with dune-gdt using continuous Lagrange finite elements.
@@ -47,9 +46,7 @@ def discretize_elliptic_cg_dirichlet_zero(grid, diffusion, source):
     V_h = ContinuousLagrangeSpace(grid, order=1)
 
     l_h = VectorFunctional(grid, source_space=V_h)
-    l_h += LocalElementIntegralFunctional(
-        LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source)
-    )
+    l_h += LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source))
 
     a_h = MatrixOperator(
         grid,
@@ -75,7 +72,6 @@ def discretize_elliptic_cg_dirichlet_zero(grid, diffusion, source):
 
 
 def discretize_elliptic_cg_dirichlet(grid, diffusion, source, dirichlet_values):
-
     """
     Discretizes the stationary heat equation with non-homogeneous Dirichlet
     boundary values everywhere with dune-gdt using continuous Lagrange finite elements.
@@ -110,9 +106,7 @@ def discretize_elliptic_cg_dirichlet(grid, diffusion, source, dirichlet_values):
     V_h = ContinuousLagrangeSpace(grid, order=1)
 
     l_h = VectorFunctional(grid, source_space=V_h)
-    l_h += LocalElementIntegralFunctional(
-        LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source)
-    )
+    l_h += LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source))
 
     a_h = MatrixOperator(
         grid,
@@ -123,9 +117,7 @@ def discretize_elliptic_cg_dirichlet(grid, diffusion, source, dirichlet_values):
     a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
 
     dirichlet_constraints = DirichletConstraints(boundary_info, V_h)
-    dirichlet_values = boundary_interpolation(
-        dirichlet_values, V_h, boundary_info, DirichletBoundary()
-    )
+    dirichlet_values = boundary_interpolation(dirichlet_values, V_h, boundary_info, DirichletBoundary())
 
     walker = Walker(grid)
     walker.append(a_h)

--- a/tutorials/source/discretize_elliptic_cg.py
+++ b/tutorials/source/discretize_elliptic_cg.py
@@ -1,6 +1,3 @@
-from dune.xt.grid import AllDirichletBoundaryInfo, Dim, DirichletBoundary, Walker
-from dune.xt.functions import GridFunction as GF
-
 from dune.gdt import (
     ContinuousLagrangeSpace,
     DirichletConstraints,
@@ -14,6 +11,8 @@ from dune.gdt import (
     boundary_interpolation,
     make_element_sparsity_pattern,
 )
+from dune.xt.functions import GridFunction as GF
+from dune.xt.grid import AllDirichletBoundaryInfo, Dim, DirichletBoundary, Walker
 
 
 def discretize_elliptic_cg_dirichlet_zero(grid, diffusion, source):

--- a/tutorials/source/discretize_elliptic_ipdg.py
+++ b/tutorials/source/discretize_elliptic_ipdg.py
@@ -1,28 +1,17 @@
 # +
 from numbers import Number
 
-from dune.xt.grid import (
-    AllDirichletBoundaryInfo,
-    ApplyOnCustomBoundaryIntersections,
-    ApplyOnInnerIntersectionsOnce,
-    Dim,
-    DirichletBoundary,
-    Walker,
-)
-from dune.xt.functions import GridFunction as GF
-
 # -
-
 from dune.gdt import (
     DiscontinuousLagrangeSpace,
     DiscreteFunction,
+    LocalCouplingIntersectionIntegralBilinearForm,
     LocalElementIntegralBilinearForm,
     LocalElementIntegralFunctional,
     LocalElementProductIntegrand,
-    LocalCouplingIntersectionIntegralBilinearForm,
+    LocalIntersectionIntegralBilinearForm,
     LocalIPDGBoundaryPenaltyIntegrand,
     LocalIPDGInnerPenaltyIntegrand,
-    LocalIntersectionIntegralBilinearForm,
     LocalLaplaceIntegrand,
     LocalLaplaceIPDGDirichletCouplingIntegrand,
     LocalLaplaceIPDGInnerCouplingIntegrand,
@@ -31,6 +20,15 @@ from dune.gdt import (
     estimate_combined_inverse_trace_inequality_constant,
     estimate_element_to_intersection_equivalence_constant,
     make_element_and_intersection_sparsity_pattern,
+)
+from dune.xt.functions import GridFunction as GF
+from dune.xt.grid import (
+    AllDirichletBoundaryInfo,
+    ApplyOnCustomBoundaryIntersections,
+    ApplyOnInnerIntersectionsOnce,
+    Dim,
+    DirichletBoundary,
+    Walker,
 )
 
 

--- a/tutorials/source/discretize_elliptic_ipdg.py
+++ b/tutorials/source/discretize_elliptic_ipdg.py
@@ -32,10 +32,12 @@ from dune.xt.grid import (
 )
 
 
-def discretize_elliptic_ipdg_dirichlet_zero(
-    grid, diffusion, source, symmetry_factor=1, penalty_parameter=None, weight=1
-):
-
+def discretize_elliptic_ipdg_dirichlet_zero(grid,
+                                            diffusion,
+                                            source,
+                                            symmetry_factor=1,
+                                            penalty_parameter=None,
+                                            weight=1):
     """
     Discretizes the stationary heat equation with homogeneous Dirichlet boundary values everywhere
     with dune-gdt using an interior penalty (IP) discontinuous Galerkin (DG) method based on first
@@ -98,9 +100,7 @@ def discretize_elliptic_ipdg_dirichlet_zero(
     assert penalty_parameter > 0
 
     l_h = VectorFunctional(grid, source_space=V_h)
-    l_h += LocalElementIntegralFunctional(
-        LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source)
-    )
+    l_h += LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source))
 
     a_h = MatrixOperator(
         grid,
@@ -112,18 +112,14 @@ def discretize_elliptic_ipdg_dirichlet_zero(
     a_h += (
         LocalCouplingIntersectionIntegralBilinearForm(
             LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
-            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)
-        ),
+            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)),
         {},
         ApplyOnInnerIntersectionsOnce(grid),
     )
     a_h += (
         LocalIntersectionIntegralBilinearForm(
             LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
-            + LocalLaplaceIPDGDirichletCouplingIntegrand(
-                symmetry_factor, diffusion
-            )
-        ),
+            + LocalLaplaceIPDGDirichletCouplingIntegrand(symmetry_factor, diffusion)),
         {},
         ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()),
     )

--- a/tutorials/source/discretize_elliptic_ipdg.py
+++ b/tutorials/source/discretize_elliptic_ipdg.py
@@ -114,7 +114,7 @@ def discretize_elliptic_ipdg_dirichlet_zero(
     a_h += (
         LocalCouplingIntersectionIntegralBilinearForm(
             LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
-            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)  # noqa:W503
+            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)
         ),
         {},
         ApplyOnInnerIntersectionsOnce(grid),
@@ -122,7 +122,7 @@ def discretize_elliptic_ipdg_dirichlet_zero(
     a_h += (
         LocalIntersectionIntegralBilinearForm(
             LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
-            + LocalLaplaceIPDGDirichletCouplingIntegrand(  # noqa:W503
+            + LocalLaplaceIPDGDirichletCouplingIntegrand(
                 symmetry_factor, diffusion
             )
         ),

--- a/tutorials/source/myst_code_init.py
+++ b/tutorials/source/myst_code_init.py
@@ -1,5 +1,6 @@
-from IPython import get_ipython
 import warnings
+
+from IPython import get_ipython
 
 ip = get_ipython()
 if ip is not None:

--- a/tutorials/source/substitutions.py
+++ b/tutorials/source/substitutions.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 
-
 # substitutions for the most important classes and methods
 common = """
 .. |NumPy| replace:: :mod:`NumPy <numpy>`

--- a/tutorials/source/try_on_binder.py
+++ b/tutorials/source/try_on_binder.py
@@ -9,6 +9,7 @@ class binder_link_node(nodes.General, nodes.Element):
 
 
 class TryOnBinder(Directive):
+
     def run(self):
         env = self.state.document.settings.env
         app = env.app
@@ -19,8 +20,7 @@ class TryOnBinder(Directive):
         # this is somewhat confusing, but the docs repository's branches are named after the
         # directories which are slugs to avoid slashes and such
         node[
-            "target"
-        ] = f"https://mybinder.org/v2/gh/dune-community/dune-gdt-tutorials-pages/{slug}?filepath={generated_nb}"
+            "target"] = f"https://mybinder.org/v2/gh/dune-community/dune-gdt-tutorials-pages/{slug}?filepath={generated_nb}"  # noqa: E501
         node["badge"] = "https://mybinder.org/badge_logo.svg"
         return [node]
 

--- a/tutorials/test_tutorials.py
+++ b/tutorials/test_tutorials.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 from pytest_notebook.nb_regression import NBRegressionFixture


### PR DESCRIPTION
Switches from `(py)flakes(8)` to ruff, which is _so much_ faster. 
Also actually applies our yapf config to the source tree. The pre-commit did not do anything...