### PR TITLE
fmatrix: document why disabled operator* overloads stay removed (#107)

### DIFF
--- a/dune/xt/common/fmatrix-2.7.hh
+++ b/dune/xt/common/fmatrix-2.7.hh
@@ -182,22 +182,27 @@ public:
     return result;
   }
 
-  /** \brief Matrix-matrix multiplication
+  /** \brief Matrix-matrix multiplication with a Dune::FieldMatrix on the right.
+   *
+   * Intentionally *not* provided (see https://github.com/dune-gdt/dune-gdt/issues/107).
+   *
+   * Since dune-common 2.9, Dune::FieldMatrix provides generic hidden-friend operator* overloads for any
+   * static-size, non-FieldMatrix matrix on either side:
+   *     friend auto operator*(const FieldMatrix&, const OtherMatrix&);
+   *     friend auto operator*(const OtherMatrix&, const FieldMatrix&);
+   * both constrained by (Impl::IsStaticSizeMatrix_v<OtherMatrix> && !Impl::IsFieldMatrix_v<OtherMatrix>).
+   * This XT::Common::FieldMatrix satisfies that constraint: it inherits the static rows/cols members from
+   * Dune::FieldMatrix (so IsStaticSizeMatrix is true), but it is a *derived* type, not Dune::FieldMatrix
+   * itself (and IsFieldMatrix matches the exact type only, so IsFieldMatrix is false).
+   *
+   * As a consequence dune-common already handles `XT::Common::FieldMatrix * Dune::FieldMatrix` (returning a
+   * Dune::FieldMatrix, which converts back to XT::Common::FieldMatrix where needed). Re-adding an own
+   *     friend auto operator*(const ThisType&, const Dune::FieldMatrix<OtherScalar, COLS, otherCols>&)
+   * here is an equally good match as dune-common's `operator*(const OtherMatrix&, const FieldMatrix&)` and
+   * makes that expression an ambiguous call. The `XT::Common::FieldMatrix * XT::Common::FieldMatrix` overload
+   * below is still required (and unambiguous) because there dune-common's two generic friends would otherwise
+   * tie.
    */
-  // template <class OtherScalar, int otherCols>
-  // friend auto operator*(const ThisType& matrixA, const Dune::FieldMatrix<OtherScalar, COLS, otherCols>& matrixB)
-  // {
-  //   FieldMatrix<typename PromotionTraits<K, OtherScalar>::PromotedType, ROWS, otherCols> result;
-  //
-  //   for (size_type i = 0; i < matrixA.mat_rows(); ++i)
-  //     for (size_type j = 0; j < matrixB.mat_cols(); ++j) {
-  //       result[i][j] = 0;
-  //       for (size_type k = 0; k < matrixA.mat_cols(); ++k)
-  //         result[i][j] += matrixA[i][k] * matrixB[k][j];
-  //     }
-  //
-  //   return result;
-  // }
 
   template <class OtherScalar, int otherRows>
   friend auto operator*(const Dune::FieldMatrix<OtherScalar, otherRows, ROWS>& matrixA, const ThisType& matrixB)
@@ -972,7 +977,14 @@ void rightmultiply(Dune::FieldMatrix<K, L_ROWS, R_COLS>& ret,
   }
 }
 
-//! TODO enabling this leads to ambig calls, check that those are actually equivalent
+// Intentionally *not* provided (see https://github.com/dune-gdt/dune-gdt/issues/107).
+//
+// This free operator*(Dune::FieldMatrix, Dune::FieldVector) duplicates the matrix-vector product already
+// offered as a member of XT::Common::FieldMatrix (Dune::XT::Common::FieldVector operator*(const
+// Dune::FieldVector&) const, see above), so for an XT::Common::FieldMatrix both are viable and enabling it
+// leads to ambiguous calls. The member already covers the XT::Common::FieldMatrix case; use mat.mv(vec, ret)
+// for a plain Dune::FieldMatrix.
+//
 // template <class K, int rows, int cols>
 // XT::Common::FieldVector<K, rows> operator*(const Dune::FieldMatrix<K, rows, cols>& mat,
 //                                            const Dune::FieldVector<K, cols>& vec)


### PR DESCRIPTION
Closes #107.

## Summary

Investigated why the `XT::Common::FieldMatrix operator*` overloads commented out in `4232e27` ("fmatrix: disable operator* overloads") broke during the dune 2.10 / vcpkg update, and **documented why they should stay removed** rather than restoring them. The two bare commented-out blocks in `dune/xt/common/fmatrix-2.7.hh` are replaced with the rationale, so the decision is recorded in-place.

## Why the overloads broke

Since **dune-common 2.9** (carried into 2.10; absent in 2.7/2.8), `Dune::FieldMatrix` carries generic hidden-friend `operator*` overloads for *any static-size, non-FieldMatrix matrix* on either side:

```cpp
template <class OtherMatrix, std::enable_if_t<
    Impl::IsStaticSizeMatrix_v<OtherMatrix> && !Impl::IsFieldMatrix_v<OtherMatrix>, int> = 0>
friend auto operator*(const FieldMatrix& a, const OtherMatrix& b);

template <class OtherMatrix, std::enable_if_t<
    Impl::IsStaticSizeMatrix_v<OtherMatrix> && !Impl::IsFieldMatrix_v<OtherMatrix>, int> = 0>
friend auto operator*(const OtherMatrix& a, const FieldMatrix& b);
```

`XT::Common::FieldMatrix` satisfies that constraint:
- `Impl::IsStaticSizeMatrix` only checks for static `rows`/`cols` members — which the XT type **inherits** from `Dune::FieldMatrix` → **true**.
- `Impl::IsFieldMatrix` is specialized on the **exact** type `Dune::FieldMatrix<K, ROWS, COLS>` and does **not** match derived classes — the XT type is a subclass → **false**.

So for `xt_matrix * dune_matrix`, dune-common's `operator*(const OtherMatrix&, const FieldMatrix&)` (with `OtherMatrix` = the XT matrix) is an equally good exact match as the XT-provided `operator*(const ThisType&, const Dune::FieldMatrix<...>&)`, producing an **ambiguous call**. In dune 2.7/2.8 these generic friends did not exist, so the XT overload was needed and unambiguous.

### Verified with a minimal reproduction

A self-contained model (plain `g++ -std=c++17`, no dune required) that mimics the dune-common traits + the three hidden friends and the XT subclass:

- **Without** the XT `operator*(ThisType, Dune::FieldMatrix)` overload → `xt * dune` compiles, resolving to dune-common's `operator*(OtherMatrix, FieldMatrix)`.
- **With** it restored → `error: ambiguous overload for 'operator*'`, the candidates being the XT overload and dune-common's generic friend, exactly as described.

## Decision

Keep them removed:

1. **`ThisType * Dune::FieldMatrix` (matrix-matrix):** restoring it re-introduces the ambiguity above, and dune-common's own generic `operator*` already handles `XT::Common::FieldMatrix * Dune::FieldMatrix` (the result is a `Dune::FieldMatrix`, which converts back to the XT type where needed).
2. **Free `operator*(Dune::FieldMatrix, Dune::FieldVector)` (matrix-vector):** duplicates the matrix-vector product already offered as a member of `XT::Common::FieldMatrix`, so it is redundant for the XT case and caused ambiguous calls.

The `XT::Common::FieldMatrix * XT::Common::FieldMatrix` overloads are left in place — they are still required and unambiguous (without them, dune-common's two generic friends would tie).

## Changes

- `dune/xt/common/fmatrix-2.7.hh`: replaced the two commented-out blocks with explanatory comments referencing #107.

https://claude.ai/code/session_016s1ExBRkJxzpBTULUsjXFm

---
_Generated by [Claude Code](https://claude.ai/code/session_016s1ExBRkJxzpBTULUsjXFm)_