### PR TITLE
ci: group dependabot updates by ecosystem with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,28 +9,43 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  cooldown-days: 7
   allow:
   - dependency-type: all
   commit-message:
     prefix: ':arrow_up:'
   open-pull-requests-limit: 50
+  groups:
+    pip-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: weekly
+  cooldown-days: 7
   allow:
   - dependency-type: all
   commit-message:
     prefix: ':arrow_up:'
   open-pull-requests-limit: 50
+  groups:
+    github-actions-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: docker
   directory: ./
   schedule:
     interval: weekly
+  cooldown-days: 7
   allow:
   - dependency-type: all
   commit-message:
     prefix: ':arrow_up:'
   open-pull-requests-limit: 50
+  groups:
+    docker-dependencies:
+      patterns:
+      - "*"


### PR DESCRIPTION
## Summary

- Add a `groups` block to each dependabot ecosystem entry so all updates in that ecosystem are batched into a single PR instead of one PR per package
- Group names are unique and include the ecosystem name: `pip-dependencies`, `github-actions-dependencies`, `docker-dependencies`
- Add `cooldown-days: 7` to each ecosystem entry to reduce update noise

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid YAML and passes any schema checks
- [ ] Confirm dependabot raises grouped PRs (one per ecosystem) on the next scheduled run
- [ ] Confirm no PRs are opened for packages updated within the last 7 days

https://claude.ai/code/session_018EbtUbTou1XpRe9nXVKfe5

---
_Generated by [Claude Code](https://claude.ai/code/session_018EbtUbTou1XpRe9nXVKfe5)_