### PR TITLE
ci: trigger required checks on merge_group events

### DIFF
--- a/.github/workflows/check_markdown_links.yml
+++ b/.github/workflows/check_markdown_links.yml
@@ -2,7 +2,7 @@
 # homepage: https://github.com/gaurav-nelson/github-action-markdown-link-check
 name: Check links in Markdown files
 
-on: [pull_request]
+on: [pull_request, merge_group]
 
 jobs:
   markdown-link-check:
@@ -12,6 +12,9 @@ jobs:
     - name: Checkout reposotiry
       uses: actions/checkout@v4
     - name: Check links in Markdown files
+      # The link check already ran on the PR; in the merge queue this step is
+      # skipped so the required "Markdown" check still resolves successfully.
+      if: github.event_name == 'pull_request'
       uses: renefritze/github-action-markdown-link-check@master
       with:
         use-verbose-mode: yes

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 # Add concurrency to cancel in-progress jobs
@@ -98,6 +99,8 @@ jobs:
     name: Publish to Test PyPI
     runs-on: ubuntu-24.04
     needs: build_wheels
+    # Don't republish from the merge queue; wheels are already built/tested there.
+    if: github.event_name != 'merge_group'
     timeout-minutes: 120
     environment: test-pypi
     permissions:

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -1,5 +1,5 @@
 ---
-on: pull_request
+on: [pull_request, merge_group]
 
 name: Sanity checks
 
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Block Autosquash Commits
+      # Only meaningful on a PR; in the merge queue this step is skipped so the
+      # required "Block Autosquash Commits" check still resolves successfully.
+      if: github.event_name == 'pull_request'
       uses: xt0rted/block-autosquash-commits-action@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -16,6 +19,9 @@ jobs:
   merge_conflict_job:
     runs-on: ubuntu-22.04
     name: Find merge conflicts
+    # Conflict detection is a PR-only concern; the merge queue already operates
+    # on the merged result.
+    if: github.event_name == 'pull_request'
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The merge queue is stuck on **"Some required checks haven't completed yet"** with required checks (`Build on Linux`, `Build wheels`, `Markdown`, `Block Autosquash Commits`) sitting as **Expected** indefinitely.

GitHub's merge queue evaluates required status checks against the special **`merge_group`** event. However, all of the workflows that produce these checks only listened for `pull_request` (and `push` for the build). Since none triggered on `merge_group`, the required checks never started in the queue and blocked merges forever.

## Fix

Add the `merge_group` trigger to the three workflows that emit required checks:

- **`non_docker_build.yml`** — adds `merge_group:` so `Build on Linux` and `Build wheels` actually run in the queue (this is the real validation we want there). The `Publish to Test PyPI` job is guarded with `if: github.event_name != 'merge_group'` so we don't republish wheels from the queue.
- **`check_markdown_links.yml`** — adds `merge_group`; the link-check step is guarded to `pull_request` (it already ran on the PR), so the required `Markdown` check still resolves successfully in the queue.
- **`sanity_checks.yml`** — adds `merge_group`; the `Block Autosquash Commits` step is guarded to `pull_request` so the required job still reports success in the queue, and the non-required `Find merge conflicts` job is skipped in the queue (the queue already operates on the merged result).

`dependabot.yml` is intentionally left untouched — it's PR-only auto-merge and produces no required check.

## Result

The required checks now run/resolve against `merge_group`, so queued entries can complete instead of waiting on checks that never start.

https://claude.ai/code/session_01BQxm2S1Xaob6vXjhpteGmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQxm2S1Xaob6vXjhpteGmp)_