### PR TITLE
[tutorials] restore broken notebooks and execute them in the CI docs build

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -120,6 +120,67 @@ jobs:
         path: build/wheelhouse/final/
         if-no-files-found: error
 
+  build_tutorials:
+    name: Build tutorials docs (executes notebooks via myst-nb)
+    runs-on: ubuntu-24.04
+    needs: build_wheels
+    timeout-minutes: 60
+    env:
+      # the tutorials are executed against the freshly built wheels (current,
+      # git-derived version), not the stale dune-gdt release on PyPI
+      PYTHON_VERSION: "3.13"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Download freshly built wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: wheels_${{ env.PYTHON_VERSION }}
+        path: wheelhouse/
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        # xvfb for headless rendering; gmsh is shelled out to by pymor's gmsh
+        # discretizer used in example__gmsh_grid
+        sudo apt-get install -y xvfb gmsh
+
+    - name: Install bindings and docs/visualisation dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # install the built dune-xt/dune-gdt wheels (xt is an exact-version dep of gdt)
+        python -m pip install --find-links wheelhouse/ wheelhouse/*.whl
+        # docs + visualisation extras (myst-nb executes the notebook cells; k3d
+        # provides visualize_function rendering when the wheels were built with K3D)
+        python -m pip install \
+          "myst-nb>=0.16" furo sphinxcontrib-bibtex python-slugify pymor \
+          "k3d>=2.15.2" vtk ipywidgets lxml xmljson matplotlib wurlitzer
+
+    - name: Build tutorials (sphinx + myst-nb notebook execution)
+      # run from a neutral directory so the repo-root `dune/` source tree does not
+      # shadow the installed bindings; mirror SPHINXOPTS from tutorials/CMakeLists.txt
+      run: |
+        cd "${RUNNER_TEMP}"
+        xvfb-run -a python -m sphinx -W --keep-going -j auto -b html \
+          "${GITHUB_WORKSPACE}/tutorials/source" \
+          "${GITHUB_WORKSPACE}/build/tutorials_html"
+
+    - name: Upload built tutorials HTML
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: tutorials_html
+        path: build/tutorials_html
+        if-no-files-found: warn
+
   test_publish:
     name: Publish to Test PyPI
     runs-on: ubuntu-24.04

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -173,6 +173,19 @@ jobs:
           "${GITHUB_WORKSPACE}/tutorials/source" \
           "${GITHUB_WORKSPACE}/build/tutorials_html"
 
+    - name: Dump notebook execution error reports
+      # myst-nb writes a per-notebook traceback here for every cell that failed;
+      # surface them directly in the job log so failures are diagnosable without
+      # downloading the artifact
+      if: failure()
+      run: |
+        shopt -s nullglob
+        for f in "${GITHUB_WORKSPACE}"/build/tutorials_html/reports/*.err.log; do
+          echo "::group::$(basename "${f}")"
+          cat "${f}"
+          echo "::endgroup::"
+        done
+
     - name: Upload built tutorials HTML
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -168,13 +168,21 @@ jobs:
           "k3d>=2.15.2" vtk ipywidgets lxml xmljson matplotlib wurlitzer
 
     - name: Build tutorials (sphinx + myst-nb notebook execution)
-      # run from a neutral directory so the repo-root `dune/` source tree does not
-      # shadow the installed bindings; mirror SPHINXOPTS from tutorials/CMakeLists.txt
+      # Run from a neutral directory so the repo-root `dune/` source tree does not
+      # shadow the installed bindings. Notebook execution is the actual test: myst-nb
+      # is configured with nb_execution_raise_on_error=False, so a failing notebook
+      # writes <out>/reports/<name>.err.log instead of aborting, and we fail the job
+      # on those below. We intentionally do NOT pass sphinx -W, because intersphinx
+      # inventory fetches emit network-dependent warnings unrelated to the tutorials.
       run: |
         cd "${RUNNER_TEMP}"
-        xvfb-run -a python -m sphinx -W --keep-going -j auto -b html \
-          "${GITHUB_WORKSPACE}/tutorials/source" \
-          "${GITHUB_WORKSPACE}/build/tutorials_html"
+        OUT="${GITHUB_WORKSPACE}/build/tutorials_html"
+        xvfb-run -a python -m sphinx --keep-going -j 1 -b html \
+          "${GITHUB_WORKSPACE}/tutorials/source" "${OUT}"
+        if compgen -G "${OUT}/reports/*.err.log" > /dev/null; then
+          echo "::error::one or more executed tutorial notebooks failed (see dumped reports below)"
+          exit 1
+        fi
 
     - name: Dump notebook execution error reports
       # myst-nb writes a per-notebook traceback here for every cell that failed;

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -148,7 +148,10 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        sudo apt-get update
+        # Do not fail the whole job if an unrelated third-party apt repo (e.g.
+        # google-chrome on the GitHub runner) has a transient index mismatch; the
+        # Ubuntu repos that provide xvfb/gmsh update fine.
+        sudo apt-get update || true
         # xvfb for headless rendering; gmsh is shelled out to by pymor's gmsh
         # discretizer used in example__gmsh_grid
         sudo apt-get install -y xvfb gmsh

--- a/python/xt/dune/xt/common/vtk/plot.py
+++ b/python/xt/dune/xt/common/vtk/plot.py
@@ -89,8 +89,13 @@ if config.HAVE_K3D:
                     "supplying transforms is currently not supported for time series VTK Data"
                 )
 
-            self.vtk_data = np.stack(
-                [_transform_to_k3d(v[0], v[1], color_attribute_name) for v in vtk_data]
+            # NumPy >= 2 refuses to build an array from a ragged sequence (the
+            # per-timestep tuples mix scalars and arrays of differing shapes) and
+            # raises "inhomogeneous shape", whereas np.stack used to yield an
+            # object array. Build the object array explicitly to stay compatible.
+            self.vtk_data = np.array(
+                [_transform_to_k3d(v[0], v[1], color_attribute_name) for v in vtk_data],
+                dtype=object,
             )
             self.value_minmax = (
                 np.nanmin(self.vtk_data[:, 2]),

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -56,10 +56,12 @@ myst_heading_anchors = 2
 import substitutions  # noqa
 
 myst_substitutions = substitutions.myst_substitutions
-nb_execute_notebooks = "cache"
+nb_execution_mode = "cache"
 nb_execution_timeout = 240  # there is an interpolation test
 # print tracebacks to stdout
 nb_execution_show_tb = True
+# fail the (sphinx -W) build if any notebook cell raises during execution
+nb_execution_raise_on_error = True
 
 bibtex_bibfiles = ["bibliography.bib"]
 # Add any paths that contain templates here, relative to this directory.

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -61,10 +61,24 @@ nb_execution_timeout = 240  # there is an interpolation test
 # print tracebacks to stdout
 nb_execution_show_tb = True
 # Do not abort on the first failing notebook: let myst-nb execute every notebook
-# and emit a warning (with traceback) for each failure, so a single build reports
-# all broken notebooks. The build still fails because sphinx is run with -W
-# (warnings treated as errors).
+# and emit a warning (with traceback) for each failure. The CI job fails the build
+# if any executed notebook wrote an error report (see non_docker_build.yml).
 nb_execution_raise_on_error = False
+# These notebooks (and the helper-free tutorials) still rely on dune-gdt python
+# bindings that are currently commented out in the C++ sources (direct
+# `MatrixOperator += local_form`, `BilinearForm.result`/`apply2`, the
+# oswald/IPDG-flux-reconstruction operators). They are restored and rendered, but
+# not executed, until the bindings are restored / the notebooks are migrated to the
+# current API. Tracked in the GitHub issues referenced from #41.
+nb_execution_excludepatterns = [
+    "*dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md",
+    "*dune_gdt_tutorial_on_data_functions_and_interpolation.md",
+    "*example__ESV2007_estimates.md",
+    "*example__MNS2002_estimates.md",
+    "*example__gmsh_grid.md",
+    "*example__ipdg_heat_equation.md",
+    "*example__prolongations_products_and_norms.md",
+]
 
 bibtex_bibfiles = ["bibliography.bib"]
 # Add any paths that contain templates here, relative to this directory.

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -69,7 +69,7 @@ nb_execution_raise_on_error = False
 # `MatrixOperator += local_form`, `BilinearForm.result`/`apply2`, the
 # oswald/IPDG-flux-reconstruction operators). They are restored and rendered, but
 # not executed, until the bindings are restored / the notebooks are migrated to the
-# current API. Tracked in the GitHub issues referenced from #41.
+# current API. Tracked in #127 (blocked on #126).
 nb_execution_excludepatterns = [
     "*dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md",
     "*dune_gdt_tutorial_on_data_functions_and_interpolation.md",

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -60,8 +60,11 @@ nb_execution_mode = "cache"
 nb_execution_timeout = 240  # there is an interpolation test
 # print tracebacks to stdout
 nb_execution_show_tb = True
-# fail the (sphinx -W) build if any notebook cell raises during execution
-nb_execution_raise_on_error = True
+# Do not abort on the first failing notebook: let myst-nb execute every notebook
+# and emit a warning (with traceback) for each failure, so a single build reports
+# all broken notebooks. The build still fails because sphinx is run with -W
+# (warnings treated as errors).
+nb_execution_raise_on_error = False
 
 bibtex_bibfiles = ["bibliography.bib"]
 # Add any paths that contain templates here, relative to this directory.

--- a/tutorials/source/discretize_elliptic_cg.py
+++ b/tutorials/source/discretize_elliptic_cg.py
@@ -1,4 +1,5 @@
 from dune.gdt import (
+    BilinearForm,
     ContinuousLagrangeSpace,
     DirichletConstraints,
     DiscreteFunction,
@@ -50,13 +51,15 @@ def discretize_elliptic_cg_dirichlet_zero(grid, diffusion, source):
         LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source)
     )
 
+    a_form = BilinearForm(grid)
+    a_form += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
     a_h = MatrixOperator(
         grid,
         source_space=V_h,
         range_space=V_h,
         sparsity_pattern=make_element_sparsity_pattern(V_h),
     )
-    a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+    a_h.append(a_form)
 
     dirichlet_constraints = DirichletConstraints(boundary_info, V_h)
 
@@ -112,13 +115,15 @@ def discretize_elliptic_cg_dirichlet(grid, diffusion, source, dirichlet_values):
         LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source)
     )
 
+    a_form = BilinearForm(grid)
+    a_form += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
     a_h = MatrixOperator(
         grid,
         source_space=V_h,
         range_space=V_h,
         sparsity_pattern=make_element_sparsity_pattern(V_h),
     )
-    a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+    a_h.append(a_form)
 
     dirichlet_constraints = DirichletConstraints(boundary_info, V_h)
     dirichlet_values = boundary_interpolation(

--- a/tutorials/source/discretize_elliptic_ipdg.py
+++ b/tutorials/source/discretize_elliptic_ipdg.py
@@ -3,6 +3,7 @@ from numbers import Number
 
 # -
 from dune.gdt import (
+    BilinearForm,
     DiscontinuousLagrangeSpace,
     DiscreteFunction,
     LocalCouplingIntersectionIntegralBilinearForm,
@@ -101,29 +102,29 @@ def discretize_elliptic_ipdg_dirichlet_zero(
         LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source)
     )
 
+    a_form = BilinearForm(grid)
+    a_form += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+    a_form += (
+        LocalCouplingIntersectionIntegralBilinearForm(
+            LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
+            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)
+        ),
+        ApplyOnInnerIntersectionsOnce(grid),
+    )
+    a_form += (
+        LocalIntersectionIntegralBilinearForm(
+            LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
+            + LocalLaplaceIPDGDirichletCouplingIntegrand(symmetry_factor, diffusion)
+        ),
+        ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()),
+    )
     a_h = MatrixOperator(
         grid,
         source_space=V_h,
         range_space=V_h,
         sparsity_pattern=make_element_and_intersection_sparsity_pattern(V_h),
     )
-    a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
-    a_h += (
-        LocalCouplingIntersectionIntegralBilinearForm(
-            LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
-            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)
-        ),
-        {},
-        ApplyOnInnerIntersectionsOnce(grid),
-    )
-    a_h += (
-        LocalIntersectionIntegralBilinearForm(
-            LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
-            + LocalLaplaceIPDGDirichletCouplingIntegrand(symmetry_factor, diffusion)
-        ),
-        {},
-        ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()),
-    )
+    a_h.append(a_form)
 
     walker = Walker(grid)
     walker.append(a_h)

--- a/tutorials/source/dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md
+++ b/tutorials/source/dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md
@@ -1,0 +1,549 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Tutorial: continuous FEM for the stationary heat equation
+
+This tutorial shows how to solve the stationary heat equation using continuous Finite Elements with `dune-gdt`.
+
+This is work in progress [WIP], still missing:
+
+* Neumann boundary values
+* Robin boundary values
+
+```{code-cell}
+
+
+import numpy as np
+
+```
+
+## diffusion with homogeneous Dirichlet boundary condition
+
+### analytical problem
+
+Let $\Omega \subset \mathbb{R}^d$ for $1 \leq d \leq 3$ be a bounded connected domain with Lipschitz-boundary $\partial\Omega$. We seek the solution $u \in H^1_0(\Omega)$ of the **linear diffusion equation** (with a homogeneous Dirichlet boundary condition)
+
+$$\begin{align}
+- \nabla\cdot(\kappa\nabla u) &= f &&\text{in } \Omega,\tag{1}\label{pde}\\
+u &= 0 &&\text{on } \partial\Omega,
+\end{align}$$
+
+in a weak sense, where $\kappa \in [L^\infty(\Omega)]^{d \times d}$ denotes a given diffusion function and $f \in L^2(\Omega)$ denotes a given source function.
+
+The variational problem associated with $\eqref{pde}$ reads: find $u \in H^1_0(\Omega)$, such that
+
+$$\begin{align}
+a(u, v) &= l(v) &&\text{for all }v \in H^1_0(\Omega),\tag{2}\label{weak_formulation}
+\end{align}$$
+
+where the bilinear form $a: H^1(\Omega) \times H^1(\Omega) \to \mathbb{R}$ and the linear functional $l \in H^{-1}(\Omega)$ are given by
+
+$$\begin{align}
+a(u, v) := \int_\Omega (\kappa\nabla u)\cdot v \,\text{d}x &&\text{and}&& l(v) := \int_\Omega f\,\,\text{d}x,\tag{3}\label{a_and_l}
+\end{align}$$
+
+respectively.
+
+
+Consider for example $\eqref{pde}$ with:
+
+* $d = 2$
+* $\Omega = [0, 1]^2$
+* $\kappa = 1$
+* $f = \exp(x_0 x_1)$
+
+```{code-cell}
+from dune.xt.grid import Dim
+from dune.xt.functions import ConstantFunction, ExpressionFunction
+
+d = 2
+omega = ([0, 0], [1, 1])
+
+kappa = ConstantFunction(dim_domain=Dim(d), dim_range=Dim(1), value=[1.], name='kappa')
+# note that we need to prescribe the approximation order,
+# which determines the quadrature on each element
+f = ExpressionFunction(
+    dim_domain=Dim(d), variable='x', expression='exp(x[0]*x[1])', order=3, name='f')
+```
+
+### continuous Finite Elements
+
+Let us for simplicity consider a simplicial **grid** $\mathcal{T}_h$ (other types of elements work analogously) as a partition of $\Omega$ into elements $K \in \mathcal{T}_h$ with $h := \max_{K \in \mathcal{T}_h} \text{diam}(K)$, we consider the discrete space of continuous piecewise polynomial functions of order $k \in \mathbb{N}$,
+
+$$\begin{align}
+V_h := \big\{ v \in C^0(\Omega) \;\big|\; v|_K \in \mathbb{P}^k(K) \big\}
+\end{align}$$
+
+where $\mathbb{P}^k(K)$ denotes the space of polynomials of (total) degree up to $k$ (*note that $V_h \subset H^1(\Omega)$ and $V_h$ does not include the Dirichlet boundary condition, thus $V_h \not\subset H^1_0(\Omega$.*). We obtain a finite-dimensional variational problem by Galerkin-projection of $\eqref{weak_formulation}$ onto $V_h$, thas is: we seek the approximate solution $u_h \in V_h \cap H^1_0(\Omega)$, such that
+
+$$\begin{align}
+a(u_h, v_h) &= l(v_h) &&\text{for all }v_h \in V_h \cap H^1_0(\Omega).\tag{4}\label{discrete_variational_problem}
+\end{align}$$
+
+A basis of $V_h$ is given by the Lagrangian basis functions
+
+$$\begin{align}
+\varPhi := \big\{\varphi_1, \dots, \varphi_N\big\}
+\end{align}$$
+
+of order $k$ (e.g., the usual hat-functions for $k = 1$, which we consider from here on), with $N := \text{dim}(V_h)$. As usual, each of these *global* basis functions, if restricted to a grid element, is given by the concatenation of a *local* shape function and the reference map: given
+
+* the invertible affine **reference map** $F_K: \hat{K} \to K$ for all $K \in \mathcal{T}_h$, such that $\hat{x} \mapsto x := F_K(\hat{x})$, where $\hat{K}$ is the reference element associated with $K$,
+* a set of Lagrangian **shape functions** $\{\hat{\varphi}_1, \dots, \hat{\varphi}_{d + 1}\} \in \mathbb{P}^1(K)$, each associated with a vertex $\hat{a}_1, \dots, \hat{a}_{d + 1}$ of the reference element $\hat{K}$ and
+* a **DoF mapping** $\sigma_K: \{1, \dots, d + 1\} \to \{1, \dots, N\}$ for all $K \in \mathcal{T}_h$, which associates the *local* index $\hat{i} \in \{1, \dots, d + 1\}$ of a vertex $\hat{a}_{\hat{i}}$ of the reference element $\hat{K}$ with the *global* index $i \in \{1, \dots, N\}$ of the vertex $a_i := F_K(\hat{a}_\hat{i})$ in the grid $\mathcal{T}_h$.
+
+The DoF mapping as well as a localizable global basis is provided by a **discrete function space** in `dune-gdt`.
+We thus have
+
+$$\begin{align}
+\varphi_i|_K &= \hat{\varphi}_\hat{i}\circ F_K^{-1} &&\text{and}\tag{5}\label{basis_transformation}\\
+(\nabla\varphi_i)|_K &= \nabla\big(\hat{\varphi}_\hat{i}\circ F_K^{-1}\big) = \nabla F_K^{-1} \cdot \big(\nabla\hat{\varphi}_\hat{i}\circ F_K^{-1}\big),\tag{6}\label{basis_transformation_grad}
+\end{align}$$
+
+owing to the chain rule, with $i := \sigma_K(\hat{i})$ for all $1 \leq \hat{i} \leq d+1$ and all $K \in \mathcal{T}_h$.
+
+To obtain the algebraic analogue to $\eqref{discrete_variational_problem}$, we
+
+* replace the bilinear form and functional by discrete counterparts acting on $V_h$, namely $a_h: V_h \times V_h \to \mathbb{R}$ and $l_h \in V_h'$ (the construction of which is detailed further below) and
+
+* assemble the respective basis representations of $a_h$ and $l_h$ w.r.t. the basis of $V_h$ into a matrix $\underline{a_h} \in \mathbb{R}^{N \times N}$ and vector $\underline{l_h} \in \mathbb{R}^N$, given by $(\underline{a_h})_{i, j} := a_h(\varphi_j, \varphi_i)$ and $(\underline{l_h})_i := l_h(\varphi_i)$, respectively, for $1 \leq i, j \leq N$;
+* and obtain the restrictions of $\underline{a_h}$ and $\underline{l_h}$ to $V_h \cap H^1_0(\Omega)$ by modifying all entries associated with basis functions defined on the Dirichlet boundary: for each index $i \in \{1, \dots N\}$, where the Lagrange-point defining the basis function $\varphi_i$ lies on the Dirichlet boundary $\partial\Omega$, we set
+  the $i$th row of $\underline{a_h}$ to a unit row and clear the $i$th entry of $\underline{l_h}$.
+
+
+The algebraic version of $\eqref{discrete_variational_problem}$ then reads: find the vector of degrees of freedom (DoF) $\underline{u_h} \in \mathbb{R}^N$, such that
+
+$$\begin{align}
+\underline{a_h}\;\underline{u_h} = \underline{l_h}.\tag{7}\label{algebraic_problem}
+\end{align}$$
+
+After solving the above linear system, we recover the solution of $\eqref{discrete_variational_problem}$ from its basis representation $u_h = \sum_{i=1}^{N}\underline{u_h}_i \varphi_i$.
+
+
+
+We consider for example a structured simplicial grid with 16 triangles.
+
+```{code-cell}
+from dune.xt.grid import Simplex, make_cube_grid, AllDirichletBoundaryInfo, visualize_grid
+
+grid = make_cube_grid(Dim(d), Simplex(),
+                      lower_left=omega[0], upper_right=omega[1], num_elements=[2, 2])
+grid.global_refine(1)  # we need to refine once to obtain a symmetric grid
+
+print(f'grid has {grid.size(0)} elements, '
+      f'{grid.size(d - 1)} edges and {grid.size(d)} vertices')
+
+boundary_info = AllDirichletBoundaryInfo(grid)
+
+_ = visualize_grid(grid)
+```
+
+```{code-cell}
+from dune.gdt import ContinuousLagrangeSpace
+
+V_h = ContinuousLagrangeSpace(grid, order=1)
+
+print(f'V_h has {V_h.num_DoFs} DoFs')
+
+assert V_h.num_DoFs == grid.size(d)
+```
+
+### approximate functionals
+
+Since the application of the functional to a *global* basis function $\psi_i$ is localizable w.r.t. the grid, e.g.
+
+$$\begin{align}
+l(\psi_i) = \sum_{K \in \mathcal{T}_h} \underbrace{\int_K f \psi_i\,\text{d}x}_{=: l^K(\psi_i)},\tag{8}\label{localized_rhs}
+\end{align}$$
+
+we first consider local functionals (such as $l^K \in L^2(K)'$), where *local* means: *with respect to a grid element $K$*. Using the reference map $F_K$ and $\eqref{basis_transformation}$ from above, we transform the evaluation of $l^K(\psi_i)$ to the reference element,
+
+$$\begin{align}
+l^K(\psi_i) &= \int_K f\psi_i\,\text{d}x = \int_{\hat{K}} |\text{det}\nabla F_K| \underbrace{(f\circ F_K)}_{=: f^K} (\hat{\psi}_\hat{i}\circ F_K^{-1}\circ F_K) \text{d}\hat{x}\\
+&=\int_{\hat{K}} |\text{det}\nabla F_K| f^K \hat{\psi}_\hat{i} \,\text{d}\hat{x},\tag{9}\label{transformed_localized_rhs}
+\end{align}$$
+
+where $f^K: \hat{K} \to \mathbb{R}$ is the *local function* associated with $f$, $i = \sigma_K(\hat{i})$ and $\hat{\psi}_\hat{i}$ is the corresponding shape function.
+
+Note that, apart from the integration domain ($\hat{K}$ instead of $K$) and the transformation factor ($|\text{det}\nabla F^K|$), the structure of the local functional from $\eqref{localized_rhs}$ is reflected in $\eqref{transformed_localized_rhs}$.
+
+This leads us to the definition of a local functional in `dune-gdt`: ignoring the user input (namely the data function $f$ for a moment), a **local functional** is determined by
+
+* an integrand, depending on a single test function, that we can evaluate at points on the reference element.
+  We call such integrands **unary element integrand**s. In the above example, given a test basis function $\hat{\psi}$ and a point in the reference element $\hat{x}$, the integrand is determined by $\Xi^{1, K}_\text{prod}: \mathbb{P}^k(\hat{K}) \times \hat{K} \to \mathbb{R}$, $\hat{\psi}, \hat{x} \mapsto f^K(\hat{x})\,\hat{\psi}(\hat{x})$,
+  which is modelled by `LocalElementProductIntegrand` in `dune-gdt` (see below); and
+* an approximation of the integral in $\eqref{transformed_localized_rhs}$ by a numerical **quadrature**:
+  given any unary element integrand $\Xi^{1, K}$, and $Q \in \mathbb{N}$ quadrature points $\hat{x}_1, \dots, \hat{x}_Q$ and weights $\omega_1, \dots, \omega_Q \in \mathbb{R}$, we approximate
+  $l_h^K(\psi_i) := \sum_{q = 1}^Q |\text{det}\nabla F_K(\hat{x}_q)|\,\omega_q\,\Xi^{1,K}(\hat{\psi}_\hat{i}, \hat{x}_q) \approx \int_\hat{K} \Xi^{1,K}(\hat{\psi}_\hat{i}, \hat{x})\,\text{d}\hat{x} = l^K(\psi_i)$,
+  which is modelled by `LocalElementIntegralFunctional` in `dune-gdt` (see below).
+
+  Note that the order of the quadrature is determined automatically, since the integrand computes its polynomial degree given all data functions and basis functions (in the above example, the polynomial order of $f^K$ is 3 by our construction and the polynomial order of $\hat{\psi}$ is 1, since we are using piecewise linear shape functions, yielding a polynomial order of 4 for $\Xi_\text{prod}^{1,K}$).
+
+Given local functionals, the purpose of the `VectorFunctional` in `dune-gdt` is to assemble $\underline{l_h}$ from $\eqref{algebraic_problem}$ by
+* creating an appropriate vector of length $N$
+* iterating over all grid elements $K \in \mathcal{T}_h$
+* localizing the basis of $V_h$ w.r.t. each grid element $K$
+* evaluating the local functionals $l_h^K$ for each localized basis function
+* adding the results to the respective entry of $\underline{l_h}$, determined by the DoF-mapping of the discrete function space `ContinuousLagrangeSpace`
+
+
+In our example, we define $l_h$ as:
+
+```{code-cell}
+from dune.xt.functions import GridFunction as GF
+
+from dune.gdt import (
+    VectorFunctional,
+    LocalElementProductIntegrand,
+    LocalElementIntegralFunctional,
+)
+
+l_h = VectorFunctional(grid, source_space=V_h)
+l_h += LocalElementIntegralFunctional(
+         LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(GF(grid, f)))
+```
+
+A few notes regarding the above code:
+
+* there exists a large variety of data functions, but in order to all handle them in `dune-gdt` we require them to be localizable w.r.t. a grid (i.e. to have *local functions* as above). This is achieved by wrapping them into a `GridFunction`, which accepts all kind of functions, discrete functions or numbers. Thus `GF(grid, 1)` creates a grid function which is localizable w.r.t. each grid elements and evaluates to 1, whenever evaluated; whereas `GF(grid, f)`, when localized to a grid element $K$ and evaluated at a point on the associated reference element, $\hat{x}$, evaluates to $f(F_K(\hat{x}))$.
+  See also the [tutorial on data functions](dune_gdt_tutorial_on_data_functions_and_interpolation.md).
+
+* the `LocalElementProductIntegrand` is actually a **binary element integrand** modelling a weighted product, as in: with a weight function $w: \Omega \to \mathbb{R}$, given an ansatz function $\hat{\varphi}$, a test function $\hat{\psi}$ and a point $\hat{x} \in \hat{K}$, this integrand is determined by
+  $\Xi_\text{prod}^{2,K}: \mathbb{P}^k(\hat{K}) \times \mathbb{P}^k(\hat{K}) \times \hat{K} \to \mathbb{R}$, $\hat{\varphi}, \hat{\psi}, \hat{x} \mapsto w^K(\hat{x})\,\hat{\varphi}(\hat{x})\,\hat{\psi}(\hat{x})$.
+  Thus, `LocalElementProductIntegrand` is often used in bilinear forms to assemble $L^2$ products (with weight $w =1$), which we achieve by `LocalElementProductIntegrand(GF(grid, 1))`. However, even with $w = 1$, the integrand $\Xi_\text{prod}^{2,K}$ still depends on the test and ansatz function. Using `with_ansatz(GF(grid, f))`, we fix $f^K$ as the ansatz function to obtain exactly the *unary* integrand we require, which only depends on the test function,
+  $\Xi_\text{prod}^{1,K}: \mathbb{P}^k(\hat{K}) \times \hat{K} \to \mathbb{R}$, $\hat{\psi}, \hat{x} \mapsto \Xi_\text{prod}^{2, K}(f^K, \hat{\psi}, \hat{x}) = f^K(\hat{x})\,\hat{\psi}(\hat{x})$,
+  which is exactly what we need to approximate  $l_\text{src}^K(\psi_i) = \int_K f\,\psi_i\text{d}x$.
+
+* the above code creates the vector $\underline{l_h}$ (available as the `vector` attribute of `l_h`) filled with `0`, but does not yet assemble the functional into it, which we can check by:
+
+```{code-cell}
+assert len(l_h.vector) == V_h.num_DoFs
+
+print(l_h.vector.sup_norm())
+```
+
+### approximate bilinear forms
+
+The approximation of the application of the bilinear form $a$ to two *global* basis function $\psi_i, \varphi_j$ follows in a similar manner. We obtain by localization
+
+$$\begin{align}
+a(\psi_i, \varphi_j) &= \int_\Omega (\kappa\nabla \varphi_j)\cdot \nabla\psi_i\,\text{d}x = \sum_{K \in \mathcal{T}_h}\underbrace{\int_K (\kappa\nabla \varphi_j)\cdot \nabla\psi_i\,\text{d}x}_{=:a^K(\psi_i, \varphi_j)}
+\end{align}$$
+
+and by transformation and the chain rule, using $\eqref{basis_transformation_grad}$ and $F_K^{-1}\circ F_K = \text{id}$
+
+$$\begin{align}
+a^K(\psi_i, \varphi_j) &= \int_{\hat{K}} |\text{det}\nabla F_K| \big(\underbrace{(\kappa\circ F_K)}_{=: \kappa^K}\underbrace{(\nabla F_K^{-1}\cdot\nabla\hat{\varphi}_\hat{j})}_{=: \nabla_K\hat{\varphi}_\hat{j}}\big)\cdot\underbrace{(\nabla F_K^{-1}\cdot\nabla\hat{\psi}_\hat{i})}_{=: \nabla_K\hat{\psi}_\hat{i}}\,\text{d}\hat{x}\\
+&= \int_{\hat{K}} |\text{det}\nabla F_K| \big(\kappa^K \nabla_K\hat{\varphi}_\hat{j}\big)\cdot\nabla_K\hat{\psi}_\hat{i}\,\text{d}\hat{x},
+\end{align}$$
+
+where $\kappa^K$ denote the *local function* of $\kappa$ as above, and where $\nabla_K\hat{\varphi}_\hat{j}$ denote suitably transformed *global* gradients of the *local* shape functions, for the integrand to reflect the same structure as above.
+
+Similar to local functionals, a **local bilinear form** is determined
+
+* by a **binary element integrand**, in our case the `LocalLaplaceIntegrand` (see below)
+  $$\begin{align}
+  \Xi_\text{laplace}^{2, K}: \mathbb{P}^k(\hat{K}) \times \mathbb{P}^k(\hat{K}) \times \hat{K} &\to \mathbb{R}\\
+  \hat{\varphi}, \hat{\xi}, \hat{x} &\mapsto \big(\kappa^K(\hat{x})\,\nabla_K\hat{\varphi}(\hat{x})\big)\cdot\nabla_K\hat{\psi}(\hat{x})
+  \end{align}$$
+  and
+* an approximation of the integral by a numerical **quadrature**: given any binary element integrand $\Xi^{2, K}$, and $Q \in \mathbb{N}$ quadrature points $\hat{x}_1, \dots, \hat{x}_Q$ and weights $\omega_1, \dots, \omega_Q \in \mathbb{R}$, we approximate
+  $\begin{align}
+  a_h^K(\psi_i, \varphi_j) := \sum_{q = 1}^Q |\text{det}\nabla F_K(\hat{x}_q)|\,\omega_q\,\Xi^{2,K}(\hat{\psi}_\hat{i}, \hat{\varphi}_\hat{j}, \hat{x}_q) \approx \int_\hat{K} \Xi^{2,K}(\hat{\psi}_\hat{i}, \hat{\varphi}_\hat{j}, \hat{x})\,\text{d}\hat{x} = a^K(\psi_i, \varphi_i),
+  \end{align}$
+  which is modelled by `LocalElementIntegralBilinearForm` in `dune-gdt` (see below).
+
+Given local bilinear forms, the purpose of the `MatrixOperator` in `dune-gdt` is to assemble $\underline{a_h}$ from $\eqref{algebraic_problem}$ by
+* creating an appropriate (sparse) matrix of size $N \times N$
+* iterating over all grid elements $K \in \mathcal{T}_h$
+* localizing the basis of $V_h$ w.r.t. each grid element $K$
+* evaluating the local bilinear form $a_h^K$ for each combination localized ansatz and test basis functions
+* adding the results to the respective entry of $\underline{a_h}$, determined by the DoF-mapping of the discrete function space `ContinuousLagrangeSpace`
+
+```{code-cell}
+from dune.gdt import (
+    MatrixOperator,
+    make_element_sparsity_pattern,
+    LocalLaplaceIntegrand,
+    LocalElementIntegralBilinearForm,
+)
+
+a_h = MatrixOperator(grid, source_space=V_h, range_space=V_h,
+                     sparsity_pattern=make_element_sparsity_pattern(V_h))
+a_h += LocalElementIntegralBilinearForm(
+        LocalLaplaceIntegrand(GF(grid, kappa, dim_range=(Dim(d), Dim(d)))))
+```
+
+A few notes regarding the above code:
+
+* the `LocalLaplaceIntegrand` expects a matrix-valued function, which we achieve by converting the scalar function `kappa` to a matrix-valued `GridFunction`
+
+* the above code creates the matrix $\underline{a_h}$ (available as the `matrix` attribute of `a_h`) with sparse `0` entries, but does not yet assemble the bilinear form into it, which we can check by:
+
+```{code-cell}
+assert a_h.matrix.rows == a_h.matrix.cols == V_h.num_DoFs
+
+print(a_h.matrix.sup_norm())
+```
+
+### handling the Dirichlet boundary condition
+
+As noted above, we handle the Dirichlet boundary condition on the algebraic level by modifying the assembled matrices and vector.
+We therefore require a means to identify all DoFs of $V_h$ associated with the Dirichlet boundary modelled by `boundary_info`.
+
+```{code-cell}
+from dune.gdt import DirichletConstraints
+
+dirichlet_constraints = DirichletConstraints(boundary_info, V_h)
+```
+
+Similar to the bilinear forms and functionals above, the `dirichlet_constraints` are not yet assembled, which we can check as follows:
+
+```{code-cell}
+print(dirichlet_constraints.dirichlet_DoFs)
+```
+
+### walking the grid
+
+Until now, we constructed a bilinear form `a_h`, a linear functional `l_h` and Dirichlet constrinaints `dirichlet_constraints`, which are all localizable w.r.t. the grid, that is: i order to compute their application or to assemble them, it is sufficient to apply them to each element of the grid.
+
+Internally, this is realized by means of the `Walker` from `dune-xt-grid`, which allows to register all kinds of *grid functors* which are applied locally on each element. All bilinear forms, operators and functionals (as well as other constructs such as the Dirichlet constraints) in `dune-gdt` are implemented as such functors.
+
+Thus, we may assemble everything in one grid walk:
+
+```{code-cell}
+from dune.xt.grid import Walker
+
+walker = Walker(grid)
+walker.append(a_h)
+walker.append(l_h)
+walker.append(dirichlet_constraints)
+walker.walk()
+```
+
+We can check that the assembled bilinear form and functional as well as the Dirichlet constraints actually contain some data:
+
+```{code-cell}
+print(f'a_h = {a_h.matrix.__repr__()}')
+print()
+print(f'l_h = {l_h.vector.__repr__()}')
+print()
+print(f'Dirichlet DoFs: {dirichlet_constraints.dirichlet_DoFs}')
+```
+
+### solving the linear system
+
+After walking the grid, the bilinra form and linear functional are assembled w.r.t. $V_h$ and we constrain them to include the handling of the Dirichlet boundary condition.
+
+```{code-cell}
+dirichlet_constraints.apply(a_h.matrix, l_h.vector)
+```
+
+Since the bilinear form is implemented as a `MatrixOperator`, we may simply invert the operator to obtain the DoF vector of the solution of $\eqref{discrete_variational_problem}$.
+
+```{code-cell}
+u_h_vector = a_h.apply_inverse(l_h.vector)
+```
+
+### postprocessing the solution
+
+To make use of the DoF vector of the approximate solution, $\underline{u_h} \in \mathbb{R}^N$, it is convenient to interpert it as a discrete function again, $u_h \in V_h$ by means of the Galerkin isomorphism. This can be achieved by the `DiscreteFunction` in `dune-gdt`.
+
+All discrete functions are in particular grid functions and can thus be compared to analytical solutions, used as input in discretization schemes or visualized.
+
+**Note:** if visualization fails for some reason, call `paraview` on the command line and open `u_h.vtu`!
+
+```{code-cell}
+from dune.gdt import DiscreteFunction, visualize_function
+
+u_h = DiscreteFunction(V_h, u_h_vector, name='u_h')
+_ = visualize_function(u_h)
+```
+
+### everything in a single function
+
+For a better overview, the above discretization code is also available in a single function in the file `discretize_elliptic_cg.py`:
+
+```{code-cell}
+import inspect
+from discretize_elliptic_cg import discretize_elliptic_cg_dirichlet_zero
+
+print(inspect.getsource(discretize_elliptic_cg_dirichlet_zero))
+```
+
+Calling it gives the same solution as above:
+
+```{code-cell}
+u_h = discretize_elliptic_cg_dirichlet_zero(grid, kappa, f)
+_ = visualize_function(u_h)
+```
+
+## diffusion with non-homogeneous Dirichlet boundary condition
+
+### analytical problem
+
+Consider problem $\eqref{pde}$ from above, but with non-homogeneous Dirichlet boundary values. That is:
+
+
+Let $\Omega \subset \mathbb{R}^d$ for $1 \leq d \leq 3$ be a bounded connected domain with Lipschitz-boundary $\partial\Omega$. We seek the solution $u \in H^1(\Omega)$ of the linear diffusion equation (with a **non-homogeneous Dirichlet boundary condition**)
+
+$$\begin{align}
+- \nabla\cdot(\kappa\nabla u) &= f &&\text{in } \Omega,\tag{10}\label{inhomogeneous_pde}\\
+u &= g_\text{D} &&\text{on } \partial\Omega,
+\end{align}$$
+
+in a weak sense, where $\kappa \in [L^\infty(\Omega)]^{d \times d}$ denotes a given diffusion function, $f \in L^2(\Omega)$ denotes a given source function and $g_\text{D} \in L^2(\partial\Omega)$ denotes given Dirichlet boundary values.
+
+The variational problem associated with $\eqref{inhomogeneous_pde}$ reads: find $u \in H^1(\Omega)$, such that
+
+$$\begin{align}
+a(u, v) &= l(v) &&\text{for all }v \in H^1_0(\Omega),\tag{11}\label{inhomogeneous_weak_formulation}
+\end{align}$$
+
+with the same bilinear form $a$ and linear functional $l$ as above in $\eqref{a_and_l}$.
+<!-- #endregion -->
+
+### Dirichlet shift
+
+Suppose $\hat{g}_\text{D} \in H^1(\Omega)$ is an extension of the Dirichlet boundary values to $\Omega$, such that
+
+$$\begin{align}
+\hat{g}_\text{D}|_{\partial\Omega} = g_\text{D}
+\end{align}$$
+
+in the sense of traces. We then have for the solution $u \in H^1(\Omega)$ of $\eqref{inhomogeneous_weak_formulation}$, that
+
+$$\begin{align}
+u = u_0 + \hat{g}_\text{D}
+\end{align}$$
+
+for some $u_0 \in H^1_0(\Omega)$. Thus, we may reformulate $\eqref{inhomogeneous_weak_formulation}$ as follows: Find $u_0 \in H^1_0(\Omega)$, such that
+
+$$\begin{align}
+a(u_0 + \hat{g}_\text{D}, v) &= l(v) &&\text{for all }v \in H^1_0(\Omega),
+\end{align}$$
+
+or equivalently
+
+$$\begin{align}
+a(u_0, v) &= l(v) - a(\hat{g}_\text{D}, v) &&\text{for all }v \in H^1_0(\Omega).
+\end{align}$$
+
+We have thus shifted problem $\eqref{inhomogeneous_weak_formulation}$ to be of familiar form, i.e., similarly to above we consider a linear diffusion equation with **homogeneous** Dirichlet boundary conditions, but a **modified source** term.
+
+
+Consider for example $\eqref{pde}$ with:
+
+* $d = 2$
+* $\Omega = [0, 1]^2$
+* $\kappa = 1$
+* $f = \exp(x_0 x_1)$
+* $g_\text{D} = x_0 x_1$
+
+Except for $g_\text{D}$, we may thus use the same grid, boundary info and data functions as above.
+
+
+### Dirichlet interpolation
+
+To obtain $\hat{g}_\text{D} \in H^1(\Omega)$, we use the Lagrange interpolation of $g_\text{D}$ and set all DoFs associated with inner Lagrange nodes to zero. This is realized by the `boundary_interpolation`.
+
+```{code-cell}
+from dune.xt.grid import DirichletBoundary
+from dune.gdt import boundary_interpolation
+
+g_D = ExpressionFunction(dim_domain=Dim(d),
+                         variable='x', expression='x[0]*x[1]', order=2, name='g_D')
+
+g_D_hat = boundary_interpolation(GF(grid, g_D), V_h, boundary_info, DirichletBoundary())
+
+_ = visualize_function(g_D_hat)
+```
+
+As we observe, the values on all boundary DoFs are $x_0 x_1$ and on all inner DoFs $0$.
+
+
+### assembling the shifted system
+
+* We assemble the unconstrained matrix- and vector representation of $a_h$ and $l_h$ w.r.t. $V_h$ similarly as above.
+
+```{code-cell}
+l_h = VectorFunctional(grid, source_space=V_h)
+l_h += LocalElementIntegralFunctional(
+        LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(GF(grid, f)))
+
+a_h = MatrixOperator(grid, source_space=V_h, range_space=V_h,
+                     sparsity_pattern=make_element_sparsity_pattern(V_h))
+a_h += LocalElementIntegralBilinearForm(
+        LocalLaplaceIntegrand(GF(grid, kappa, dim_range=(Dim(d), Dim(d)))))
+
+walker = Walker(grid)
+walker.append(a_h)
+walker.append(l_h)
+walker.walk()
+```
+
+* We then obtain the shifted system by directly modifying the right hand side vector.
+
+```{code-cell}
+rhs_vector = l_h.vector - a_h.matrix@g_D_hat.dofs.vector
+```
+
+* *Afterwards*, we constrain the shifted system to $V_h \cap H^1_0(\Omega)$.
+
+```{code-cell}
+dirichlet_constraints.apply(a_h.matrix, rhs_vector)
+```
+
+* Then, we solve the shifted and constrained system for the DoF vector of $u_{0, h}$.
+
+```{code-cell}
+u_0_h_vector = a_h.apply_inverse(rhs_vector)
+```
+
+* We may then obtain the solution by shifting it back.
+
+```{code-cell}
+u_h = DiscreteFunction(V_h, u_0_h_vector + g_D_hat.dofs.vector)
+
+_ = visualize_function(u_h)
+```
+
+### everything in a single function
+
+As above, solving with non-homogeneous Dirichlet values is also available in a single function.
+
+```{code-cell}
+from discretize_elliptic_cg import discretize_elliptic_cg_dirichlet
+
+u_h = discretize_elliptic_cg_dirichlet(grid, kappa, f, g_D)
+
+_ = visualize_function(u_h)
+```
+
+Download the code:
+{download}`dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md`
+{nb-download}`dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.ipynb`

--- a/tutorials/source/dune_gdt_tutorial_on_data_functions_and_interpolation.md
+++ b/tutorials/source/dune_gdt_tutorial_on_data_functions_and_interpolation.md
@@ -1,0 +1,362 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Tutorial: data functions and interpolation
+
+This is work in progress, still missing:
+
+* visualization in 1d
+* visualization in 3d?
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+#%load_ext wurlitzer
+
+
+import numpy as np
+
+```
+
+## creating functions
+
+We'll work mostly in 2d in this tutorial since scalar functions in 2d can be best visualized within the notebook.
+Let's set up a 2d grid first, as seen in other tutorials and examples.
+
+```{code-cell}
+from dune.xt.grid import Dim, Cube, Simplex, make_cube_grid
+from dune.xt.functions import ConstantFunction, ExpressionFunction, GridFunction as GF
+
+d = 2
+omega = ([0, 0], [1, 1])
+grid = make_cube_grid(Dim(d), Simplex(),
+                      lower_left=omega[0], upper_right=omega[1], num_elements=[1, 1])
+
+print(f'grid has {grid.size(0)} elements, '
+      f'{grid.size(d - 1)} edges and {grid.size(d)} vertices')
+```
+
+Some examples of data functions include analytical functions, such as
+
+$$\begin{align}
+f: \mathbb{R}^2 &\to \mathbb{R} && &g: \mathbb{R}^2 &\to \mathbb{R}^{2\times 2}\\
+x &\mapsto \alpha&& &x&\mapsto A
+\end{align}$$
+
+for a given number $\alpha \in \mathbb{R}$ and matrix $A \in \mathbb{R}^{2 \times 2}$, or
+
+$$\begin{align}
+h: \mathbb{R}^2 &\to \mathbb{R}\\
+x &\mapsto \text{epx}(x_0\, x_1)
+\end{align}$$
+
+or discrete functions $v_h \in V_h$, where $V_h$ is some finite-dimensional discrete function space associated with a grid. Other examples include functions obtained by reading values from a file.
+
+Let's create some of these functions.
+
+
+### using the `ConstantFunction`
+
+For constant functions.
+
+```{code-cell}
+from dune.xt.functions import ConstantFunction
+
+alpha = 0.5
+f = ConstantFunction(dim_domain=Dim(d), dim_range=Dim(1), value=[alpha], name='f')
+# note that we have to provide [alpha],
+# since scalar constant functions expect a vector of length 1
+
+A = [[1, 0], [0, 1]]
+g = ConstantFunction(dim_domain=Dim(d), dim_range=(Dim(d), Dim(d)), value=A, name='g')
+```
+
+### using the `ExpressionFunction`
+
+For functions given by an expression, where we have to specify the polynomial order of the expression (or the approximation order for non-polynomial functions).
+
+Note that if the name of the variable is `Foo`, the components `Foo[0]`, ... `Foo[d - 1]` are available to be used in the expression.
+
+*  We have functions which do not provide a gradient ...
+
+```{code-cell}
+from dune.xt.functions import ExpressionFunction
+
+h = ExpressionFunction(
+        dim_domain=Dim(d), variable='x', order=10, expression='exp(x[0]*x[1])', name='h')
+```
+
+* ... and functions which provide a gradient, useful for analytical solutions to compare to and compute $H^1$ errors
+
+```{code-cell}
+h = ExpressionFunction(
+        dim_domain=Dim(d), variable='x', order=10, expression='exp(x[0]*x[1])',
+        gradient_expressions=['x[1]*exp(x[0]*x[1])', 'x[0]*exp(x[0]*x[1])'], name='h')
+```
+
+### discrete functions
+
+These often result from a discretization scheme, see the [tutorial on continuous Finite Elements for the stationary heat equation](dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md).
+
+```{code-cell}
+from dune.gdt import DiscontinuousLagrangeSpace, DiscreteFunction
+
+V_h = DiscontinuousLagrangeSpace(grid, order=1)
+v_h = DiscreteFunction(V_h, name='v_h')  # initialized with a zero DoF vector
+
+print(v_h.dofs.vector.sup_norm())
+```
+
+## visualizing functions
+
+### visualizing scalar functions in 2d
+
+We can easily visualize functions mapping from $\mathbb{R}^2 \to \mathbb{R}$. Internally, this is achieved by writing a `.vtk` file to disk and displaying the file using [K3D](https://github.com/K3D-tools/K3D-jupyter).
+
+```{code-cell}
+from dune.xt.functions import visualize_function
+
+_ = visualize_function(h, grid)
+```
+
+**Note**: since functions are always visualized as piecewise linears on each grid element, `dune-grid` supports to write functions on a virtually refined grid, which may be an improvement for higher order data functions. To see this, let us have a look at the rather coarse grid consisting of two simplices:
+
+```{code-cell}
+from dune.xt.grid import visualize_grid
+
+_ = visualize_grid(grid)
+```
+
+The two grid elements are clearly visible in the above plot of $h$.
+By enabling subsampling, we obtain a much smoother plot, where the underlying virtually refined grid is barely visible.
+
+```{code-cell}
+_ = visualize_function(h, grid, subsampling=True)
+```
+
+Subsampling may thus be a means to obtain pretty pictures, but it can also be misleading.
+
+
+### visualizing functions in other dimensions
+
+Functions mapping from and to other dimensions can still be written to disk to be viewed with external viewers such as [Paraview](https://www.paraview.org/).
+Therefore, they need to be wrapped as a `GridFunction`, as explained in the next section.
+
+
+## The `GridFunction`
+
+No matter the type of data function, we want to be able to use all of these in a discretization scheme without changing the discretization code (e.g., we should be able to pass them all to one of the `discretize_...` functions in `discretize_elliptic_cg.py`).
+As explained in [the tutorial on continuous Finite Elements for the stationary heat equation](dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md), these functions thus need to be localizable w.r.t. a grid.
+While the discrete function $v_h$ is already associated with a grid (namely the `grid` used to create `V_h`), the analytical functions $f$, $g$ and $h$ are not, which poses some problems when writing generic discretization schemes.
+
+Exactly for this purpose, `dune.xt.functions` contains a `GridFunction`, which is a quite powerful means to wrap all kinds of things into a function associated with a grid.
+
+For instance, we can wrap any existing function.
+
+```{code-cell}
+from dune.xt.functions import GridFunction
+
+f_grid = GridFunction(grid, f)
+g_grid = GridFunction(grid, g)
+h_grid = GridFunction(grid, h)
+```
+
+In addition, the `GridFunction` directly supports the creation of constant functions.
+
+```{code-cell}
+f_grid = GridFunction(grid, alpha, name='f')
+g_grid = GridFunction(grid, A, name='g')
+```
+
+Another powerful means to obtain a function is to pass a lambda expression, the first argument of which (`x`) is the point in physical space to evaluate at.
+
+```{code-cell}
+h_grid_lambda = GF(grid,
+                   order=10, evaluate_lambda=lambda x, _: [np.exp(x[0]*x[1])],
+                   dim_range=Dim(1), name='h')
+```
+
+**Note** that using a Python lambda might not yield be the most efficient code, but it is a great way to quickly implement data functions.
+
+
+### visualizing grid functions in all dimension
+
+To continue the visualization example from above, we can also write any grid function or discrete function to disk.
+
+```{code-cell}
+f_grid.visualize(grid, 'f') # writes f.vtu
+```
+
+```{code-cell}
+!ls -l f.vtu
+```
+
+Note that the grid function `f_grid` is associated with the *type* of the grid `grid`, but not with the actual object `grid`.
+The function can thus be localized w.r.t. all grids of the same type as `grid`.
+For visualization, for instance, we still need to pass an actual `grid` object with respect to which the visualization is to be carried out.
+
+The discrete function, on the other hand, is defined w.r.t. an actual grid object (namely the one used to construct the corresponding discrete function space `V_h`).
+
+```{code-cell}
+v_h.visualize('v_h') # writes v_h.vtu
+```
+
+```{code-cell}
+!ls -l v_h.vtu
+```
+
+## interpolation
+
+It is often desirable to interpolate data functions in a given discrete function space.
+
+
+### using `dune-gdt`s interpolation
+
+For most discrete function space, the `default_interpolation` will do the right thing, e.g. perform an $L^2$- or Lagrange-Interpolation. There are more specialized interpolations for special cases, e.g. for Raviart-Thomas spaces.
+
+```{code-cell}
+from dune.gdt import (
+    default_interpolation,
+    visualize_function,  # can also visualize discrete functions
+)
+
+h_h = default_interpolation(h_grid, V_h)
+_ = visualize_function(h_h, subsampling=False)
+```
+
+### using vectorized Python code
+
+For Lagrangian discrete function spaces the interpolation can be performed by point evaluation.
+We can extract the correct Lagrange-points from the discrete function space and wrap them into a `numpy`-array (without copying them). We can then perform the usual vectorized `numpy` operations and store the result in the DoF-vector of a discrete function (by again wrapping the vector without a copy into a `numpy`-array).
+
+```{code-cell}
+interpolation_points = np.array(V_h.interpolation_points(), copy=False)
+
+h_h_numpy = DiscreteFunction(V_h)
+h_h_numpy_vec = np.array(h_h_numpy.dofs.vector, copy=False)
+h_h_numpy_vec[:] = np.exp(interpolation_points[..., 0]*interpolation_points[..., 1])
+
+_ = visualize_function(h_h_numpy)
+```
+
+## performance considerations
+
+The way a function is constructed may have a large impact on its performance. Let us consider the function $h(x) = exp(x_0\,x_1)$ from above.
+We should use a finer grid to obtain some representative timings.
+
+**Note**: by choosing a `Simplex` grid, we obtain an instance of an unstructured `dune-alugrid` grid, which may be runtime efficient, but at the cost of a higher memory footprint.
+Choosing a `Cube` grid, on the other hand, would give us an instance of `dune-grid`s structured `YaspGrid` with nearly no memory footprint, at the price of lower runtime performance.
+
+```{code-cell}
+from timeit import default_timer as timer
+
+tic = timer()
+grid = make_cube_grid(Dim(d), Simplex(),
+                      lower_left=omega[0], upper_right=omega[1], num_elements=[512, 512])
+grid.global_refine(1)
+toc = timer() - tic
+
+print(f'grid has {grid.size(0)} elements, '
+      f'{grid.size(d - 1)} edges and {grid.size(d)} vertices (took {toc}s)')
+```
+
+```{code-cell}
+tic = timer()
+V_h = DiscontinuousLagrangeSpace(grid, order=3)
+toc = timer() - tic
+
+print(f'space has {V_h.num_DoFs} DoFs (took {toc}s)')
+```
+
+### interpolation test
+
+One measure of performance is the time it takes to interpolate a data function. Note that the comparison greatly depends on the grid and the polynomial order of `V_h`.
+
+```{code-cell}
+tic = timer()
+
+h_dune_expression = GridFunction(
+    grid,
+    ExpressionFunction(dim_domain=Dim(d), variable='x', order=10,
+                       expression='exp(x[0]*x[1])'))
+
+h_dune_expression_h = default_interpolation(h_dune_expression, V_h)
+
+t_dune = timer() - tic
+print(f'interpolating h_dune_expression took {t_dune}s')
+```
+
+```{code-cell}
+tic = timer()
+
+h_python_lambda = GF(grid,
+                     order=10, evaluate_lambda=lambda x, _: [np.exp(x[0]*x[1])],
+                     dim_range=Dim(1), name='h')
+
+h_python_lambda_h = default_interpolation(h_python_lambda, V_h)
+
+t_python = timer() - tic
+print(f'interpolating h_python_lambda took {t_python}s')
+```
+
+```{code-cell}
+print(f'using a lambda expression in an interpolation test is {t_python/t_dune} times slower')
+```
+
+### discretization test
+
+For a more realistic comparison, we use the `discretize_elliptic_cg_dirichlet_zero` function as explained in the [tutorial on continuous Finite Elements for the stationary heat equation](dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md).
+
+```{code-cell}
+from discretize_elliptic_cg import discretize_elliptic_cg_dirichlet_zero
+
+tic = timer()
+
+u_h_dune = discretize_elliptic_cg_dirichlet_zero(grid, h_dune_expression, 1)
+
+t_dune = timer() - tic
+print(f'discretizing using h_dune_expression took {t_dune}s')
+```
+
+```{code-cell}
+tic = timer()
+
+u_h_dune = discretize_elliptic_cg_dirichlet_zero(grid, h_python_lambda, 1)
+
+t_python = timer() - tic
+print(f'discretizing using h_python_lambda took {t_python}s')
+```
+
+```{code-cell}
+print(f'using a lambda expression in a discretization test is {t_python/t_dune} times slower')
+```
+
+This test is more realistic than the pure interpolation one. Since evaluating the diffusion is only a small part of the overall computation, the performance loss using the Python lambda is much smaller.
+Overall, the gain in flexibility outweighs the loss in performance (at least for quick tests).
+
+Download the code:
+{download}`dune_gdt_tutorial_on_data_functions_and_interpolation.md`
+{nb-download}`dune_gdt_tutorial_on_data_functions_and_interpolation.ipynb`

--- a/tutorials/source/example__ESV2007_estimates.md
+++ b/tutorials/source/example__ESV2007_estimates.md
@@ -1,0 +1,189 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: a posteriori error estimates based on flux reconstruction
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+
+import numpy as np
+
+```
+
+```{code-cell}
+from dune.xt.grid import Dim, Simplex, make_cube_grid, AllDirichletBoundaryInfo, visualize_grid
+
+d = 2
+grid = make_cube_grid(Dim(d), Simplex(), [-1, -1], [1, 1], [4, 4])
+grid.global_refine(2)
+
+print(f'grid has {grid.size(0)} elements, {grid.size(d - 1)} edges and {grid.size(d)} vertices')
+
+boundary_info = AllDirichletBoundaryInfo(grid)
+```
+
+```{code-cell}
+from dune.xt.functions import ExpressionFunction, GridFunction as GF
+
+diffusion = GF(grid, 1., dim_range=(Dim(d), Dim(d)), name='diffusion')
+source = GF(grid, ExpressionFunction(
+    dim_domain=Dim(d), variable='x',
+    expression='0.5*pi*pi*cos(0.5*pi*x[0])*cos(0.5*pi*x[1])', order=4, name='source'))
+```
+
+```{code-cell}
+from dune.xt.grid import (
+    ApplyOnCustomBoundaryIntersections,
+    ApplyOnInnerIntersectionsOnce,
+    DirichletBoundary,
+    Walker,
+)
+
+from dune.gdt import (
+    DiscontinuousLagrangeSpace,
+    DiscreteFunction,
+    LocalElementIntegralBilinearForm,
+    LocalElementIntegralFunctional,
+    LocalElementProductIntegrand,
+    LocalCouplingIntersectionIntegralBilinearForm,
+    LocalIPDGBoundaryPenaltyIntegrand,
+    LocalIPDGInnerPenaltyIntegrand,
+    LocalIntersectionIntegralBilinearForm,
+    LocalLaplaceIntegrand,
+    LocalLaplaceIPDGDirichletCouplingIntegrand,
+    LocalLaplaceIPDGInnerCouplingIntegrand,
+    MatrixOperator,
+    VectorFunctional,
+    estimate_combined_inverse_trace_inequality_constant,
+    estimate_element_to_intersection_equivalence_constant,
+    make_element_and_intersection_sparsity_pattern,
+)
+
+V_h = DiscontinuousLagrangeSpace(grid, order=1)
+```
+
+```{code-cell}
+weight = diffusion
+penalty_parameter = 16
+symmetry_factor = 1
+
+l_h = VectorFunctional(grid, V_h)
+l_h += LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source))
+
+a_h = MatrixOperator(grid, V_h, V_h, make_element_and_intersection_sparsity_pattern(V_h))
+a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+a_h += (LocalCouplingIntersectionIntegralBilinearForm(
+            LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
+            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)),
+        {}, ApplyOnInnerIntersectionsOnce(grid))
+a_h += (LocalIntersectionIntegralBilinearForm(
+            LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
+            + LocalLaplaceIPDGDirichletCouplingIntegrand(symmetry_factor, diffusion)),
+       {}, ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()))
+
+walker = Walker(grid)
+walker.append(a_h)
+walker.append(l_h)
+walker.walk()
+```
+
+```{code-cell}
+from dune.gdt import visualize_function
+
+u_h = DiscreteFunction(V_h, 'u_h')
+
+a_h.apply_inverse(l_h.vector, u_h.dofs.vector)
+
+_ = visualize_function(u_h)
+```
+
+```{code-cell}
+from dune.gdt import oswald_interpolation
+
+s_h = oswald_interpolation(u_h, V_h)
+
+_ = visualize_function(u_h - s_h, grid)
+```
+
+```{code-cell}
+from dune.gdt import LaplaceIpdgFluxReconstructionOperator, RaviartThomasSpace
+
+RT_0 = RaviartThomasSpace(grid, order=0)
+
+flux_reconstruction = LaplaceIpdgFluxReconstructionOperator(
+    grid, V_h, RT_0, symmetry_factor, penalty_parameter, penalty_parameter, diffusion, weight)
+flux_reconstruction.assemble()
+
+t_h = DiscreteFunction(RT_0, 't_h')
+flux_reconstruction.apply(u_h.dofs.vector, t_h.dofs.vector)
+```
+
+```{code-cell}
+from dune.gdt import FiniteVolumeSpace, Operator, LocalElementBilinearFormIndicatorOperator
+
+fv_space = FiniteVolumeSpace(grid)
+
+eta_nc_op = Operator(grid, V_h, fv_space)
+eta_nc_op += LocalElementBilinearFormIndicatorOperator(
+    LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(weight)))
+eta_nc_2 = eta_nc_op.apply(u_h - s_h)
+_ = visualize_function(eta_nc_2)
+print(np.sqrt(eta_nc_2.dofs.vector.l1_norm()))
+```
+
+```{code-cell}
+from dune.xt.functions import divergence, ElementwiseMinimumFunction, ElementwiseDiameterFunction, inverse
+
+h = ElementwiseDiameterFunction(grid)
+min_EV = ElementwiseMinimumFunction(diffusion, search_quadrature_order=0) # we know diffusion is constant
+C_P = GF(grid, 1/np.pi**2) # known for simplices
+
+eta_r_op = Operator(grid, V_h, fv_space)
+eta_r_op += LocalElementBilinearFormIndicatorOperator(
+    LocalElementIntegralBilinearForm(LocalElementProductIntegrand((C_P*h*h)/min_EV)))
+eta_r_2 = eta_r_op.apply(source - divergence(t_h))
+print(np.sqrt(eta_r_2.dofs.vector.l1_norm()))
+_ = visualize_function(eta_r_2)
+```
+
+```{code-cell}
+from dune.xt.functions import gradient
+
+eta_df_op = Operator(grid, RT_0, fv_space)
+eta_df_op += LocalElementBilinearFormIndicatorOperator(
+    LocalElementIntegralBilinearForm(LocalElementProductIntegrand(inverse(diffusion, order=0))))
+eta_df_2 = eta_df_op.apply(diffusion*gradient(u_h) + t_h)
+print(eta_df_2.dofs.vector.l1_norm())
+_ = visualize_function(eta_df_2)
+```
+
+
+Download the code:
+{download}`example__ESV2007_estimates.md`
+{nb-download}`example__ESV2007_estimates.ipynb`

--- a/tutorials/source/example__MNS2002_estimates.md
+++ b/tutorials/source/example__MNS2002_estimates.md
@@ -1,0 +1,330 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: residual-based a posteriori error estimates
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+
+import numpy as np
+
+```
+
+## 1: inspect grid properties and relations between elements and intersections
+
+```{code-cell}
+from dune.xt.grid import Dim, Simplex, make_cube_grid, AllDirichletBoundaryInfo, visualize_grid
+
+d = 2
+grid = make_cube_grid(Dim(d), Simplex(), [-1, -1], [1, 1], [1, 1])
+grid.global_refine(1)
+
+print(f'grid has {grid.size(0)} elements, {grid.size(d - 1)} edges and {grid.size(d)} vertices')
+
+boundary_info = AllDirichletBoundaryInfo(grid)
+
+_ = visualize_grid(grid)
+```
+
+```{code-cell}
+intersection_centers = np.array(grid.centers(1), copy=False)
+
+inner_intersections = np.array(grid.inner_intersection_indices(), copy=False)
+print(f'grid has {len(inner_intersections)} inner intersections')
+print(f'  with indices {inner_intersections}')
+print(f'  and centers:')
+print(intersection_centers[inner_intersections])
+```
+
+```{code-cell}
+from dune.xt.grid import ApplyOnCustomBoundaryIntersections, DirichletBoundary
+
+dirichlet_intersections = np.array(
+    grid.boundary_intersection_indices(intersection_filter=
+        ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary())), copy=False)
+print(f'grid has {len(dirichlet_intersections)} Dirichlet intersections')
+print(f'  with indices {dirichlet_intersections}')
+print(f'  and centers:')
+print(intersection_centers[dirichlet_intersections])
+```
+
+```{code-cell}
+element_centers = np.array(grid.centers(0), copy=False)
+
+inner_element_indices = np.array(grid.inside_element_indices(), copy=False)
+print(f'index of each intersections inside element: {inner_element_indices}')
+print('this means that')
+for intersection_index, element_index in enumerate(inner_element_indices):
+    print(f'  intersection {intersection_index} with center {intersection_centers[intersection_index]}')
+    print(f'    has inside element {element_index} with center {element_centers[element_index]}')
+```
+
+```{code-cell}
+outside_element_indices = np.array(grid.outside_element_indices(), copy=False)
+print(f'index of each intersections outside element: {outside_element_indices}')
+```
+
+The large numbers are invalid indices and represent intersections which do not have an outside element, e.g. boundary intersections. We should thus restrict the lookup to inner intersections:
+
+```{code-cell}
+print(f'index of each inner intersections outside element: {outside_element_indices[inner_intersections]}')
+print('this means that')
+for intersection_index, element_index in enumerate(outside_element_indices[inner_intersections]):
+    print(f'  (inner) intersection {intersection_index} with center {intersection_centers[intersection_index]}')
+    print(f'    has outside element {element_index} with center {element_centers[element_index]}')
+```
+
+## 2: solving an elliptic PDE
+
+```{code-cell}
+from dune.xt.functions import ExpressionFunction, GridFunction as GF
+
+A = GF(grid, 1., dim_range=(Dim(d), Dim(d)), name='A')
+f = GF(grid,
+       ExpressionFunction(dim_domain=Dim(d), variable='x', expression='exp(x[0]*x[1])', order=7, name='f'))
+```
+
+```{code-cell}
+from dune.xt.grid import AllDirichletBoundaryInfo, Dim, Walker
+
+from dune.gdt import (
+    ContinuousLagrangeSpace,
+    DirichletConstraints,
+    DiscreteFunction,
+    LocalElementIntegralBilinearForm,
+    LocalElementIntegralFunctional,
+    LocalElementProductIntegrand,
+    LocalLaplaceIntegrand,
+    MatrixOperator,
+    VectorFunctional,
+    make_element_sparsity_pattern,
+)
+
+V_h = ContinuousLagrangeSpace(grid, order=1)
+```
+
+```{code-cell}
+l_h = VectorFunctional(grid, source_space=V_h)
+l_h += LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(f))
+
+a_h = MatrixOperator(grid, source_space=V_h, range_space=V_h,
+                     sparsity_pattern=make_element_sparsity_pattern(V_h))
+a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(A))
+
+dirichlet_constraints = DirichletConstraints(boundary_info, V_h)
+
+walker = Walker(grid)
+walker.append(a_h)
+walker.append(l_h)
+walker.append(dirichlet_constraints)
+walker.walk()
+
+dirichlet_constraints.apply(a_h.matrix, l_h.vector)
+```
+
+```{code-cell}
+from dune.gdt import visualize_function
+
+u_h = DiscreteFunction(V_h, 'u_h')
+
+a_h.apply_inverse(l_h.vector, u_h.dofs.vector)
+
+_ = visualize_function(u_h)
+```
+
+## 3: computing the a posterior error estimates and indicators from [MNS2002]
+
+We consider the set of all faces (or sides) of the grid, $\mathcal{F}_h$, with a face denoted by $\Gamma \in \mathcal{F}_h$.
+Each face $\Gamma \in \mathcal{F}_h$ is either
+
+* an inner face, i.e. $\Gamma = \overline{\partial K^- \cap \partial K^+}$ for two grid elements $K^-, K^+ \in \mathcal{T}_h$, or
+* a boundary face, i.e. $\Gamma = \overline{\partial K^- \cap \partial\Omega}$ for a grid element $K^- \in \mathcal{T}_h$
+
+and has a
+
+* unit outer normal $n_\Gamma \in \mathbb{R}^d$ poiting away from $K^-$.
+
+We call $K^-$ the *inner* element and $K^+$ the outer element.
+
+The local face indicator in [MNS2002, (2.6)] is defined by
+
+$$\begin{align}
+\eta_\Gamma^2 := \underbrace{\big\| \sqrt{h_\gamma}\; [[A \nabla u_h]]\cdot n_\Gamma \big\|_{L^2(\Gamma)}^2}_{:= \eta_{\Gamma\text{, flux}}^2} + \underbrace{\|h\,f\|_{L^2(\omega_\Gamma)}^2}_{=: \eta_{\Gamma, f}^2}
+\end{align}$$
+
+where $h_\Gamma := \text{diam}(\Gamma)$ for all $\Gamma \in \mathcal{F}_h$, $h|_K := \text{diam}(K)$ for all $K \in \mathcal{T}_h$ and
+
+* the jump of a vector valued function $v: \Omega \to \mathbb{R}^d$ over a face $\Gamma$ defined by
+
+  $$\begin{align}
+  [[v]] := \begin{cases}v^- - v^+, &\Gamma\text{ is an inner intersection and}\\v^-,&\Gamma\text{ is a boundary intersection}\end{cases}
+  \end{align}$$
+
+  where $v^- := v|_{K^-}$ and $v^+ := v|_{K^+}$; and
+
+* the patch
+
+  $$\begin{align}
+  \omega_\Gamma := \begin{cases}K^- \cup K^+, &\Gamma\text{ is an inner intersection and}\\K^-,&\Gamma\text{ is a boundary intersection}\end{cases}
+  \end{align}$$
+
+To compute the first contribution to the indicator, we use an operator mapping the flux $A \nabla u_h$ to the vector
+$\underline{\eta_\text{flux}} \in \mathbb{R}^{|\mathcal{F}_h|}$, where the $i$-the entry of the vector is the squared indicator contribution associated with the respective intersection, i.e.
+
+$$\begin{align}
+\underline{\eta_\text{flux}}_i := \eta_{\Gamma\text{, flux}}^2&&\text{with }\Gamma\text{ the intersection with global index }i.
+\end{align}$$
+
+We use a `RaviartThomasSpace` to represent the flux space (only for its dimensions, the flux need not be an actual element of the space), and `FiniteVolumeSkeletonSpace` to represent numbers associated with intersections.
+
+```{code-cell}
+from dune.xt.grid import ApplyOnInnerIntersectionsOnce, ApplyOnCustomBoundaryIntersections, DirichletBoundary
+
+from dune.xt.functions import gradient
+
+from dune.gdt import (
+    FiniteVolumeSkeletonSpace,
+    LocalCouplingIntersectionIntegralBilinearForm,
+    LocalCouplingIntersectionBilinearFormIndicatorOperator,
+    LocalIntersectionIntegralBilinearForm,
+    LocalIntersectionBilinearFormIndicatorOperator,
+    LocalInnerJumpIntegrand,
+    LocalBoundaryJumpIntegrand,
+    Operator,
+    RaviartThomasSpace,
+)
+
+flux_space = RaviartThomasSpace(grid, order=0)
+flux = A*gradient(u_h)
+
+intersection_indices = FiniteVolumeSkeletonSpace(grid)
+
+eta_flux_op = Operator(grid, flux_space, intersection_indices)
+eta_flux_op += (
+    LocalCouplingIntersectionBilinearFormIndicatorOperator(
+        LocalCouplingIntersectionIntegralBilinearForm(
+            LocalInnerJumpIntegrand(grid, dim_range=Dim(d), weighted_by_intersection_diameter=True))),
+    ApplyOnInnerIntersectionsOnce(grid))
+eta_flux_op += (
+    LocalIntersectionBilinearFormIndicatorOperator(
+        LocalIntersectionIntegralBilinearForm(
+            LocalBoundaryJumpIntegrand(grid, dim_range=Dim(d), weighted_by_intersection_diameter=True))),
+    ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()))
+eta_flux_2 = np.array(eta_flux_op.apply(flux).dofs.vector, copy=False)
+print(f'flux jump indicators = {eta_flux_2}')
+```
+
+```{code-cell}
+# individual entries may contain negative values due to numerical inaccuracies, which we set to zero here
+negative_entries = np.where(eta_flux_2 < 0)[0]
+if len(negative_entries)> 0:
+    eta_flux_2[negative_entries] = np.zeros(len(negative_entries))
+    print(f'flux jump indicators (cleaned up) = {eta_flux_2}')
+del negative_entries
+```
+
+For the second contribution we first compute $\|h f\|_{L^2(K)}^2$ for all $K \in \mathcal{T}_h$ and combine them to obtain the intersection patch indicators.
+
+```{code-cell}
+from dune.xt.functions import ElementwiseDiameterFunction
+
+from dune.gdt import (
+    LocalElementBilinearFormIndicatorOperator,
+    FiniteVolumeSpace,
+    default_interpolation,
+)
+
+element_indices = FiniteVolumeSpace(grid)
+h = ElementwiseDiameterFunction(grid)
+
+eta_f_op = Operator(grid, V_h, element_indices)
+eta_f_op += LocalElementBilinearFormIndicatorOperator(
+    LocalElementIntegralBilinearForm(LocalElementProductIntegrand(weight=GF(grid, 1))))
+eta_f_2_per_element = np.array(eta_f_op.apply(h*f).dofs.vector, copy=False)
+print(eta_f_2_per_element)
+```
+
+```{code-cell}
+eta_f_2_per_intersection = np.zeros(intersection_indices.num_DoFs)
+
+eta_f_2_per_intersection += eta_f_2_per_element[inner_element_indices]
+eta_f_2_per_intersection[inner_intersections] += eta_f_2_per_element[outside_element_indices[inner_intersections]]
+```
+
+We can now obtain the indicators simply by combining the two contributions.
+
+```{code-cell}
+eta_2_per_intersection = eta_flux_2 + eta_f_2_per_intersection
+```
+
+Since `eta_2_per_intersection` contains the squared contributions, we obtain the estimate as the square root of the sum.
+
+```{code-cell}
+eta = np.sqrt(np.linalg.norm(eta_2_per_intersection, ord=1))
+
+print(f'estimated error: {eta}')
+```
+
+## 4: data oscialltion
+
+We compute the data oscillation on a finer grid, for visualization. **Note** that all quantities from above are now invalid!
+
+```{code-cell}
+grid.global_refine(4)
+
+V_h = ContinuousLagrangeSpace(grid, order=1)
+```
+
+```{code-cell}
+# f_h is the piecewise constant average value on each element
+p0_space = FiniteVolumeSpace(grid)
+f_h = default_interpolation(f, p0_space)
+
+oscillation_op = Operator(grid, V_h, p0_space)
+oscillation_op += LocalElementBilinearFormIndicatorOperator(
+    LocalElementIntegralBilinearForm(
+        LocalElementProductIntegrand(weight=GF(grid, 1))))
+osc_2 = oscillation_op.apply(h*(f - f_h))
+
+# osc_2 is a discrete function, where the entries of its DoF vector
+# correspond to the squared data oscillation on each grid element.
+# Since the information is element-based (and not intersection-based),
+# we can easily visualize it:
+
+_ = visualize_function(osc_2)
+```
+
+```{code-cell}
+# we obtain ||h(f - f_h)||_{L^2(\Omega)} by the L^1-norm since the indicators are already squared
+print(np.sqrt(osc_2.dofs.vector.l1_norm()))
+```
+
+Download the code:
+{download}`example__MNS2002_estimates.md`
+{nb-download}`example__MNS2002_estimates.ipynb`

--- a/tutorials/source/example__gmsh_grid.md
+++ b/tutorials/source/example__gmsh_grid.md
@@ -1,0 +1,126 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: working with gmsh grids
+
+## 1: creating a gmsh file
+
+We use pyMORs `PolygonalDomain`description and `discretize_gmsh` to obtain a grid file that `gmsh` can read. **Note** that `dune-grid` can only handle `gmsh` version 2 files, we have thus installed `gmsh` version `2.16` in this virtualenv. For newer versions of `gmsh`,  you need to follow [these instructions](https://gitlab.dune-project.org/core/dune-grid/issues/85).
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+
+import numpy as np
+
+```
+
+```{code-cell}
+from pymor.analyticalproblems.domaindescriptions import PolygonalDomain
+
+L_shaped_domain = PolygonalDomain(points=[
+    [0, 0],
+    [0, 1],
+    [-1, 1],
+    [-1, -1],
+    [1, -1],
+    [1, 0],
+], boundary_types={'dirichlet': [1, 2, 3, 4, 5, 6]})
+```
+
+```{code-cell}
+from pymor.discretizers.builtin.domaindiscretizers.gmsh import discretize_gmsh
+
+grid, bi = discretize_gmsh(L_shaped_domain, msh_file_path='L_shaped_domain.msh')
+```
+
+## 2: discretization using pyMOR
+
+We may use pyMOR to solve an elliptic PDE on this grid.
+
+```{code-cell}
+from pymor.analyticalproblems.functions import ConstantFunction
+from pymor.analyticalproblems.elliptic import StationaryProblem
+
+problem = StationaryProblem(
+    domain=L_shaped_domain,
+    rhs=ConstantFunction(1, dim_domain=2),
+    diffusion=ConstantFunction(1, dim_domain=2),
+)
+```
+
+```{code-cell}
+from pymor.discretizers.builtin import discretize_stationary_cg
+
+fom, fom_data = discretize_stationary_cg(problem, grid=grid, boundary_info=bi)
+```
+
+```{code-cell}
+fom.visualize(fom.solve())
+```
+
+## 3: using the gmsh grid in dune
+
+`dune-grid` [only supports](https://gitlab.dune-project.org/core/dune-grid/issues/85) `gmsh` version 2 files, and only a subset of the specification.
+This virtualenv includes the `gmsh` version 2.16 (as visible in the output of the `discretize_gmsh` command above), but we still need to clean up the mesh file for `dune-grid` to [correctly parse](https://gitlab.dune-project.org/core/dune-grid/-/issues/89) it.
+In particular, we need to remove the boundary type definition (which we do not require, we have our own boundary info), which is achieved by the following bash code (**Note** that you have to provide the same filename here as in the call to `discretize_gmsh`):
+
+```{code-cell}
+# remove all lines between $PhysicalNames and $EndPhysicalNames ...
+!sed '/^\$PhysicalNames/,/^\$EndPhysicalNames/{//!d;};' -i L_shaped_domain.msh
+# ... and remove those two lines as well:
+!sed '/^\$PhysicalNames/d' -i L_shaped_domain.msh
+!sed '/^\$EndPhysicalNames/d' -i L_shaped_domain.msh
+```
+
+```{code-cell}
+from dune.xt.grid import make_gmsh_grid, Dim, Simplex, visualize_grid
+
+grid = make_gmsh_grid('L_shaped_domain.msh', Dim(2), Simplex())
+```
+
+This grid can now be used as any other grid, e.g. for visualization ...
+
+```{code-cell}
+_ = visualize_grid(grid)
+```
+
+... or discretization:
+
+```{code-cell}
+from dune.gdt import visualize_function
+
+from discretize_elliptic_cg import discretize_elliptic_cg_dirichlet_zero
+
+u_h = discretize_elliptic_cg_dirichlet_zero(grid, diffusion=1, source=1)
+_ = visualize_function(u_h)
+```
+
+Download the code:
+{download}`example__gmsh_grid.md`
+{nb-download}`example__gmsh_grid.ipynb`

--- a/tutorials/source/example__ipdg_heat_equation.md
+++ b/tutorials/source/example__ipdg_heat_equation.md
@@ -1,0 +1,207 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: SIPDG for the instationary heat equation
+
+## This is work in progress (WIP), still missing:
+
+* explanations
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+
+import numpy as np
+
+```
+
+```{code-cell}
+from dune.xt.grid import Dim, Simplex, make_cube_grid, AllDirichletBoundaryInfo, visualize_grid
+
+d = 2
+grid = make_cube_grid(Dim(d), Simplex(), [0, 0], [1, 1], [2, 2])
+grid.global_refine(1) # we need to refine once to obtain a symmetric grid
+
+print(f'grid has {grid.size(0)} elements, {grid.size(d - 1)} edges and {grid.size(d)} vertices')
+
+boundary_info = AllDirichletBoundaryInfo(grid)
+```
+
+## stationary data functions
+
+```{code-cell}
+from dune.xt.functions import GridFunction as GF
+
+diffusion = GF(grid, 1., dim_range=(Dim(d), Dim(d)), name='diffusion')
+source = GF(grid, 1., name='source')
+u_0 = GF(grid, 0., name='u_0')
+```
+
+```{code-cell}
+from dune.xt.grid import (
+    ApplyOnCustomBoundaryIntersections,
+    ApplyOnInnerIntersectionsOnce,
+    DirichletBoundary,
+    Walker,
+)
+
+from dune.gdt import (
+    DiscontinuousLagrangeSpace,
+    DiscreteFunction,
+    LocalElementIntegralBilinearForm,
+    LocalElementIntegralFunctional,
+    LocalElementProductIntegrand,
+    LocalCouplingIntersectionIntegralBilinearForm,
+    LocalIPDGBoundaryPenaltyIntegrand,
+    LocalIPDGInnerPenaltyIntegrand,
+    LocalIntersectionIntegralBilinearForm,
+    LocalLaplaceIntegrand,
+    LocalLaplaceIPDGDirichletCouplingIntegrand,
+    LocalLaplaceIPDGInnerCouplingIntegrand,
+    MatrixOperator,
+    VectorFunctional,
+    estimate_combined_inverse_trace_inequality_constant,
+    estimate_element_to_intersection_equivalence_constant,
+    make_element_and_intersection_sparsity_pattern,
+)
+
+V_h = DiscontinuousLagrangeSpace(grid, order=1)
+```
+
+```{code-cell}
+weight = GF(grid, 1., dim_range=(Dim(d), Dim(d)), name='weight')
+penalty_parameter = 16
+symmetry_factor = 1
+
+sp = make_element_and_intersection_sparsity_pattern(V_h)
+m_h = MatrixOperator(grid, source_space=V_h, range_space=V_h, sparsity_pattern=sp)
+m_h += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+
+l_h = VectorFunctional(grid, V_h)
+l_h += LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source))
+
+a_h = MatrixOperator(grid, source_space=V_h, range_space=V_h, sparsity_pattern=sp)
+a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+a_h += (LocalCouplingIntersectionIntegralBilinearForm(
+            LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
+            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)),
+        {}, ApplyOnInnerIntersectionsOnce(grid))
+a_h += (LocalIntersectionIntegralBilinearForm(
+            LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
+            + LocalLaplaceIPDGDirichletCouplingIntegrand(symmetry_factor, diffusion)),
+       {}, ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()))
+
+walker = Walker(grid)
+walker.append(m_h)
+walker.append(a_h)
+walker.append(l_h)
+walker.walk()
+```
+
+$$\begin{align}
+\Delta t m_h(u^{n + 1} - u^n, v) + a_h(u^{n + 1}, v) &= l_h(v)\\
+m_h(u^{n + 1} - u^n, v) + \Delta t \cdot a_h(u^{n + 1}, v) &= \Delta t \cdot l_h(v)\\
+m_h(u^{n + 1},v) - m_h(u^n, v) + \Delta t \cdot a_h(u^{n + 1}, v) &= \Delta t \cdot l_h(v)\\
+m_h(u^{n + 1},v) + \Delta t \cdot a_h(u^{n + 1}, v) &= m_h(u^n, v) + \Delta t \cdot l_h(v)
+\end{align}$$
+
+```{code-cell}
+from dune.gdt import default_interpolation
+from dune.xt.la import make_solver
+
+u_h = [default_interpolation(u_0, V_h).dofs.vector]
+
+T_end = 1
+dt = 0.1
+time = 0
+while time < T_end + dt:
+    time += dt
+    u_n = u_h[-1]
+    u_n_plus_one = (m_h + dt*a_h).apply_inverse(m_h.apply(u_n) + dt*l_h.vector)
+    u_h.append(u_n_plus_one)
+```
+
+```{code-cell}
+for ii, vec in enumerate(u_h):
+    DiscreteFunction(V_h, vec, 'solution').visualize(f'solution_{ii}')
+```
+
+Start `paraview` in a terminal to visualize the time series.
+
+
+## timedependent right hand side
+
+```{code-cell}
+from dune.xt.functions import ExpressionFunction, ParametricExpressionFunction
+
+u_str = '0.1*sin(20*pi*_t)*exp(-10*(x[0]*x[0]+x[1]*x[1]))'
+u_0 = GF(grid,
+         ExpressionFunction(dim_domain=Dim(d), variable='x', expression=u_str.replace('_t', '0'),
+                            order=2, name='u_0'))
+
+diffusion = GF(grid, 1., dim_range=(Dim(d), Dim(d)), name='diffusion')
+source = GF(grid, ParametricExpressionFunction(
+    dim_domain=Dim(d), variable='x', param_type={'_t': 1},
+    expressions=['exp(-0.1*(x[0]*x[0]+x[1]*x[1]))*(2*pi*cos(20*pi*_t)+4*sin(20*pi*_t)-40*sin(20*pi*_t)(x[0]*x[0]+x[1]*x[1]))'],
+    order=2, name='source'))
+```
+
+Use the same `m_h` and `a_h` as above, but we need to assemble `l_h` anew for each time point. We could either directly create a new stationary `source` in each time step as an `ExpressionFunction` (like `u_0`), but we demonstrate the parametric assembly here. Computational demand is the same ...
+
+```{code-cell}
+l_h = VectorFunctional(grid, V_h)
+```
+
+```{code-cell}
+from dune.xt.grid import ApplyOnAllElements
+
+u_h = [default_interpolation(u_0, V_h).dofs.vector]
+
+T_end = 1
+dt = 0.1
+time = 0
+while time < T_end + dt:
+    time += dt
+    l_h.vector.set_all(0)
+    l_h += (LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source)),
+            {'_t': [time]},
+            ApplyOnAllElements(grid))
+    l_h.assemble()
+    u_n = u_h[-1]
+    u_n_plus_one = (m_h + dt*a_h).apply_inverse(m_h.apply(u_n) + dt*l_h.vector)
+    u_h.append(u_n_plus_one)
+```
+
+```{code-cell}
+for ii, vec in enumerate(u_h):
+    DiscreteFunction(V_h, vec, 'solution').visualize(f'solution_timedep_data_{ii}')
+```
+
+Download the code:
+{download}`example__ipdg_heat_equation.md`
+{nb-download}`example__ipdg_heat_equation.ipynb`

--- a/tutorials/source/example__ipdg_stationary_heat_equation.md
+++ b/tutorials/source/example__ipdg_stationary_heat_equation.md
@@ -1,0 +1,94 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+# Tutorial: discontinuous IPDG for the stationary heat equation
+
+This tutorial shows how to solve the stationary heat equation with homogeneous Dirichlet boundary conditions using interior penalty (IP) discontinuous Galerkin (DG) Finite Elements with `dune-gdt`.
+
+This is work in progress [WIP], still missing:
+
+* mathematical theory on IPDG methods
+* explanation of the IPDG implementation
+* non-homonegenous Dirichlet boundary values
+* Neumann boundary values
+* Robin boundary values
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+
+import numpy as np
+
+```
+
+```{code-cell}
+from dune.xt.grid import Dim
+from dune.xt.functions import ConstantFunction, ExpressionFunction
+
+d = 2
+omega = ([0, 0], [1, 1])
+
+kappa = ConstantFunction(dim_domain=Dim(d), dim_range=Dim(1), value=[1.], name='kappa')
+# note that we need to prescribe the approximation order, which determines the quadrature on each element
+f = ExpressionFunction(dim_domain=Dim(d), variable='x', expression='exp(x[0]*x[1])', order=3, name='f')
+```
+
+```{code-cell}
+from dune.xt.grid import Simplex, make_cube_grid, visualize_grid
+
+grid = make_cube_grid(Dim(d), Simplex(), lower_left=omega[0], upper_right=omega[1], num_elements=[2, 2])
+grid.global_refine(1) # we need to refine once to obtain a symmetric grid
+
+print(f'grid has {grid.size(0)} elements, {grid.size(d - 1)} edges and {grid.size(d)} vertices')
+
+_ = visualize_grid(grid)
+```
+
+## 1.9: everything in a single function
+
+For a better overview, the above discretization code is also available in a single function in the file `discretize_elliptic_ipdg.py`.
+
+```{code-cell}
+import inspect
+from discretize_elliptic_ipdg import discretize_elliptic_ipdg_dirichlet_zero
+
+print(inspect.getsource(discretize_elliptic_ipdg_dirichlet_zero))
+```
+
+```{code-cell}
+from dune.gdt import visualize_function
+
+u_h = discretize_elliptic_ipdg_dirichlet_zero(
+    grid, kappa, f,
+    symmetry_factor=1, penalty_parameter=16, weight=1) # SIPDG scheme
+
+_ = visualize_function(u_h)
+```
+
+Download the code:
+{download}`example__ipdg_stationary_heat_equation.md`
+{nb-download}`example__ipdg_stationary_heat_equation.ipynb`

--- a/tutorials/source/example__prolongations_products_and_norms.md
+++ b/tutorials/source/example__prolongations_products_and_norms.md
@@ -1,0 +1,180 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: prolongations and computing products and norms
+
+## This is work in progress (WIP), still missing:
+
+* documentation and explanation
+* assembled matrix as product
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+
+import numpy as np
+
+```
+
+## 1: prolongation onto a finer grid
+
+Let's set up a 2d grid first, as seen in other tutorials and examples.
+
+```{code-cell}
+from dune.xt.grid import Dim, Cube, Simplex, make_cube_grid
+from dune.xt.functions import ExpressionFunction, GridFunction as GF
+
+d = 2
+omega = ([0, 0], [1, 1])
+grid = make_cube_grid(Dim(d), Simplex(), lower_left=omega[0], upper_right=omega[1], num_elements=[2, 2])
+grid.global_refine(1)
+
+print(f'grid has {grid.size(0)} elements, {grid.size(d - 1)} edges and {grid.size(d)} vertices')
+```
+
+```{code-cell}
+from dune.gdt import default_interpolation, prolong, DiscontinuousLagrangeSpace
+
+V_H = DiscontinuousLagrangeSpace(grid, order=1)
+
+f = ExpressionFunction(dim_domain=Dim(d), variable='x', order=10, expression='exp(x[0]*x[1])', name='f')
+f_H = default_interpolation(GF(grid, f), V_H)
+
+print(f'f_H has {len(f_H.dofs.vector)} DoFs')
+```
+
+```{code-cell}
+reference_grid = make_cube_grid(Dim(d), Simplex(), lower_left=omega[0], upper_right=omega[1], num_elements=[16, 16])
+reference_grid.global_refine(1)
+
+print(f'grid has {reference_grid.size(0)} elements')
+```
+
+```{code-cell}
+from dune.gdt import DiscreteFunction
+
+V_h = DiscontinuousLagrangeSpace(reference_grid, order=1)
+
+f_h = prolong(f_H, V_h)
+print(f'f_h has {len(f_h.dofs.vector)} DoFs')
+```
+
+## 2: computing products and norms
+
+```{code-cell}
+u = GF(grid,
+       ExpressionFunction(dim_domain=Dim(d), variable='x', order=10, expression='exp(x[0]*x[1])',
+                          gradient_expressions=['x[1]*exp(x[0]*x[1])', 'x[0]*exp(x[0]*x[1])'], name='h'))
+```
+
+$$
+(u, v)_{H^1} = (u, v)_{L^2} + (u, v)_{H^1_0}
+$$
+
+$$
+||u||_{H^1} = \sqrt{||u||_{L^2}^2 + |u|_{H^1_0}^2}
+$$
+
+
+Either comupte all in one grid walk ...
+
+```{code-cell}
+from dune.xt.grid import Walker
+
+from dune.gdt import (
+    BilinearForm,
+    LocalElementProductIntegrand,
+    LocalElementIntegralBilinearForm,
+    LocalLaplaceIntegrand,
+)
+
+L2_product = BilinearForm(grid, u, u)
+L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+
+H1_semi_product = BilinearForm(grid, u, u)
+H1_semi_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
+
+H1_product = BilinearForm(grid, u, u)
+H1_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+H1_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
+
+walker = Walker(grid)
+walker.append(L2_product)
+walker.append(H1_semi_product)
+walker.append(H1_product)
+walker.walk()
+
+print(f'|| u ||_L2 = {np.sqrt(L2_product.result)}')
+print(f' | u |_H1  = {np.sqrt(H1_semi_product.result)}')
+print(f'|| u ||_H1 = {np.sqrt(H1_product.result)}')
+```
+
+```{code-cell}
+np.allclose(L2_product.result + H1_semi_product.result, H1_product.result)
+```
+
+... or let each product do the grid walking in `apply2` (possibly less runtime efficient, but maybe more intuitive)
+
+```{code-cell}
+L2_product = BilinearForm(grid, u, u)
+L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+print(f'|| u ||_L2 = {np.sqrt(L2_product.apply2())}')
+
+H1_semi_product = BilinearForm(grid, u, u)
+H1_semi_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
+print(f' | u |_H1  = {np.sqrt(H1_semi_product.apply2())}')
+
+H1_product = BilinearForm(grid, u, u)
+H1_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+H1_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
+print(f'|| u ||_H1 = {np.sqrt(H1_product.apply2())}')
+```
+
+## 3: computing errors w.r.t. a known reference solution
+
+```{code-cell}
+# suppose we have a DiscreteFunction on a coarse grid, usually the solution of a discretization
+# (we use the interpolation here for simplicity)
+
+u_H = default_interpolation(u, V_H)
+
+# prolong it onto the reference grid
+u_h = prolong(u_H, V_h)
+
+# define error function using the analytically known solution u
+error = GF(grid, u - u_h)
+
+# compute norms on reference grid
+L2_product = BilinearForm(reference_grid, error, error)
+L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+print(f'|| error ||_L2 = {np.sqrt(L2_product.apply2())}')
+```
+
+Download the code:
+{download}`example__prolongations_products_and_norms.md`
+{nb-download}`example__prolongations_products_and_norms.ipynb`

--- a/tutorials/source/examples.md
+++ b/tutorials/source/examples.md
@@ -3,10 +3,11 @@
 The examples each highlight a specific aspect, possibly without much explanation.
 
 ```{toctree}
-
+example__prolongations_products_and_norms
 example__simple_grid_adaptation
-
-
-
-
+example__ESV2007_estimates
+example__gmsh_grid
+example__MNS2002_estimates
+example__ipdg_stationary_heat_equation
+example__ipdg_heat_equation
 ```

--- a/tutorials/source/tutorials.md
+++ b/tutorials/source/tutorials.md
@@ -3,5 +3,6 @@
 The tutorials each cover a topic with in-depth explanations.
 
 ```{toctree}
-
+dune_gdt_tutorial_on_data_functions_and_interpolation
+dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation
 ```


### PR DESCRIPTION
Fixes the first part of #41 ("fix broken tutorials"), which reverts the removal in `3fd0cc6` and gets the tutorials executing in CI again.

## What this does

- **Restores** the 8 MyST notebooks deleted in `3fd0cc6` (2 tutorials + 6 examples) and their Sphinx toctree entries.
- **Wires notebook execution into the docs build**: a new `build_tutorials` job in `non_docker_build.yml` installs the freshly built (current, git-derived) wheels + docs/visualisation deps and runs `sphinx-build`, so myst-nb executes the notebooks. The job fails if any *executed* notebook errors (myst-nb writes a per-notebook `reports/*.err.log`, which is also dumped into the job log).
- **Fixes a real numpy>=2 bug** in `dune.xt.common.vtk.plot` (`np.stack` over ragged per-timestep tuples → "inhomogeneous shape"), which broke every `visualize_grid` / `visualize_function` call.
- **Migrates the shared helpers** `discretize_elliptic_{cg,ipdg}.py` to the current two-level assembly API (`BilinearForm` accumulates local forms via the `(form, filter)` tuple form; `MatrixOperator.append(bilinear_form)`).

## Currently executed & passing in CI
- `example__simple_grid_adaptation.md`
- `example__ipdg_stationary_heat_equation.md` (unblocked by the IPDG helper migration)

## Deferred (restored + rendered, excluded from execution)
The other notebooks depend on dune-gdt python bindings that are currently commented out in the C++ sources (direct `MatrixOperator += local_form`, `BilinearForm.result`/`apply2`, oswald / IPDG-flux-reconstruction operators). They are excluded from execution via `nb_execution_excludepatterns` and tracked in **#127** (blocked on **#126**), per the "land infra now, defer the rest" decision on #41.

## Notes
- `Build on Linux` and `Publish to Test PyPI` failures on this PR are pre-existing/unrelated (vcpkg bootstrap fails on `main` too; Test PyPI rejects the already-published version) and are out of scope here.

Refs #41, #126, #127