### PR TITLE
ci: fix poisoned build cache breaking cmake configure on fresh runners

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -28,8 +28,23 @@ jobs:
     - name: Restore build cache
       uses: actions/cache/restore@v3
       with:
-        path: build
-        key: ${{ runner.os }}-build
+        # The configured build/ tree embeds absolute paths into the vcpkg
+        # toolchain that lives in .vcpkg-root (set up by cmake/VcpkgBootStrap.cmake
+        # at configure time). Both must be cached together, otherwise a restored
+        # build/ references a .vcpkg-root that does not exist on a fresh runner and
+        # the configure step fails (missing vcpkg.cmake -> LAPACKE/BLAS not found).
+        # The transient vcpkg dirs (buildtrees/downloads/packages) are excluded to
+        # keep the cache lean; the installed deps live under build/*/vcpkg_installed.
+        path: |
+          build
+          .vcpkg-root
+          !.vcpkg-root/buildtrees
+          !.vcpkg-root/downloads
+          !.vcpkg-root/packages
+        # Content-addressed key: invalidates when the vcpkg/toolchain inputs change
+        # and (by dropping the old static "Linux-build" key) abandons any stale,
+        # poisoned cache from before this fix.
+        key: ${{ runner.os }}-build-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake', '.vcpkg-overlays/ports/**') }}
 
     - name: Install dependencies
       run: |
@@ -55,8 +70,13 @@ jobs:
       if: ${{ success() && steps.configure_cmake.outcome == 'success' }}
       uses: actions/cache/save@v3
       with:
-        path: build
-        key: ${{ runner.os }}-build
+        path: |
+          build
+          .vcpkg-root
+          !.vcpkg-root/buildtrees
+          !.vcpkg-root/downloads
+          !.vcpkg-root/packages
+        key: ${{ runner.os }}-build-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake', '.vcpkg-overlays/ports/**') }}
 
     - name: Upload error logs (in case of failure)
       if: always() && (steps.configure_cmake.conclusion == 'failure')


### PR DESCRIPTION
## Problem

The `Build on Linux` job in `non_docker_build.yml` fails at the **Configure CMake** step (`cmake --preset=debug`, exit 1) on every run that restores the build cache:

```
-- Setting up vcpkg for re-use in .vcpkg-root (this may take some time)
-- Setting up vcpkg for re-use in .vcpkg-root (this may take some time) - done   ← 0.1s, no clone
CMake Error at build/debug/CMakeFiles/3.31.6/CMakeSystem.cmake:6 (include):
  include could not find requested file:
    /home/runner/work/dune-gdt/dune-gdt/.vcpkg-root/scripts/buildsystems/vcpkg.cmake
Call Stack (most recent call first):
  CMakeLists.txt:26 (project)
```
followed by `FindLAPACKE.cmake:37` → `check_function_exists` failing (`mkl.h not found`, `LAPACKE not found`) — all symptoms of the missing vcpkg toolchain.

This is an infra/config regression from the `refactor-ci` work (PR #81), not a code bug.

## Root cause

The job cached `build/` under a **static, cross-branch, write-once** key `${{ runner.os }}-build` (`Linux-build`).

- `cmake/VcpkgBootStrap.cmake` (included at `CMakeLists.txt:24`, before `project()`) sets up vcpkg into `.vcpkg-root/` via `FetchContent` and points `CMAKE_TOOLCHAIN_FILE` at `.vcpkg-root/scripts/buildsystems/vcpkg.cmake`.
- `.vcpkg-root/` is **gitignored** and was **never part of the cache** — only `build/` was.
- Run #60 (cold cache) bootstrapped vcpkg and saved `build/`, whose `CMakeCache.txt` / `CMakeSystem.cmake` embed the **absolute** path to `.vcpkg-root`, plus `FetchContent` stamps marking vcpkg "already populated".
- Every later run on a fresh checkout restores that `build/` but has **no `.vcpkg-root`**. `FetchContent` trusts its cached stamp ("done" in 0.1s) and never re-clones, so `project()` loads the cached `CMakeSystem.cmake`, tries to `include()` the missing toolchain, and errors. With no toolchain, vcpkg deps are off the prefix path, so LAPACKE/BLAS detection fails too.

## Fix

- Cache `.vcpkg-root` **together with** `build/` so the restored tree's toolchain reference actually resolves (the `EXISTS .vcpkg-root/.../vcpkg.cmake` reuse branch in `VcpkgBootStrap.cmake` is taken — no `FetchContent` skip-hazard).
- Switch to a **content-addressed key** (`hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake', '.vcpkg-overlays/ports/**')`) so the cache self-invalidates when the vcpkg/toolchain inputs change, and the old poisoned `Linux-build` cache is abandoned.
- Exclude the transient `.vcpkg-root/{buildtrees,downloads,packages}` to keep the cache lean — the installed deps already live under `build/*/vcpkg_installed`, and an unchanged manifest makes vcpkg a no-op (no buildtrees needed).

Restore and save use the same paths/key so the two stay consistent. No `restore-keys` fallback, to avoid ever reusing a `.vcpkg-root` built from a different pinned vcpkg revision.

The first run after merge starts cold (new key), bootstraps vcpkg cleanly, and saves a consistent `build/` + `.vcpkg-root` pair for subsequent warm runs.

https://claude.ai/code/session_016iNvwuxMkrNz8RmmsYHPHU

---
_Generated by [Claude Code](https://claude.ai/code/session_016iNvwuxMkrNz8RmmsYHPHU)_