### PR TITLE
Fix dependabot config rejected by check-dependabot hook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 ---
-# Configuration: https://dependabot.com/docs/config-file/
-# Docs: https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically
+# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 
@@ -9,7 +8,8 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  cooldown-days: 7
+  cooldown:
+    default-days: 7
   allow:
   - dependency-type: all
   commit-message:
@@ -24,7 +24,8 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  cooldown-days: 7
+  cooldown:
+    default-days: 7
   allow:
   - dependency-type: all
   commit-message:
@@ -39,7 +40,8 @@ updates:
   directory: ./
   schedule:
     interval: weekly
-  cooldown-days: 7
+  cooldown:
+    default-days: 7
   allow:
   - dependency-type: all
   commit-message:


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` uses a flat `cooldown-days: 7` key, which is **not** a valid property in the Dependabot config schema. The cooldown period must be configured via the `cooldown` object with a `default-days` sub-key.

This is rejected by the `check-dependabot` pre-commit hook (provided by `check-jsonschema`, which vendors GitHub's official Dependabot schema):

```
.github/dependabot.yml::$.updates[0]: Additional properties are not allowed ('cooldown-days' was unexpected)
.github/dependabot.yml::$.updates[1]: Additional properties are not allowed ('cooldown-days' was unexpected)
.github/dependabot.yml::$.updates[2]: Additional properties are not allowed ('cooldown-days' was unexpected)
```

## Verification — is the check up to date or a stale schema?

I verified the check is **not** failing due to an outdated schema — `cooldown-days` is genuinely invalid:

- The valid form per the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown) is a `cooldown` object (`default-days`, `semver-major-days`, etc.).
- Validated the fix against **both** schema versions:
  - `check-jsonschema 0.33.0` — the version currently pinned on `main` → `ok`
  - `check-jsonschema 0.37.2` — the version #132 bumps to → `ok`

So the original config was invalid under the current pin too; #132's hook bump just surfaces it more consistently.

## Change

```diff
-  cooldown-days: 7
+  cooldown:
+    default-days: 7
```

Applied to all three ecosystems (pip, github-actions, docker). Also dropped the dead `dependabot.com/docs/config-file/` link from the header comment.

https://claude.ai/code/session_01EQYj1AE7onKSgyJVtcBzXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQYj1AE7onKSgyJVtcBzXy)_