### PR TITLE
Re-enable CG-FEM and data-functions tutorials in the CI docs build (#127)

### DIFF
--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -83,14 +83,21 @@ nb_execution_raise_on_error = False
 #   vector), there is no MatrixOperator-based workaround.
 # * example__gmsh_grid.md: needs `meshio` (and a gmsh v2 mesh) for pymor's
 #   `discretize_gmsh`; the runners ship gmsh v4, which dune-grid cannot read.
+# * example__ipdg_heat_equation.md: its assembly was migrated to the `BilinearForm`
+#   + `append` API (and that part executes fine), but the time-stepping cells form
+#   `m_h + dt*a_h`, i.e. a `GDT::LincombOperator`, whose pybind type is not registered
+#   ("Unregistered type ... LincombOperator" / "Could not activate keep_alive!"). The
+#   migration is kept so that only the LincombOperator registration remains to re-enable.
 #
-# The CG/IPDG FEM tutorials, the data-functions tutorial and the IPDG heat equation
-# example were re-enabled by migrating their bodies to the `BilinearForm` + `append`
-# assembly API. Tracked in #127 (blocked on #126).
+# The CG-FEM tutorial and the data-functions tutorial were re-enabled: the former by
+# migrating its assembly cells to the `BilinearForm` + `append` API, the latter
+# unchanged (it already relied solely on the migrated discretize_elliptic_cg helper).
+# Tracked in #127 (blocked on #126).
 nb_execution_excludepatterns = [
     "*example__ESV2007_estimates.md",
     "*example__MNS2002_estimates.md",
     "*example__gmsh_grid.md",
+    "*example__ipdg_heat_equation.md",
     "*example__prolongations_products_and_norms.md",
 ]
 

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -64,19 +64,33 @@ nb_execution_show_tb = True
 # and emit a warning (with traceback) for each failure. The CI job fails the build
 # if any executed notebook wrote an error report (see non_docker_build.yml).
 nb_execution_raise_on_error = False
-# These notebooks (and the helper-free tutorials) still rely on dune-gdt python
-# bindings that are currently commented out in the C++ sources (direct
-# `MatrixOperator += local_form`, `BilinearForm.result`/`apply2`, the
-# oswald/IPDG-flux-reconstruction operators). They are restored and rendered, but
-# not executed, until the bindings are restored / the notebooks are migrated to the
-# current API. Tracked in #127 (blocked on #126).
+# The remaining notebooks still rely on dune-gdt python bindings that are currently
+# commented out in the C++ sources. They are restored and rendered, but not executed,
+# until those bindings are restored (tracked in #126) -- migrating the notebook bodies
+# to the current two-level assembly API is not sufficient here, because the required
+# functionality has no python-exposed replacement:
+#
+# * example__MNS2002_estimates.md: the local-indicator assembly uses the generic
+#   `Operator += LocalElement/IntersectionBilinearFormIndicatorOperator`, whose
+#   `__iadd__`/`append` overloads are commented out in operators/operator.cc (only the
+#   `apply` methods are bound).
+# * example__ESV2007_estimates.md: same generic `Operator +=` blocker, plus
+#   `oswald_interpolation` and `LaplaceIpdgFluxReconstructionOperator` expose no symbols
+#   (their bindings are guarded by `#if 0`).
+# * example__prolongations_products_and_norms.md: evaluates `a(u, u)` for analytical
+#   grid functions via `BilinearForm(grid, u, u)` + `.result`/`.apply2`, all commented
+#   out in operators/bilinear-form.cc. As the operands are grid functions (no DoF
+#   vector), there is no MatrixOperator-based workaround.
+# * example__gmsh_grid.md: needs `meshio` (and a gmsh v2 mesh) for pymor's
+#   `discretize_gmsh`; the runners ship gmsh v4, which dune-grid cannot read.
+#
+# The CG/IPDG FEM tutorials, the data-functions tutorial and the IPDG heat equation
+# example were re-enabled by migrating their bodies to the `BilinearForm` + `append`
+# assembly API. Tracked in #127 (blocked on #126).
 nb_execution_excludepatterns = [
-    "*dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md",
-    "*dune_gdt_tutorial_on_data_functions_and_interpolation.md",
     "*example__ESV2007_estimates.md",
     "*example__MNS2002_estimates.md",
     "*example__gmsh_grid.md",
-    "*example__ipdg_heat_equation.md",
     "*example__prolongations_products_and_norms.md",
 ]
 

--- a/tutorials/source/dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md
+++ b/tutorials/source/dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md
@@ -286,19 +286,24 @@ Given local bilinear forms, the purpose of the `MatrixOperator` in `dune-gdt` is
 
 ```{code-cell}
 from dune.gdt import (
+    BilinearForm,
     MatrixOperator,
     make_element_sparsity_pattern,
     LocalLaplaceIntegrand,
     LocalElementIntegralBilinearForm,
 )
 
+a_form = BilinearForm(grid)
+a_form += LocalElementIntegralBilinearForm(
+        LocalLaplaceIntegrand(GF(grid, kappa, dim_range=(Dim(d), Dim(d)))))
 a_h = MatrixOperator(grid, source_space=V_h, range_space=V_h,
                      sparsity_pattern=make_element_sparsity_pattern(V_h))
-a_h += LocalElementIntegralBilinearForm(
-        LocalLaplaceIntegrand(GF(grid, kappa, dim_range=(Dim(d), Dim(d)))))
+a_h.append(a_form)
 ```
 
 A few notes regarding the above code:
+
+* we first collect all local bilinear forms in a `BilinearForm` (using `+=`) and then hand it to the `MatrixOperator` via `append`, which is the assembly API `dune-gdt` currently exposes: the `BilinearForm` describes *what* to assemble, the `MatrixOperator` *where* (into which matrix and sparsity pattern)
 
 * the `LocalLaplaceIntegrand` expects a matrix-valued function, which we achieve by converting the scalar function `kappa` to a matrix-valued `GridFunction`
 
@@ -495,10 +500,12 @@ l_h = VectorFunctional(grid, source_space=V_h)
 l_h += LocalElementIntegralFunctional(
         LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(GF(grid, f)))
 
+a_form = BilinearForm(grid)
+a_form += LocalElementIntegralBilinearForm(
+        LocalLaplaceIntegrand(GF(grid, kappa, dim_range=(Dim(d), Dim(d)))))
 a_h = MatrixOperator(grid, source_space=V_h, range_space=V_h,
                      sparsity_pattern=make_element_sparsity_pattern(V_h))
-a_h += LocalElementIntegralBilinearForm(
-        LocalLaplaceIntegrand(GF(grid, kappa, dim_range=(Dim(d), Dim(d)))))
+a_h.append(a_form)
 
 walker = Walker(grid)
 walker.append(a_h)

--- a/tutorials/source/example__ipdg_heat_equation.md
+++ b/tutorials/source/example__ipdg_heat_equation.md
@@ -71,6 +71,7 @@ from dune.xt.grid import (
 )
 
 from dune.gdt import (
+    BilinearForm,
     DiscontinuousLagrangeSpace,
     DiscreteFunction,
     LocalElementIntegralBilinearForm,
@@ -99,22 +100,27 @@ penalty_parameter = 16
 symmetry_factor = 1
 
 sp = make_element_and_intersection_sparsity_pattern(V_h)
+
+m_form = BilinearForm(grid)
+m_form += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
 m_h = MatrixOperator(grid, source_space=V_h, range_space=V_h, sparsity_pattern=sp)
-m_h += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+m_h.append(m_form)
 
 l_h = VectorFunctional(grid, V_h)
 l_h += LocalElementIntegralFunctional(LocalElementProductIntegrand(GF(grid, 1)).with_ansatz(source))
 
+a_form = BilinearForm(grid)
+a_form += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+a_form += (LocalCouplingIntersectionIntegralBilinearForm(
+               LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
+               + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)),
+           ApplyOnInnerIntersectionsOnce(grid))
+a_form += (LocalIntersectionIntegralBilinearForm(
+               LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
+               + LocalLaplaceIPDGDirichletCouplingIntegrand(symmetry_factor, diffusion)),
+           ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()))
 a_h = MatrixOperator(grid, source_space=V_h, range_space=V_h, sparsity_pattern=sp)
-a_h += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
-a_h += (LocalCouplingIntersectionIntegralBilinearForm(
-            LocalLaplaceIPDGInnerCouplingIntegrand(symmetry_factor, diffusion, weight)
-            + LocalIPDGInnerPenaltyIntegrand(penalty_parameter, weight)),
-        {}, ApplyOnInnerIntersectionsOnce(grid))
-a_h += (LocalIntersectionIntegralBilinearForm(
-            LocalIPDGBoundaryPenaltyIntegrand(penalty_parameter, weight)
-            + LocalLaplaceIPDGDirichletCouplingIntegrand(symmetry_factor, diffusion)),
-       {}, ApplyOnCustomBoundaryIntersections(grid, boundary_info, DirichletBoundary()))
+a_h.append(a_form)
 
 walker = Walker(grid)
 walker.append(m_h)


### PR DESCRIPTION
Follow-up to #127 (which follows #41). Re-enables execution of the tutorial notebooks that the CI `build_tutorials` job can actually run today, by migrating their bodies to the supported two-level assembly API (`BilinearForm` + `MatrixOperator.append`) where needed — the same pattern the `discretize_elliptic_*` helpers already use.

## Re-enabled (verified green in CI — removed from `nb_execution_excludepatterns`)

- **`dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md`** — migrated both assembly cells to `BilinearForm` + `append`; added a short note explaining the two-level API.
- **`dune_gdt_tutorial_on_data_functions_and_interpolation.md`** — no code change. It already relied solely on the migrated `discretize_elliptic_cg_dirichlet_zero` helper and `default_interpolation`; un-excluded as-is.

## Still deferred (excluded from execution) — all blocked on disabled C++ bindings (#126)

These cannot be fixed by notebook-level migration; the required functionality has no python-exposed replacement:

| Notebook | Blocker (verified in C++ sources / CI) |
|---|---|
| `example__ipdg_heat_equation.md` | assembly **was** migrated to `BilinearForm` + `append` (executes fine), but the time-stepping forms `m_h + dt*a_h`, a `GDT::LincombOperator` whose pybind type is **not registered** (CI: `Unregistered type … LincombOperator` / `Could not activate keep_alive!`). Migration kept so only the LincombOperator registration remains. |
| `example__MNS2002_estimates.md` | local-indicator assembly uses the **generic `Operator +=`/`append`**, commented out in `operators/operator.cc` (only `apply` is bound). |
| `example__ESV2007_estimates.md` | same generic `Operator +=` blocker, **plus** `oswald_interpolation` and `LaplaceIpdgFluxReconstructionOperator` expose no symbols (guarded by `#if 0`). |
| `example__prolongations_products_and_norms.md` | evaluates `a(u, u)` for **analytical grid functions** via the disabled `BilinearForm(grid, u, u)` + `.result`/`.apply2`; operands have no DoF vector, so no `MatrixOperator`-based workaround. |
| `example__gmsh_grid.md` | needs `meshio` **and** a gmsh v2 mesh for pymor's `discretize_gmsh`; the runners ship gmsh v4, which `dune-grid` cannot read. |

The `conf.py` comment documents the precise per-notebook blocker. CI's pip install is intentionally left unchanged (no `meshio`), since that package is only useful once `example__gmsh_grid.md` is itself re-enabled.

## Verification

The bindings aren't built in this environment, so CI's `build_tutorials` job is the verification path. The first CI run confirmed the two re-enabled notebooks execute cleanly and surfaced the `ipdg_heat` `LincombOperator` blocker, which prompted re-deferring that one.

Refs #127, #126