### PR TITLE
drop pymumps as a dependency

### DIFF
--- a/python/xt/setup.py.in
+++ b/python/xt/setup.py.in
@@ -32,7 +32,7 @@ extras_require = {
                      'cmake_format==0.4.1', 'codecov', 'yapf==0.32',
                      'pytest-notebook==0.8.0', 'notebook',
                      'jinja2', 'pytest-cov', 'docutils', 'hypothesis', "codecov"] + visualization_packages + docs_packages,
-  'parallel': ('bokeh', 'pymumps', 'metis'),
+  'parallel': ('bokeh', 'metis'),
 }
 
 if '${HAVE_MPI}' == 'TRUE':


### PR DESCRIPTION
Rebases #57 onto current main.

Removes `pymumps` from the `parallel` extras in `python/xt/setup.py.in`, as discussed in #24.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZPh9QLKR4Vatzs4d6i2nn)_