### PR TITLE
[py] rewire config import guards for plotting

### DIFF
--- a/python/gdt/dune/gdt/__init__.py
+++ b/python/gdt/dune/gdt/__init__.py
@@ -91,7 +91,7 @@ for mod_name in (  # order should not matter!
 ):
     guarded_import(globals(), 'dune.gdt', mod_name)
 
-if config.HAVE_K3D:
+if config.HAVE_VISUALIZATION:
     from dune.xt.common.vtk.plot import plot
 
     def visualize_function(function, grid=None, subsampling=False):

--- a/python/xt/dune/xt/common/config.py
+++ b/python/xt/dune/xt/common/config.py
@@ -19,6 +19,10 @@ def _can_import(module):
 
 _PACKAGES = {
     'K3D': lambda: _can_import('k3d'),
+    'VTK': lambda: _can_import('vtk'),
+    'IPYWIDGETS': lambda: _can_import('ipywidgets'),
+    'MATPLOTLIB': lambda: _can_import('matplotlib'),
+    'VISUALIZATION': lambda: _can_import(['vtk', 'k3d', 'ipywidgets', 'matplotlib']),
 }
 
 

--- a/python/xt/dune/xt/common/vtk/plot.py
+++ b/python/xt/dune/xt/common/vtk/plot.py
@@ -12,7 +12,7 @@
 
 from dune.xt.common.config import config
 
-if config.HAVE_K3D:
+if config.HAVE_VISUALIZATION:
     import time
     import warnings
 

--- a/python/xt/dune/xt/functions/__init__.py
+++ b/python/xt/dune/xt/functions/__init__.py
@@ -41,7 +41,7 @@ for mod_name in (
 ):
     guarded_import(globals(), 'dune.xt.functions', mod_name)
 
-if config.HAVE_K3D:
+if config.HAVE_VISUALIZATION:
     import os
     import tempfile
     from dune.xt.common.vtk.plot import plot


### PR DESCRIPTION
Previously we had code paths where only k3d was checked and imports then
failed with missing mpl/vtk
