### PR TITLE
shellcheck

### DIFF
--- a/.ci/gitlab/test_tutorials.bash
+++ b/.ci/gitlab/test_tutorials.bash
@@ -2,10 +2,10 @@
 
 COV_OPTION="--cov=dune"
 
-THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ; pwd -P )"
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
 BINARY_DIR="${1}"
 
-for fn in ${THIS_DIR}/../../tutorials/source/example__*md ; do
+for fn in "${THIS_DIR}"/../../tutorials/source/example__*md ; do
   mystnb-to-jupyter -o "${fn}" "${fn/example/..\/converted_example}".ipynb
 done
 
@@ -13,7 +13,7 @@ COMMON_PYTEST_OPTS="--junitxml=${BINARY_DIR}/dune/pytest_results_tutorials.xml \
   --cov-report= ${COV_OPTION} --cov-config=${BINARY_DIR}/python/xt/setup.cfg --cov-context=test"
 export COVERAGE_FILE=${BINARY_DIR}/coverage-tutorials
 # manually add plugins to load that are excluded for other runs
-cd ${THIS_DIR}/../..
-xvfb-run -a pytest ${COMMON_PYTEST_OPTS} --nb-coverage -s -p no:pycharm -v -s\
+cd "${THIS_DIR}"/../.. || exit
+xvfb-run -a pytest "${COMMON_PYTEST_OPTS}" --nb-coverage -s -p no:pycharm -v -s\
   -p nb_regression -p notebook tutorials/test_tutorials.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,8 @@ repos:
   hooks:
   - id: actionlint
     additional_dependencies: [pyflakes>=3.0.1, shellcheck-py>=0.9.0.5]
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.10.0.1
+  hooks:
+  - id: shellcheck
+

--- a/.vcpkg-overlays/update_ports.bash
+++ b/.vcpkg-overlays/update_ports.bash
@@ -13,7 +13,7 @@ cd "$REPO_ROOT"
 mkdir -p tmp
 
 # Generate the list of submodules dynamically, filtering only those that are CMake-based projects
-if ! git submodule foreach --quiet '([ -f CMakeLists.txt ] && echo $path) || true' > tmp/submodule_list.txt; then
+if ! git submodule foreach --quiet "([ -f CMakeLists.txt ] && echo $path) || true" > tmp/submodule_list.txt; then
     echo "Warning: Some submodules could not be processed. Continuing with the rest." >&2
 fi
 
@@ -134,13 +134,13 @@ EOF
 }
 
 # Process all submodules
-while read submodule_dir; do
+while read -r submodule_dir; do
     submodule_name=$(basename "$submodule_dir")
 
     # Create the overlay port directory
-    mkdir -p .vcpkg-overlays/ports/$submodule_name
+    mkdir -p .vcpkg-overlays/ports/"$submodule_name"
 
     create_port_files "$submodule_name" "$submodule_dir"
-    pre-commit run cmake-format --files .vcpkg-overlays/ports/$submodule_name/* || true
-    pre-commit run clang-format --files .vcpkg-overlays/ports/$submodule_name/* || true
+    pre-commit run cmake-format --files .vcpkg-overlays/ports/"$submodule_name"/* || true
+    pre-commit run clang-format --files .vcpkg-overlays/ports/"$submodule_name"/* || true
 done < tmp/submodule_list.txt

--- a/.vcsetup/run.d/01_install_precommit.bash
+++ b/.vcsetup/run.d/01_install_precommit.bash
@@ -2,5 +2,5 @@
 
 set -e
 
-THIS_DIR="$(cd "$(dirname ${BASH_SOURCE[0]:-$0})" ; pwd -P )"
-cd ${THIS_DIR}/../.. && pre-commit install
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" ; pwd -P )"
+cd "${THIS_DIR}"/../.. && pre-commit install

--- a/deps/.ci/deploy_docs.sh
+++ b/deps/.ci/deploy_docs.sh
@@ -16,9 +16,9 @@ git config user.name "DUNE Community Bot"
 git config user.email "dune-community.bot@wwu.de"
 
 TARGET=docs/${MODULE}/${ID}/
-mkdir -p ${TARGET}
-rsync -a --delete  ${BUILDDIR}/${MODULE}/doc/doxygen/html/ ${TARGET}/
-git add ${TARGET}
+mkdir -p "${TARGET}"
+rsync -a --delete  "${BUILDDIR}"/"${MODULE}"/doc/doxygen/html/ "${TARGET}"/
+git add "${TARGET}"
 
 git commit -m "Updated documentation for ${MODULE} ${ID}"
 git push

--- a/deps/.ci/init_sshkey.sh
+++ b/deps/.ci/init_sshkey.sh
@@ -6,8 +6,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 KEY=${1}
 IV=${2}
 RSAKEY=${3}.rsa.enc
-pushd ${DIR}
+pushd "${DIR}"
 [ -d ~/.ssh ] || mkdir ~/.ssh
-openssl aes-256-cbc -K ${KEY} -iv ${IV} -in ${RSAKEY} -out ~/.ssh/id_rsa -d
+openssl aes-256-cbc -K "${KEY}" -iv "${IV}" -in "${RSAKEY}" -out ~/.ssh/id_rsa -d
 chmod 600 ~/.ssh/id_rsa
 popd

--- a/deps/build_interactive_bindings_venv.sh
+++ b/deps/build_interactive_bindings_venv.sh
@@ -16,20 +16,22 @@ fi
 
 # initialize the virtualenv, if not yet present
 export BASEDIR="${PWD}"
-mkdir -p environments/${DXT_ENVIRONMENT}/venv
-if [ -e environments/${DXT_ENVIRONMENT}/venv/${OPTS} ]; then
-  echo not creating virtualenv in environments/${DXT_ENVIRONMENT}/venv/${OPTS}, already exists
+mkdir -p environments/"${DXT_ENVIRONMENT}"/venv
+if [ -e environments/"${DXT_ENVIRONMENT}"/venv/"${OPTS}" ]; then
+  echo not creating virtualenv in environments/"${DXT_ENVIRONMENT}"/venv/"${OPTS}", already exists
 else
-  cd environments/${DXT_ENVIRONMENT}/venv
-  virtualenv --python=python3 ${OPTS}
-  source ${OPTS}/bin/activate
+  cd environments/"${DXT_ENVIRONMENT}"/venv
+  virtualenv --python=python3 "${OPTS}"
+  # shellcheck disable=SC1091
+  source "${OPTS}"/bin/activate
   deactivate
 fi
 cd "${BASEDIR}"
 unset BASEDIR
 
 # load the variables of this environment, sources the virtualenv
-VENV=environments/${DXT_ENVIRONMENT}/venv/${OPTS} source environments/${DXT_ENVIRONMENT}/PATH.sh
+# shellcheck disable=SC1090
+VENV=environments/"${DXT_ENVIRONMENT}"/venv/"${OPTS}" source environments/"${DXT_ENVIRONMENT}"/PATH.sh
 
 # build dune
 if [ "${OPTS: -6}" == ".ninja" ]; then
@@ -40,20 +42,20 @@ fi
 
 cd "${BASEDIR}"
 # configure
-WERROR=0 ./dune-common/bin/dunecontrol --opts=config.opts/$OPTS --builddir=${BASEDIR}/build-$OPTS configure
+WERROR=0 ./dune-common/bin/dunecontrol --opts=config.opts/"${OPTS}" --builddir="${BASEDIR}"/build-"${OPTS}" configure
 for mod in dune-xt dune-gdt; do
-  WERROR=1 ./dune-common/bin/dunecontrol --opts=config.opts/$OPTS --only=$mod --builddir=${BASEDIR}/build-$OPTS configure
+  WERROR=1 ./dune-common/bin/dunecontrol --opts=config.opts/"${OPTS}" --only="$mod" --builddir="${BASEDIR}"/build-"${OPTS}" configure
 done
 # make all
-./dune-common/bin/dunecontrol --builddir=${BASEDIR}/build-$OPTS bexec "$MAKE all"
+./dune-common/bin/dunecontrol --builddir="${BASEDIR}"/build-"${OPTS}" bexec "$MAKE all"
 # make bindings
 for mod in dune-xt dune-gdt; do
-  ./dune-common/bin/dunecontrol --builddir=${BASEDIR}/build-$OPTS --only=$mod bexec "$MAKE bindings_no_ext"
-  ./dune-common/bin/dunecontrol --builddir=${BASEDIR}/build-$OPTS --only=$mod bexec "$MAKE install_python"
+  ./dune-common/bin/dunecontrol --builddir="${BASEDIR}"/build-"${OPTS}" --only="$mod" bexec "$MAKE bindings_no_ext"
+  ./dune-common/bin/dunecontrol --builddir="${BASEDIR}"/build-"${OPTS}" --only="$mod" bexec "$MAKE install_python"
 done
 
 cd "${BASEDIR}"
 echo
 echo "All done! From now on run"
-echo "  OPTS=$OPTS source envs/${DXT_ENVIRONMENT}/PATH.sh"
+echo "  OPTS=${OPTS} source envs/${DXT_ENVIRONMENT}/PATH.sh"
 echo "to activate the virtualenv!"

--- a/deps/entrypoint.bash
+++ b/deps/entrypoint.bash
@@ -1,5 +1,6 @@
 #!/bin/bash
 
- . /venv/bin/activate
+# shellcheck disable=SC1091
+. /venv/bin/activate
 
- exec "${@}"
+exec "${@}"

--- a/deps/environments/debian-full/PATH.sh
+++ b/deps/environments/debian-full/PATH.sh
@@ -1,4 +1,5 @@
-BASEDIR="$(cd "$(dirname ${BASH_SOURCE[0]})/../.." ;  pwd -P )"
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit ;  pwd -P )"
+cd "${BASEDIR}" || exit
 export DXT_ENVIRONMENT=${DXT_ENVIRONMENT:-debian-full}
 export OPTS=${OPTS:-clang-relwithdebinfo.ninja}
 export VENV=${VENV:-environments/${DXT_ENVIRONMENT}/venv/${OPTS}}
@@ -6,6 +7,7 @@ export PATH=${BASEDIR}/bin:$PATH
 export F77=gfortran
 export CMAKE_FLAGS="-DDS_HEADERCHECK_DISABLE=1 -DCMAKE_DISABLE_FIND_PACKAGE_MPI=FALSE -DMINIMAL_DEBUG_LEVEL=grave -DDUNE_PYTHON_VIRTUALENV_SETUP=1 -DDUNE_PYTHON_VIRTUALENV_PATH=${BASEDIR}/${VENV}"
 if [ -e "${BASEDIR}/${VENV}/bin/activate" ]; then
+    # shellcheck disable=SC1091
     source "${BASEDIR}/${VENV}/bin/activate"
 else
     echo "WARNING: missing virtualenv ${BASEDIR}/${VENV}, did you call build_interactive_bindings_venv.sh?"

--- a/deps/environments/debian-minimal/PATH.sh
+++ b/deps/environments/debian-minimal/PATH.sh
@@ -1,10 +1,11 @@
-DIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ;  pwd -P )"
-export BASEDIR=${DIR}/..
-export INSTALL_PREFIX=${DIR}/local
-export PATH=${INSTALL_PREFIX}/bin:$PATH
-export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib64:${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH
-export PKG_CONFIG_PATH=${INSTALL_PREFIX}/lib64/pkgconfig:${INSTALL_PREFIX}/lib/pkgconfig:${INSTALL_PREFIX}/share/pkgconfig:$PKG_CONFIG_PATH
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit ;  pwd -P )"
+export BASEDIR="${DIR}/.."
+export INSTALL_PREFIX="${DIR}/local"
+export PATH="${INSTALL_PREFIX}/bin:$PATH"
+export LD_LIBRARY_PATH="${INSTALL_PREFIX}/lib64:${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="${INSTALL_PREFIX}/lib64/pkgconfig:${INSTALL_PREFIX}/lib/pkgconfig:${INSTALL_PREFIX}/share/pkgconfig:$PKG_CONFIG_PATH"
 # -DCMAKE_PREFIX_PATH= is for alberta
-export CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=$INSTALL_PREFIX -DEIGEN3_INCLUDE_DIR=$INSTALL_PREFIX/include/eigen3 -DDUNE_XT_WITH_PYTHON_BINDINGS=TRUE"
-[ -e ${INSTALL_PREFIX}/bin/activate ] && . ${INSTALL_PREFIX}/bin/activate
+export CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DEIGEN3_INCLUDE_DIR=${INSTALL_PREFIX}/include/eigen3 -DDUNE_XT_WITH_PYTHON_BINDINGS=TRUE"
+# shellcheck disable=SC1091
+[ -e "${INSTALL_PREFIX}/bin/activate" ] && . "${INSTALL_PREFIX}/bin/activate"
 export OMP_NUM_THREADS=1

--- a/docker/build_ci.sh
+++ b/docker/build_ci.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # the dir containing this script is the base
-BASEDIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ;  pwd -P)"
-cd "${BASEDIR}"
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit ;  pwd -P)"
+cd "${BASEDIR}" || exit
 
 # ensure there are no open changes, as the commit hash will enter the docker image
 ./check_for_clean_working_dir.sh
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "ERROR: refusing to build docker image in dirty working directory!"
     exit 1
@@ -20,16 +21,19 @@ echo "done"
 
 echo -n "patching docker/ci/Dockerfile ... "
 sed -i "s/FROM_DEV_HASH/${DEV_HASH}/" ci/Dockerfile
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "failed (see above)!"
     exit 1
 fi
 sed -i "s/LABEL_BUILD_DATE/${DATE}/" ci/Dockerfile
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "failed (see above)!"
     exit 1
 fi
 sed -i "s/LABEL_VCS_REF/${VCS_REF}/" ci/Dockerfile
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "failed (see above)!"
     exit 1
@@ -41,6 +45,7 @@ echo "==========================================================================
 
 docker build -t ghcr.io/dune-gdt/dune-gdt/ci:${HASH} -f ci/Dockerfile ci/
 
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "======================================================================================================="
     >&2 echo "building ... failed (see above)!"
@@ -53,6 +58,7 @@ echo "==========================================================================
 echo "building ... done!"
 echo -n "restoring docker/ci/Dockerfile ... "
 git restore ci/Dockerfile
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "failed (see above)!"
     exit 1

--- a/docker/build_dev.sh
+++ b/docker/build_dev.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-BASEDIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ;  pwd -P)"
-cd "${BASEDIR}"
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit ;  pwd -P)"
+cd "${BASEDIR}" || exit
 
 # ensure there are no open changes, as the commit hash will enter the docker image
 ./check_for_clean_working_dir.sh
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "ERROR: refusing to build docker image in dirty working directory!"
     exit 1
@@ -18,11 +19,13 @@ echo "done"
 
 echo -n "patching docker/ci/Dockerfile ... "
 sed -i "s/LABEL_BUILD_DATE/${DATE}/" dev/Dockerfile
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "failed (see above)!"
     exit 1
 fi
 sed -i "s/LABEL_VCS_REF/${VCS_REF}/" dev/Dockerfile
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "failed (see above)!"
     exit 1
@@ -34,6 +37,7 @@ echo "==========================================================================
 
 docker build -t ghcr.io/dune-gdt/dune-gdt/dev:${HASH} -f dev/Dockerfile dev/
 
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "======================================================================================================="
     >&2 echo "building ... failed (see above)!"
@@ -45,6 +49,7 @@ echo "==========================================================================
 echo "building ... done!"
 echo -n "restoring docker/dev/Dockerfile ... "
 git restore dev/Dockerfile
+# shellcheck disable=SC2181
 if [[ $? != 0 ]] ; then
     >&2 echo "failed (see above)!"
     exit 1

--- a/docker/check_for_clean_working_dir.sh
+++ b/docker/check_for_clean_working_dir.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-BASEDIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ;  pwd -P)"
-cd "${BASEDIR}/.."
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit ;  pwd -P)"
+cd "${BASEDIR}/.." || exit
 
 git update-index -q --really-refresh && \
     git diff-index --quiet HEAD && \

--- a/docker/compute_ci_hash.sh
+++ b/docker/compute_ci_hash.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-BASEDIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ;  pwd -P)"
-cd "${BASEDIR}"
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit ;  pwd -P)"
+cd "${BASEDIR}" || exit
 
 export DEV_HASH=$(./compute_dev_hash.sh)
 export CI_HASH=$(sha256sum ci/* compute_ci_hash.sh | sort | sha256sum | cut -d ' ' -f 1)
 export SUBMODULES_HASH=$(git ls-tree HEAD deps/ | grep commit | sha256sum | sort | sha256sum | cut -d ' ' -f 1)
 export OPTS_HASH=$(sha256sum ../deps/config.opts/* | sort | sha256sum | cut -d ' ' -f 1)
-echo $(echo $DEV_HASH $CI_HASH $SUBMODULES_HASH $OPTS_HASH | sort | sha256sum | cut -d ' ' -f 1)
+echo "$(echo "$DEV_HASH" "$CI_HASH" "$SUBMODULES_HASH" "$OPTS_HASH" | sort | sha256sum | cut -d ' ' -f 1)"

--- a/docker/compute_dev_hash.sh
+++ b/docker/compute_dev_hash.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASEDIR="$(cd "$(dirname ${BASH_SOURCE[0]})" ;  pwd -P)"
-cd "${BASEDIR}"
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit ;  pwd -P)"
+cd "${BASEDIR}" || exit
 
-echo $(sha256sum dev/* compute_dev_hash.sh | sort | sha256sum | cut -d ' ' -f 1)
+echo "$(sha256sum dev/* compute_dev_hash.sh | sort | sha256sum | cut -d ' ' -f 1)"

--- a/docker/run_ci.sh
+++ b/docker/run_ci.sh
@@ -5,10 +5,10 @@ if [[ "X${OPTS}" == "X" ]] ; then
 fi
 
 # the dir containing this script is needed for mounting stuff into the container
-PROJECTDIR="$(cd "$(dirname ${BASH_SOURCE[0]})/.." ;  pwd -P)"
+PROJECTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit ;  pwd -P)"
 CONTAINER=ghcr.io/dune-gdt/dune-gdt/ci
 TAG=${TAG:-$(./docker/compute_ci_hash.sh)}
-PORT="18$(( ( RANDOM % 10 ) ))$(( ( RANDOM % 10 ) ))$(( ( RANDOM % 10 ) ))"
+PORT="18$((  RANDOM % 10  ))$((  RANDOM % 10  ))$((  RANDOM % 10  ))"
 DOCKER_BIN=${DOCKER:-docker}
 SOURCE=${PROJECTDIR}
 TARGET="/source"
@@ -19,13 +19,13 @@ echo "  Starting a CI docker container for dune-gdt using"
 echo "    ${BUILDDIR}"
 echo "  as persistent build-dir"
 echo "======================================================================================"
-mkdir -p ${BUILDDIR}
+mkdir -p "${BUILDDIR}"
 
-${DOCKER_BIN} run --rm=true --privileged=true -t ${DOCKER_RUN_CI_ARGS} --hostname docker \
-  -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
-  -e OPTS=${OPTS} \
+${DOCKER_BIN} run --rm=true --privileged=true -t "${DOCKER_RUN_CI_ARGS}" --hostname docker \
+  -e DISPLAY="$DISPLAY" -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -e OPTS="${OPTS}" \
   -e EXPOSED_PORT=$PORT -p 127.0.0.1:$PORT:$PORT \
   -v /etc/localtime:/etc/localtime:ro \
   -v "${SOURCE}":"${TARGET}" \
   -v "${BUILDDIR}":"/build/${OPTS}/dune-gdt" \
-  ${CONTAINER}:${TAG} "${@}"
+  ${CONTAINER}:"${TAG}" "${@}"

--- a/docker/run_dev.sh
+++ b/docker/run_dev.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # the dir containing this script is needed for mounting stuff into the container
-PROJECTDIR="$(cd "$(dirname ${BASH_SOURCE[0]})/.." ;  pwd -P)"
+PROJECTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit ;  pwd -P)"
 CONTAINER=ghcr.io/dune-gdt/dune-gdt/dev
 TAG=${TAG:-$(./docker/compute_dev_hash.sh)}
 CID_FILE=/tmp/${CONTAINER//\//_}_${USER}.cid
-PORT="18$(( ( RANDOM % 10 ) ))$(( ( RANDOM % 10 ) ))$(( ( RANDOM % 10 ) ))"
+PORT="18$((  RANDOM % 10  ))$((  RANDOM % 10  ))$((  RANDOM % 10  ))"
 DOCKER_BIN=${DOCKER:-docker}
 
 SOURCE=${PROJECTDIR}
@@ -13,11 +13,11 @@ TARGET="/root/dune-gdt"
 if [ $# -eq 0 ] ; then
   EXEC="/bin/bash"
 else
-  EXEC="${@}"
+  EXEC="${*}"
 fi
 DOCKER_HOME="${HOME}/.docker-homes/${CONTAINER//\//_}"
 
-if [ -e ${CID_FILE} ]; then
+if [ -e "${CID_FILE}" ]; then
 
   echo "A dev docker container for dune-gdt is already running."
   echo "Execute"
@@ -55,21 +55,21 @@ echo                                                     ') /bin/bash'
 echo "======================================================================================"
 echo
 
-mkdir -p ${DOCKER_HOME} &> /dev/null
+mkdir -p "${DOCKER_HOME}" &> /dev/null
 
-${DOCKER_BIN} run --rm=true --privileged=true -t -i --hostname docker --cidfile=${CID_FILE} \
+${DOCKER_BIN} run --rm=true --privileged=true -t -i --hostname docker --cidfile="${CID_FILE}" \
   -e LOCAL_USER=root -e LOCAL_UID=0 -e LOCAL_GID=0 \
-  -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -e DISPLAY="$DISPLAY" -v /tmp/.X11-unix:/tmp/.X11-unix \
   -e QT_X11_NO_MITSHM=1 \
-  -e QT_SCALE_FACTOR=${QT_SCALE_FACTOR:-1} \
-  -e GDK_DPI_SCALE=${GDK_DPI_SCALE:-1} \
+  -e QT_SCALE_FACTOR="${QT_SCALE_FACTOR:-1}" \
+  -e GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}" \
   -e EXPOSED_PORT=$PORT -p 127.0.0.1:$PORT:$PORT \
   -v /etc/localtime:/etc/localtime:ro \
   -v "${DOCKER_HOME}":/root \
   -v "${SOURCE}":"${TARGET}" \
-  ${CONTAINER}:${TAG} "cd ~/dune-gdt && ${EXEC}"
+  ${CONTAINER}:"${TAG}" "cd ~/dune-gdt && ${EXEC}"
 
 echo
 echo "Removing ${CID_FILE}"
-rm -f ${CID_FILE}
+rm -f "${CID_FILE}"
 exit 0

--- a/dune/xt/test/common/compile_pgf_output.sh
+++ b/dune/xt/test/common/compile_pgf_output.sh
@@ -15,4 +15,4 @@
 
 make grid_output_pgf
 ./grid_output_pgf
-find . -name "*.tex" | xargs echo pdflatex
+find . -name "*.tex" -print0 | xargs -0 echo pdflatex


### PR DESCRIPTION
This pull request focuses on improving shell script robustness and consistency by quoting variable expansions, handling errors explicitly, and adhering to best practices such as disabling specific shellcheck warnings where necessary. Additionally, a new pre-commit hook for `shellcheck` has been added to enforce linting. Below are the most important changes grouped by theme:

### Shell Script Robustness Improvements:
* Quoted variable expansions to prevent word splitting and globbing in various scripts, such as `THIS_DIR`, `BASEDIR`, and `OPTS`. This change impacts files like `.ci/gitlab/test_tutorials.bash`, `.vcsetup/run.d/01_install_precommit.bash`, and `deps/.ci/init_sshkey.sh`. [[1]](diffhunk://#diff-337f33f4cff68f666d0d8b9041f852e259b6c0ef363f6e3cedf9806eda734a9dL5-R17) [[2]](diffhunk://#diff-16670d60787bcdec851b06e8624296a7fbd0a32067a4ec9e0740be1bd3be1d50L5-R6) [[3]](diffhunk://#diff-aeb91da41c6c9f4ef54f82d11b0ed3780ce394c9020b79ead1f30240af7f9079L9-R11)
* Added error handling using `|| exit` to ensure scripts terminate on failure when changing directories. Examples include `docker/build_ci.sh` and `docker/build_dev.sh`. [[1]](diffhunk://#diff-7ba15443f4fba7f82e50c5febf1515d115281f1e6a3ecf1e1f7b1434cd5cbb2bL4-R9) [[2]](diffhunk://#diff-7fa0bfc25b6d2e257385be0615bb4a665fb70f25dacee17f446df918df1357e1L3-R8)
* Disabled specific `shellcheck` warnings (e.g., SC2181, SC1091) where necessary to maintain clarity and avoid false positives in scripts like `docker/build_ci.sh` and `deps/environments/debian-full/PATH.sh`. [[1]](diffhunk://#diff-7ba15443f4fba7f82e50c5febf1515d115281f1e6a3ecf1e1f7b1434cd5cbb2bR24-R36) [[2]](diffhunk://#diff-b89e422aa9eee9b41986fb383e82801d09d9c2cc118c3a79876165217a34e3f0L1-R10)

### Pre-commit Hook Enhancements:
* Added a new `shellcheck` pre-commit hook to `.pre-commit-config.yaml` to enforce shell script linting with `shellcheck-py`.

### Docker Script Improvements:
* Improved quoting and error handling in Docker-related scripts, such as `docker/run_ci.sh`, `docker/run_dev.sh`, and `docker/compute_ci_hash.sh`, to ensure compatibility and reliability. [[1]](diffhunk://#diff-4e6fd4215596f013464cae202cca3a05f4799a53934b2bf0b49464ebafa8cf1eL8-R11) [[2]](diffhunk://#diff-8607e114e5c5679735896ef1a0d0a8dc62e3aac3e95ee5ed2dd1dc26f33434e1L4-R20) [[3]](diffhunk://#diff-27ef14d2d6f6e362f8d34da19f5baae0d48a949f7cdc50d475715c60b71dadbaL3-R10)

### Virtual Environment and Build Scripts:
* Updated paths and commands in scripts like `deps/build_interactive_bindings_venv.sh` to use quoted variables and handle virtual environments more reliably. [[1]](diffhunk://#diff-948176b200efdfc2026888ec6a05719d4d2f8cb3716cc19563f33d5633c16fb2L19-R34) [[2]](diffhunk://#diff-948176b200efdfc2026888ec6a05719d4d2f8cb3716cc19563f33d5633c16fb2L43-R60)

These changes collectively enhance the maintainability, reliability, and security of the shell scripts in the repository.