### PR TITLE
ci: run non-docker build on tags and publish wheels to PyPI

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -4,6 +4,7 @@ name: Non-docker Build and Test
 on:
   push:
     branches: [main]
+    tags: ['*']
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -149,4 +150,31 @@ jobs:
       with:
         packages-dir: wheels/
         repository-url: https://test.pypi.org/legacy/
+        verbose: true
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-24.04
+    needs: build_wheels
+    if: startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 120
+    environment: pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for PyPi Trusted Publishing
+      id-token: write
+
+    steps:
+    - name: Download wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: wheels_*
+        merge-multiple: true
+        path: wheels/
+    - run: |
+        ls -l wheels/*
+      shell: bash
+    - name: Upload wheels to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.12.4
+      with:
+        packages-dir: wheels/
         verbose: true


### PR DESCRIPTION
## Summary

Updates `.github/workflows/non_docker_build.yml` so the workflow also runs on tag pushes, and deploys the built wheels to the **real PyPI** when a tag is pushed.

## Changes

- Added `tags: ['*']` to the `push` trigger so the workflow runs when any tag is pushed (in addition to `main` pushes, PRs, and manual dispatch).
- Added a new `publish` job that:
  - depends on `build_wheels`,
  - only runs on tags (`if: startsWith(github.ref, 'refs/tags/')`),
  - uses the `pypi` GitHub environment,
  - uploads the wheels to the real PyPI via `pypa/gh-action-pypi-publish` with Trusted Publishing (`id-token: write`).

The existing `test_publish` job (Test PyPI) is left unchanged and continues to run on every triggering event.

## Notes

- This relies on a GitHub environment named `pypi` being configured with Trusted Publishing on PyPI (mirroring the existing `test-pypi` environment used for Test PyPI). The environment can be used to gate publishing with required reviewers if desired.

https://claude.ai/code/session_01Ac9HrtpnxYmaRaHvZQX2UE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ac9HrtpnxYmaRaHvZQX2UE)_