### PR TITLE
ci: unique Test PyPI versions, publish only on push to main

### DIFF
--- a/.ci/make_docker_wheels.bash
+++ b/.ci/make_docker_wheels.bash
@@ -49,9 +49,12 @@ done
 
 # default command is "build-wheels.sh"
 # this deletes testtols and uggrid source dirs
+# forward CI markers so versioneer renders a unique, CI-style wheel version
+# (CI -> pep440-pre style, GITHUB_RUN_NUMBER -> unique build number)
 DOCKER_RUN="docker run ${DT} --env-file=${ENV_FILE} -e DUNE_SRC_DIR=/home/dxt/src -v ${THISDIR}/../:/home/dxt/src \
   -e LOCAL_USER=${LOCAL_USER} -e LOCAL_GID=${LOCAL_GID} -e LOCAL_UID=${LOCAL_UID} \
   -e WHEELDIR_RELATIVE=${WHEELDIR_RELATIVE} -e PYTHON_VERSION=${PYTHON_VERSION} -e PLATFORM=${PLATFORM} \
+  -e CI -e GITHUB_RUN_NUMBER \
   -i ${IMAGE}"
 
 ${DOCKER_RUN} /home/dxt/src/.ci/build-wheels.sh

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -86,6 +86,10 @@ jobs:
         ./.ci/make_docker_wheels.bash
       env:
         GDT_PYTHON_VERSION: ${{ matrix.python-version }}
+        # mark this as a CI build (selects versioneer's pep440-pre style) and
+        # provide a unique build number so every upload gets a distinct version
+        CI: "true"
+        GITHUB_RUN_NUMBER: ${{ github.run_number }}
 
     - name: Upload wheels
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -98,6 +102,8 @@ jobs:
     name: Publish to Test PyPI
     runs-on: ubuntu-24.04
     needs: build_wheels
+    # only publish to Test PyPI on pushes to main, never on PRs or manual runs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 120
     environment: test-pypi
     permissions:


### PR DESCRIPTION
## Summary

Fixes the versioning for Test PyPI uploads so every upload gets a unique version, and restricts publishing to pushes on `main`.

### Problem
- Test PyPI rejects re-uploading an already-existing version. The wheel version is produced by `versioneer` (`cmake/modules/versioneer.py`), whose `pep440-pre` style already supports a unique build number via `GITHUB_RUN_NUMBER` (`TAG.post2.dev<RUN_NUMBER>`). However the wheels are built **inside a Docker container** (`make_docker_wheels.bash`), and neither `CI` (which selects the `pep440-pre` style) nor `GITHUB_RUN_NUMBER` was forwarded into that container — so builds didn't get a unique, CI-style version.
- The `test_publish` job had no event guard, so it ran on pull requests and manual `workflow_dispatch` runs as well, not just pushes to `main`.

### Changes
- **`.ci/make_docker_wheels.bash`**: forward `CI` and `GITHUB_RUN_NUMBER` into the build container (pass-through `-e` form, so they're omitted on local builds where they're unset and versioneer falls back to the commit distance).
- **`.github/workflows/non_docker_build.yml`**:
  - Set `CI=true` and `GITHUB_RUN_NUMBER` in the `build_wheels` step env so versioneer renders a unique `pep440-pre` version per run.
  - Gate the `test_publish` job with `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`.

### Notes
The build jobs (`build-linux`, `build_wheels`) still run on PRs and manual dispatch for validation; only the Test PyPI publish step is restricted to pushes on `main`.

https://claude.ai/code/session_01YCZAQxDWUM26GomngSC3mf

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCZAQxDWUM26GomngSC3mf)_