### PR TITLE
Add standalone nanobench benchmarks for e2e solves

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,133 @@
+---
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Only one benchmark run at a time; do not cancel an in-progress run (we want every push to main
+# to produce a report).
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  # required to push the JSON reports onto the `benchmarks` branch
+  contents: write
+
+jobs:
+  benchmarks:
+    name: Build and run benchmarks (Release)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-tags: true
+        fetch-depth: 0
+
+    - name: Restore build cache
+      uses: actions/cache/restore@v3
+      with:
+        # See non_docker_build.yml: the vcpkg toolchain in .vcpkg-root must be cached together with
+        # build/, otherwise the restored CMake config points at a toolchain that no longer exists.
+        path: |
+          build
+          .vcpkg-root
+        key: ${{ runner.os }}-bench-release-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+        restore-keys: |
+          ${{ runner.os }}-bench-release-
+
+    - name: Drop stale build cache if vcpkg toolchain is missing
+      run: |
+        if [ -d build ] && [ ! -f .vcpkg-root/scripts/buildsystems/vcpkg.cmake ]; then
+          echo "Restored build/ but .vcpkg-root toolchain is missing; clearing stale" \
+               "build/ so CMake re-bootstraps vcpkg from scratch."
+          rm -rf build
+        fi
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build
+
+    - name: Configure CMake
+      id: configure_cmake
+      run: cmake --preset=release
+
+    - name: Build benchmarks
+      run: cmake --build --preset=release --target benchmarks --parallel
+
+    - name: Save build cache
+      if: ${{ success() && steps.configure_cmake.outcome == 'success' }}
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          build
+          .vcpkg-root
+        key: ${{ runner.os }}-bench-release-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+
+    - name: Run benchmarks
+      run: cmake --build --preset=release --target run_benchmarks
+
+    - name: Upload benchmark reports artifact
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: benchmark-reports
+        path: build/release/benchmarks/reports/*.json
+        if-no-files-found: error
+
+    - name: Publish reports to the benchmarks branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        reports_src="${GITHUB_WORKSPACE}/build/release/benchmarks/reports"
+        if ! ls "${reports_src}"/*.json >/dev/null 2>&1; then
+          echo "::error::no benchmark reports found in ${reports_src}"
+          exit 1
+        fi
+        ts="$(date -u +%Y%m%d-%H%M%S)"
+        sha="$(git rev-parse --short HEAD)"
+        remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        work="$(mktemp -d)"
+        # check out the existing benchmarks branch, or start a fresh orphan branch
+        if git ls-remote --exit-code --heads "${remote}" benchmarks >/dev/null 2>&1; then
+          git clone --depth 1 --branch benchmarks "${remote}" "${work}"
+          cd "${work}"
+        else
+          git clone --depth 1 "${remote}" "${work}"
+          cd "${work}"
+          git checkout --orphan benchmarks
+          git rm -rf . >/dev/null 2>&1 || true
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        dest="reports/${ts}-${sha}"
+        mkdir -p "${dest}" "reports/latest"
+        cp "${reports_src}"/*.json "${dest}/"
+        rm -f reports/latest/*.json
+        cp "${reports_src}"/*.json "reports/latest/"
+        git add reports
+        if git diff --cached --quiet; then
+          echo "no changes to commit"
+          exit 0
+        fi
+        git commit -m "benchmark reports for ${sha} (${ts} UTC)"
+        n=0
+        until [ "${n}" -ge 4 ]; do
+          if git push "${remote}" benchmarks; then
+            break
+          fi
+          n=$((n + 1))
+          echo "push failed, retry ${n} ..."
+          sleep "$((2 ** n))"
+        done
+        if [ "${n}" -ge 4 ]; then
+          echo "::error::failed to push benchmark reports after retries"
+          exit 1
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ __pycache__
 dune/xt/test/gtest/lib
 data
 !dune/xt/data
+!dune/gdt/data
 .libs
 *.o
 *.la

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ add_header_listing()
 add_subdirectory(dune)
 add_subdirectory("cmake/modules")
 add_subdirectory(examples)
+add_subdirectory(benchmarks)
 add_subdirectory(tutorials)
 
 add_tidy(${CMAKE_CURRENT_SOURCE_DIR})

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -10,14 +10,11 @@
 # nanobench is a single-header micro-benchmarking library, pulled in via vcpkg (see vcpkg.json).
 find_package(nanobench CONFIG REQUIRED)
 
-# Any C++ file dropped into this directory is automatically built as a standalone benchmark
-# executable named bench_<filename>. The benchmarks are plain `int main()` programs (no gtest, no
-# CTest registration) that drive the public dune-gdt API and emit nanobench JSON reports.
-file(
-  GLOB_RECURSE benchmark_sources
-  CONFIGURE_DEPENDS
-  "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
-  "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
+# Any C++ file dropped into this directory is automatically built as a standalone benchmark executable named
+# bench_<filename>. The benchmarks are plain `int main()` programs (no gtest, no CTest registration) that drive the
+# public dune-gdt API and emit nanobench JSON reports.
+file(GLOB_RECURSE benchmark_sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
 
 set(benchmark_targets)
 set(benchmark_report_dir "${CMAKE_BINARY_DIR}/benchmarks/reports")
@@ -25,8 +22,8 @@ set(benchmark_report_dir "${CMAKE_BINARY_DIR}/benchmarks/reports")
 foreach(source ${benchmark_sources})
   get_filename_component(_name ${source} NAME_WE)
   set(_target "bench_${_name}")
-  # EXCLUDE_FROM_ALL: benchmarks are only built on demand (target `benchmarks`), never as part of
-  # the default build or the test binaries.
+  # EXCLUDE_FROM_ALL: benchmarks are only built on demand (target `benchmarks`), never as part of the default build or
+  # the test binaries.
   add_executable(${_target} EXCLUDE_FROM_ALL ${source})
   dune_target_enable_all_packages(${_target})
   target_link_libraries(${_target} PRIVATE dunext ${GRID_LIBS} nanobench::nanobench)
@@ -39,12 +36,19 @@ add_custom_target(
   DEPENDS ${benchmark_targets}
   COMMENT "Build all dune-gdt benchmarks")
 
-# `run_benchmarks`: build, then run every benchmark, writing one <name>.json nanobench report per
-# benchmark into ${benchmark_report_dir}.
+# `run_benchmarks`: build, then run every benchmark, writing one <name>.json nanobench report per benchmark into
+# ${benchmark_report_dir}.
 set(_run_commands COMMAND ${CMAKE_COMMAND} -E make_directory ${benchmark_report_dir})
 foreach(_target ${benchmark_targets})
-  list(APPEND _run_commands COMMAND ${CMAKE_COMMAND} -E env
-       "DUNE_GDT_BENCHMARK_OUTPUT_DIR=${benchmark_report_dir}" $<TARGET_FILE:${_target}>)
+  list(
+    APPEND
+    _run_commands
+    COMMAND
+    ${CMAKE_COMMAND}
+    -E
+    env
+    "DUNE_GDT_BENCHMARK_OUTPUT_DIR=${benchmark_report_dir}"
+    $<TARGET_FILE:${_target}>)
 endforeach()
 add_custom_target(
   run_benchmarks

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -16,8 +16,8 @@ find_package(nanobench CONFIG REQUIRED)
 file(GLOB_RECURSE benchmark_sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
      "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
 
-set(benchmark_targets)
-set(benchmark_report_dir "${CMAKE_BINARY_DIR}/benchmarks/reports")
+set(_benchmark_targets)
+set(_benchmark_report_dir "${CMAKE_BINARY_DIR}/benchmarks/reports")
 
 foreach(source ${benchmark_sources})
   get_filename_component(_name ${source} NAME_WE)
@@ -27,19 +27,19 @@ foreach(source ${benchmark_sources})
   add_executable(${_target} EXCLUDE_FROM_ALL ${source})
   dune_target_enable_all_packages(${_target})
   target_link_libraries(${_target} PRIVATE dunext ${GRID_LIBS} nanobench::nanobench)
-  list(APPEND benchmark_targets ${_target})
+  list(APPEND _benchmark_targets ${_target})
 endforeach()
 
 # `benchmarks`: build every benchmark executable.
 add_custom_target(
   benchmarks
-  DEPENDS ${benchmark_targets}
+  DEPENDS ${_benchmark_targets}
   COMMENT "Build all dune-gdt benchmarks")
 
 # `run_benchmarks`: build, then run every benchmark, writing one <name>.json nanobench report per benchmark into
-# ${benchmark_report_dir}.
-set(_run_commands COMMAND ${CMAKE_COMMAND} -E make_directory ${benchmark_report_dir})
-foreach(_target ${benchmark_targets})
+# ${_benchmark_report_dir}.
+set(_run_commands COMMAND ${CMAKE_COMMAND} -E make_directory ${_benchmark_report_dir})
+foreach(target ${_benchmark_targets})
   list(
     APPEND
     _run_commands
@@ -47,12 +47,12 @@ foreach(_target ${benchmark_targets})
     ${CMAKE_COMMAND}
     -E
     env
-    "DUNE_GDT_BENCHMARK_OUTPUT_DIR=${benchmark_report_dir}"
-    $<TARGET_FILE:${_target}>)
+    "DUNE_GDT_BENCHMARK_OUTPUT_DIR=${_benchmark_report_dir}"
+    $<TARGET_FILE:${target}>)
 endforeach()
 add_custom_target(
   run_benchmarks
   ${_run_commands}
   DEPENDS benchmarks
   USES_TERMINAL
-  COMMENT "Run all dune-gdt benchmarks and write nanobench JSON reports to ${benchmark_report_dir}")
+  COMMENT "Run all dune-gdt benchmarks and write nanobench JSON reports to ${_benchmark_report_dir}")

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,54 @@
+# ~~~
+# This file is part of the dune-gdt project:
+#   https://github.com/dune-community/dune-gdt
+# Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# ~~~
+
+# nanobench is a single-header micro-benchmarking library, pulled in via vcpkg (see vcpkg.json).
+find_package(nanobench CONFIG REQUIRED)
+
+# Any C++ file dropped into this directory is automatically built as a standalone benchmark
+# executable named bench_<filename>. The benchmarks are plain `int main()` programs (no gtest, no
+# CTest registration) that drive the public dune-gdt API and emit nanobench JSON reports.
+file(
+  GLOB_RECURSE benchmark_sources
+  CONFIGURE_DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
+
+set(benchmark_targets)
+set(benchmark_report_dir "${CMAKE_BINARY_DIR}/benchmarks/reports")
+
+foreach(source ${benchmark_sources})
+  get_filename_component(_name ${source} NAME_WE)
+  set(_target "bench_${_name}")
+  # EXCLUDE_FROM_ALL: benchmarks are only built on demand (target `benchmarks`), never as part of
+  # the default build or the test binaries.
+  add_executable(${_target} EXCLUDE_FROM_ALL ${source})
+  dune_target_enable_all_packages(${_target})
+  target_link_libraries(${_target} PRIVATE dunext ${GRID_LIBS} nanobench::nanobench)
+  list(APPEND benchmark_targets ${_target})
+endforeach()
+
+# `benchmarks`: build every benchmark executable.
+add_custom_target(
+  benchmarks
+  DEPENDS ${benchmark_targets}
+  COMMENT "Build all dune-gdt benchmarks")
+
+# `run_benchmarks`: build, then run every benchmark, writing one <name>.json nanobench report per
+# benchmark into ${benchmark_report_dir}.
+set(_run_commands COMMAND ${CMAKE_COMMAND} -E make_directory ${benchmark_report_dir})
+foreach(_target ${benchmark_targets})
+  list(APPEND _run_commands COMMAND ${CMAKE_COMMAND} -E env
+       "DUNE_GDT_BENCHMARK_OUTPUT_DIR=${benchmark_report_dir}" $<TARGET_FILE:${_target}>)
+endforeach()
+add_custom_target(
+  run_benchmarks
+  ${_run_commands}
+  DEPENDS benchmarks
+  USES_TERMINAL
+  COMMENT "Run all dune-gdt benchmarks and write nanobench JSON reports to ${benchmark_report_dir}")

--- a/benchmarks/benchmark_common.hh
+++ b/benchmarks/benchmark_common.hh
@@ -1,0 +1,59 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#ifndef DUNE_GDT_BENCHMARKS_BENCHMARK_COMMON_HH
+#define DUNE_GDT_BENCHMARKS_BENCHMARK_COMMON_HH
+
+#include <cstdlib>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+// The benchmarks are standalone executables (one translation unit each), so it is safe to emit
+// the nanobench implementation here in the single header every benchmark includes.
+#define ANKERL_NANOBENCH_IMPLEMENT
+#include <nanobench.h>
+
+namespace Dune {
+namespace GDT {
+namespace Benchmark {
+
+
+/**
+ * \brief Create a nanobench Bench tuned for heavy (multi-millisecond to multi-second) PDE solves.
+ *
+ * We keep the iteration count low because a single run of an e2e solve already dominates the
+ * measurement; nanobench would otherwise try to accumulate many iterations per epoch.
+ */
+inline ankerl::nanobench::Bench make_bench(const std::string& title)
+{
+  ankerl::nanobench::Bench bench;
+  bench.title(title).warmup(0).epochs(3).minEpochIterations(1);
+  return bench;
+}
+
+
+/**
+ * \brief Render the nanobench results as JSON to ${DUNE_GDT_BENCHMARK_OUTPUT_DIR}/<name>.json
+ *        (or ./<name>.json if the environment variable is unset).
+ */
+inline void write_report(const ankerl::nanobench::Bench& bench, const std::string& name)
+{
+  const char* dir = std::getenv("DUNE_GDT_BENCHMARK_OUTPUT_DIR");
+  const std::string path = (dir && dir[0] != '\0' ? std::string(dir) + "/" : std::string()) + name + ".json";
+  std::ofstream out(path);
+  if (!out)
+    throw std::runtime_error("failed to open benchmark report file for writing: " + path);
+  ankerl::nanobench::render(ankerl::nanobench::templates::json(), bench, out);
+}
+
+
+} // namespace Benchmark
+} // namespace GDT
+} // namespace Dune
+
+#endif // DUNE_GDT_BENCHMARKS_BENCHMARK_COMMON_HH

--- a/benchmarks/burgers__1d__explicit__fv.cpp
+++ b/benchmarks/burgers__1d__explicit__fv.cpp
@@ -1,0 +1,78 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+//
+// Standalone benchmark (no gtest / no test harness) of the 1d Burgers equation solved with an
+// explicit-Euler finite-volume scheme and an upwind numerical flux. Mirrors the computation in
+// dune/gdt/test/burgers/ but reuses only the shared, gtest-free problem data.
+
+#include "config.h"
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <dune/xt/common/parallel/threadmanager.hh>
+#include <dune/xt/grid/filters/intersection.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/grid/view/periodic.hh>
+#include <dune/xt/la/container/istl.hh>
+
+#include <dune/gdt/data/burgers.hh>
+#include <dune/gdt/local/numerical-fluxes/upwind.hh>
+#include <dune/gdt/operators/advection-fv.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+#include <dune/gdt/tools/hyperbolic.hh>
+
+#include "benchmark_common.hh"
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+int main(int argc, char** argv)
+{
+  MPIHelper::instance(argc, argv);
+  XT::Common::threadManager().set_max_threads(1);
+
+  using G = YASP_1D_EQUIDISTANT_OFFSET;
+  static constexpr size_t d = G::dimension;
+  static constexpr size_t m = 1;
+  using R = double;
+  using M = XT::LA::IstlRowMajorSparseMatrix<R>;
+  using V = XT::LA::IstlDenseVector<R>;
+
+  const Data::BurgersProblem<G> problem;
+  auto grid = problem.make_initial_grid();
+  grid.global_refine(6); // ~16 * 2^6 = 1024 cells, enough work for a meaningful measurement
+
+  auto periodic_grid_view = XT::Grid::make_periodic_grid_layer(grid.leaf_view());
+  using GV = decltype(periodic_grid_view);
+  using I = XT::Grid::extract_intersection_t<GV>;
+
+  const FiniteVolumeSpace<GV, m> space(periodic_grid_view);
+  const auto u_0 = problem.template make_initial_values<V>(space);
+
+  const NumericalUpwindFlux<I, d, m> numerical_flux(problem.flux);
+  AdvectionFvOperator<GV, m, R, M> op(
+      space.grid_view(), numerical_flux, space, space, XT::Grid::ApplyOn::NoIntersections<GV>());
+  op.assemble();
+
+  const double T_end = problem.T_end;
+  const double dt = 0.99 * estimate_dt_for_hyperbolic_system(space.grid_view(), u_0, problem.flux);
+
+  auto bench = Benchmark::make_bench("burgers__1d__explicit__fv");
+  bench.run("explicit_euler__upwind", [&]() {
+    auto u = u_0.dofs().vector();
+    double time = 0.;
+    while (time < T_end) {
+      u -= op.apply(u, {{"_t", {time}}, {"_dt", {dt}}}) * dt;
+      time += dt;
+    }
+    ankerl::nanobench::doNotOptimizeAway(u);
+  });
+  Benchmark::write_report(bench, "burgers__1d__explicit__fv");
+
+  return 0;
+}

--- a/benchmarks/stationary_heat_equation__ESV2007.cpp
+++ b/benchmarks/stationary_heat_equation__ESV2007.cpp
@@ -1,0 +1,121 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+//
+// Standalone benchmark (no gtest / no test harness) of the stationary heat equation (ESV2007
+// testcase) discretized with a p1 SIPDG scheme. Times the assembly of the IPDG system plus the
+// linear solve. Mirrors dune/gdt/test/stationary-heat-equation/ but reuses only the shared,
+// gtest-free problem data.
+
+#include "config.h"
+
+#include <functional>
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <dune/xt/common/parallel/threadmanager.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/grid/boundaryinfo/types.hh>
+#include <dune/xt/grid/filters/intersection.hh>
+#include <dune/xt/grid/walker.hh>
+#include <dune/xt/la/container/istl.hh>
+#include <dune/xt/la/solver.hh>
+
+#include <dune/gdt/data/stationary_heat_equation.hh>
+#include <dune/gdt/functionals/vector-based.hh>
+#include <dune/gdt/local/bilinear-forms/integrals.hh>
+#include <dune/gdt/local/functionals/integrals.hh>
+#include <dune/gdt/local/integrands/ipdg.hh>
+#include <dune/gdt/local/integrands/laplace.hh>
+#include <dune/gdt/local/integrands/laplace-ipdg.hh>
+#include <dune/gdt/local/integrands/product.hh>
+#include <dune/gdt/operators/bilinear-form.hh>
+#include <dune/gdt/operators/matrix.hh>
+#include <dune/gdt/spaces/l2/discontinuous-lagrange.hh>
+
+#include "benchmark_common.hh"
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+#if HAVE_DUNE_ALUGRID
+
+int main(int argc, char** argv)
+{
+  MPIHelper::instance(argc, argv);
+  XT::Common::threadManager().set_max_threads(1);
+
+  using G = ALU_2D_SIMPLEX_CONFORMING;
+  using GV = typename G::LeafGridView;
+  static constexpr size_t d = G::dimension;
+  using E = XT::Grid::extract_entity_t<GV>;
+  using I = XT::Grid::extract_intersection_t<GV>;
+  using M = XT::LA::IstlRowMajorSparseMatrix<double>;
+  using V = XT::LA::IstlDenseVector<double>;
+
+  // SIPDG parameters as used by the ESV2007 testcase
+  const double inner_penalty = 8.;
+  const double dirichlet_penalty = 14.;
+  const std::function<double(const I&)> intersection_diameter = [](const I& intersection) {
+    return intersection.geometry().volume();
+  };
+
+  const Data::ESV2007DiffusionProblem<GV> problem(/*force_order=*/2);
+  auto grid = problem.make_initial_grid();
+  grid.global_refine(2); // extra refinement on top of the testcase grid for a meaningful workload
+  const GV grid_view = grid.leaf_view();
+
+  const DiscontinuousLagrangeSpace<GV> space(grid_view, /*order=*/1);
+
+  auto bench = Benchmark::make_bench("stationary_heat_equation__ESV2007");
+  bench.run("sipdg_p1__assemble_and_solve", [&]() {
+    // assemble the SIPDG bilinear form (weight == diffusion)
+    auto lhs = make_bilinear_form(space.grid_view());
+    lhs += LocalElementIntegralBilinearForm<E>(LocalLaplaceIntegrand<E>(problem.diffusion));
+    lhs += {LocalCouplingIntersectionIntegralBilinearForm<I>(
+                LocalLaplaceIPDGIntegrands::InnerCoupling<I>(1., problem.diffusion, problem.diffusion)),
+            XT::Grid::ApplyOn::InnerIntersectionsOnce<GV>()};
+    lhs += {LocalCouplingIntersectionIntegralBilinearForm<I>(
+                LocalIPDGIntegrands::InnerPenalty<I>(inner_penalty, problem.diffusion, intersection_diameter)),
+            XT::Grid::ApplyOn::InnerIntersectionsOnce<GV>()};
+    lhs += {LocalIntersectionIntegralBilinearForm<I>(
+                LocalLaplaceIPDGIntegrands::DirichletCoupling<I>(1., problem.diffusion)),
+            XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info,
+                                                              new XT::Grid::DirichletBoundary())};
+    lhs += {LocalIntersectionIntegralBilinearForm<I>(
+                LocalIPDGIntegrands::BoundaryPenalty<I>(dirichlet_penalty, problem.diffusion, intersection_diameter)),
+            XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info,
+                                                              new XT::Grid::DirichletBoundary())};
+    auto matrix_op = make_matrix_operator<M>(space);
+    matrix_op.append(lhs);
+    // assemble the right hand side functional
+    auto rhs_func = make_vector_functional<V>(space);
+    rhs_func.append(LocalElementIntegralFunctional<E>(LocalProductIntegrand<E>().with_ansatz(problem.force)));
+    // assemble everything in one grid walk
+    auto walker = XT::Grid::make_walker(space.grid_view());
+    walker.append(matrix_op);
+    walker.append(rhs_func);
+    walker.walk(/*parallel=*/false);
+    // solve the linear system
+    V solution(space.mapper().size(), 0.);
+    XT::LA::make_solver(matrix_op.matrix()).apply(rhs_func.vector(), solution);
+    ankerl::nanobench::doNotOptimizeAway(solution);
+  });
+  Benchmark::write_report(bench, "stationary_heat_equation__ESV2007");
+
+  return 0;
+}
+
+#else // HAVE_DUNE_ALUGRID
+
+int main()
+{
+  // The ESV2007 benchmark requires a simplex grid (dune-alugrid); nothing to do otherwise.
+  return 0;
+}
+
+#endif // HAVE_DUNE_ALUGRID

--- a/benchmarks/stationary_heat_equation__ESV2007.cpp
+++ b/benchmarks/stationary_heat_equation__ESV2007.cpp
@@ -82,14 +82,14 @@ int main(int argc, char** argv)
     lhs += {LocalCouplingIntersectionIntegralBilinearForm<I>(
                 LocalIPDGIntegrands::InnerPenalty<I>(inner_penalty, problem.diffusion, intersection_diameter)),
             XT::Grid::ApplyOn::InnerIntersectionsOnce<GV>()};
-    lhs += {LocalIntersectionIntegralBilinearForm<I>(
-                LocalLaplaceIPDGIntegrands::DirichletCoupling<I>(1., problem.diffusion)),
-            XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info,
-                                                              new XT::Grid::DirichletBoundary())};
-    lhs += {LocalIntersectionIntegralBilinearForm<I>(
-                LocalIPDGIntegrands::BoundaryPenalty<I>(dirichlet_penalty, problem.diffusion, intersection_diameter)),
-            XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info,
-                                                              new XT::Grid::DirichletBoundary())};
+    lhs +=
+        {LocalIntersectionIntegralBilinearForm<I>(
+             LocalLaplaceIPDGIntegrands::DirichletCoupling<I>(1., problem.diffusion)),
+         XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info, new XT::Grid::DirichletBoundary())};
+    lhs +=
+        {LocalIntersectionIntegralBilinearForm<I>(
+             LocalIPDGIntegrands::BoundaryPenalty<I>(dirichlet_penalty, problem.diffusion, intersection_diameter)),
+         XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info, new XT::Grid::DirichletBoundary())};
     auto matrix_op = make_matrix_operator<M>(space);
     matrix_op.append(lhs);
     // assemble the right hand side functional

--- a/benchmarks/stokes__taylorhood.cpp
+++ b/benchmarks/stokes__taylorhood.cpp
@@ -1,0 +1,143 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+//
+// Standalone benchmark (no gtest / no test harness) of a stationary Stokes problem discretized
+// with Taylor-Hood (P2/Q2 velocity, P1/Q1 pressure) elements and solved with a direct saddle-point
+// solver. Mirrors the assemble+solve in dune/gdt/test/stokes/ but reuses only the shared,
+// gtest-free problem data.
+
+#include "config.h"
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <dune/xt/common/parallel/threadmanager.hh>
+#include <dune/xt/grid/boundaryinfo/types.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/grid/walker.hh>
+#include <dune/xt/functions/constant.hh>
+
+#include "benchmark_common.hh"
+
+#if HAVE_DUNE_ISTL
+
+#  include <dune/xt/la/container/eigen.hh>
+#  include <dune/xt/la/container/istl.hh>
+#  include <dune/xt/la/solver/saddlepoint.hh>
+
+#  include <dune/gdt/data/stokes.hh>
+#  include <dune/gdt/discretefunction/default.hh>
+#  include <dune/gdt/functionals/vector-based.hh>
+#  include <dune/gdt/interpolations/boundary.hh>
+#  include <dune/gdt/local/bilinear-forms/integrals.hh>
+#  include <dune/gdt/local/functionals/integrals.hh>
+#  include <dune/gdt/local/integrands/conversion.hh>
+#  include <dune/gdt/local/integrands/div.hh>
+#  include <dune/gdt/local/integrands/laplace.hh>
+#  include <dune/gdt/local/integrands/product.hh>
+#  include <dune/gdt/operators/bilinear-form.hh>
+#  include <dune/gdt/operators/matrix.hh>
+#  include <dune/gdt/spaces/h1/continuous-lagrange.hh>
+#  include <dune/gdt/tools/dirichlet-constraints.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+int main(int argc, char** argv)
+{
+  MPIHelper::instance(argc, argv);
+  XT::Common::threadManager().set_max_threads(1);
+
+  using G = YASP_2D_EQUIDISTANT_OFFSET;
+  using GV = typename G::LeafGridView;
+  static constexpr size_t d = G::dimension;
+  using E = XT::Grid::extract_entity_t<GV>;
+  using I = XT::Grid::extract_intersection_t<GV>;
+  using RangeField = double;
+  using Matrix = XT::LA::EigenRowMajorSparseMatrix<double>;
+  using Vector = XT::LA::EigenDenseVector<double>;
+  using VelocitySpace = ContinuousLagrangeSpace<GV, d>;
+  using PressureSpace = ContinuousLagrangeSpace<GV, 1>;
+
+  const int velocity_order = 2;
+
+  Data::StokesDirichletProblem<GV> problem(Data::StokesDirichletProblem<GV>::default_diffusion(),
+                                           Data::StokesDirichletProblem<GV>::default_rhs_f(),
+                                           Data::StokesDirichletProblem<GV>::default_rhs_g(),
+                                           Data::stokes_testcase1_dirichlet<GV>());
+  const auto& grid_view = problem.grid_view();
+
+  auto bench = Benchmark::make_bench("stokes__taylorhood");
+  bench.run("taylor_hood_order2__assemble_and_solve", [&]() {
+    const VelocitySpace velocity_space(grid_view, velocity_order);
+    const PressureSpace pressure_space(grid_view, velocity_order - 1);
+    // bilinear form a: \int \nabla u : \nabla v
+    BilinearForm<GV, d> a(grid_view);
+    a += LocalElementIntegralBilinearForm<E, d>(LocalLaplaceIntegrand<E, d>(problem.diffusion()));
+    // bilinear form b: \int -p div(v)
+    BilinearForm<GV, 1, 1, d, 1> b(grid_view);
+    b += LocalElementIntegralBilinearForm<E, d, 1, RangeField, RangeField, 1>(
+        LocalElementAnsatzValueTestDivProductIntegrand<E>(-1.));
+    auto A = a.template with<Matrix>(velocity_space, velocity_space);
+    auto B = b.template with<Matrix>(pressure_space, velocity_space);
+    // rhs functional f
+    auto f_functional = make_vector_functional<Vector>(velocity_space);
+    f_functional.append(
+        LocalElementIntegralFunctional<E, d>(LocalProductIntegrand<E, d>().with_ansatz(problem.rhs_f())));
+    // integrated pressure basis (for fixing the pressure constant)
+    auto p_basis_integrated_functional = make_vector_functional<Vector>(pressure_space);
+    p_basis_integrated_functional.append(LocalElementIntegralFunctional<E, 1>(
+        LocalProductIntegrand<E, 1>().with_ansatz(XT::Functions::ConstantGridFunction<E>(1))));
+    // Dirichlet constraints for u
+    DirichletConstraints<I, VelocitySpace> dirichlet_constraints(problem.boundary_info(), velocity_space);
+    // assemble everything in one grid walk
+    auto walker = XT::Grid::make_walker(grid_view);
+    walker.append(A);
+    walker.append(B);
+    walker.append(f_functional);
+    walker.append(p_basis_integrated_functional);
+    walker.append(dirichlet_constraints);
+    walker.walk(/*parallel=*/false);
+    // build the right hand sides, eliminating the Dirichlet values
+    const auto discrete_dirichlet_values = boundary_interpolation<Vector>(
+        problem.dirichlet(), velocity_space, problem.boundary_info(), XT::Grid::DirichletBoundary());
+    auto rhs_vector_u = A.apply(discrete_dirichlet_values.dofs().vector());
+    rhs_vector_u *= -1.;
+    rhs_vector_u += f_functional.vector();
+    auto rhs_vector_p = B.matrix().mtv(discrete_dirichlet_values.dofs().vector());
+    rhs_vector_p *= -1;
+    dirichlet_constraints.apply(A.matrix(), rhs_vector_u);
+    for (const auto& DoF : dirichlet_constraints.dirichlet_DoFs())
+      B.matrix().clear_row(DoF);
+    // fix the pressure at the first DoF to make the solution unique
+    auto C = make_matrix_operator<Matrix>(pressure_space);
+    const size_t dof_index = 0;
+    B.matrix().clear_col(dof_index);
+    rhs_vector_p.set_entry(dof_index, 0.);
+    C.matrix().set_entry(dof_index, dof_index, 1.);
+    // solve the saddle point system with a direct solver
+    XT::LA::SaddlePointSolver<Vector, Matrix> solver(A.matrix(), B.matrix(), B.matrix(), C.matrix());
+    auto solution_u = make_discrete_function<Vector>(velocity_space);
+    auto solution_p = make_discrete_function<Vector>(pressure_space);
+    solver.apply(rhs_vector_u, rhs_vector_p, solution_u.dofs().vector(), solution_p.dofs().vector(), "direct");
+    ankerl::nanobench::doNotOptimizeAway(solution_u.dofs().vector());
+    ankerl::nanobench::doNotOptimizeAway(solution_p.dofs().vector());
+  });
+  Benchmark::write_report(bench, "stokes__taylorhood");
+
+  return 0;
+}
+
+#else // HAVE_DUNE_ISTL
+
+int main()
+{
+  // The Stokes benchmark uses the dune-istl backed saddle-point solver; nothing to do otherwise.
+  return 0;
+}
+
+#endif // HAVE_DUNE_ISTL

--- a/dune/gdt/data/burgers.hh
+++ b/dune/gdt/data/burgers.hh
@@ -1,0 +1,75 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2019)
+
+#ifndef DUNE_GDT_DATA_BURGERS_HH
+#define DUNE_GDT_DATA_BURGERS_HH
+
+#include <cmath>
+
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/interpolations/default.hh>
+#include <dune/gdt/spaces/interface.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Data {
+
+
+/**
+ * \brief Problem data for the Burgers equation \partial_t u + \partial_x (u^2 / 2) = 0.
+ *
+ * gtest-free problem definition shared by the tests in dune/gdt/test/burgers/ and the
+ * benchmarks in benchmarks/.
+ */
+template <class G>
+struct BurgersProblem
+{
+  static constexpr size_t d = G::dimension;
+  static_assert(d == 1, "Not implemented yet!");
+
+  const XT::Functions::GenericFunction<1, d, 1> flux;
+  const double T_end;
+
+  BurgersProblem()
+    : flux(
+          2,
+          [&](const auto& u, const auto& /*param*/) { return 0.5 * u * u; },
+          "burgers",
+          {},
+          [&](const auto& u, const auto& /*param*/) { return u; })
+    , T_end(1.)
+  {
+  }
+
+  XT::Grid::GridProvider<G> make_initial_grid() const
+  {
+    return XT::Grid::make_cube_grid<G>(0., 1., 16u);
+  }
+
+  template <class Vector, class GV>
+  DiscreteFunction<Vector, GV> make_initial_values(const SpaceInterface<GV, 1>& space) const
+  {
+    return default_interpolation<Vector>(
+        3,
+        [&](const auto& xx, const auto& /*mu*/) {
+          return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
+        },
+        space);
+  }
+}; // struct BurgersProblem
+
+
+} // namespace Data
+} // namespace GDT
+} // namespace Dune
+
+#endif // DUNE_GDT_DATA_BURGERS_HH

--- a/dune/gdt/data/stationary_heat_equation.hh
+++ b/dune/gdt/data/stationary_heat_equation.hh
@@ -1,0 +1,93 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2019)
+
+#ifndef DUNE_GDT_DATA_STATIONARY_HEAT_EQUATION_HH
+#define DUNE_GDT_DATA_STATIONARY_HEAT_EQUATION_HH
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/common/type_traits.hh>
+#include <dune/xt/la/container/eye-matrix.hh>
+#include <dune/xt/grid/boundaryinfo/alldirichlet.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/functions/ESV2007.hh>
+#include <dune/xt/functions/constant.hh>
+#include <dune/xt/functions/grid-function.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Data {
+
+
+/**
+ * \brief Diffusion problem data from [1], Section 8.1 (stationary heat equation).
+ *
+ * gtest-free problem definition shared by the tests in
+ * dune/gdt/test/stationary-heat-equation/ and the benchmarks in benchmarks/.
+ *
+ * [1]: Ern, Stephansen, Vohralik, 2007, Improved energy norm a posteriori error estimation based on flux reconstruction
+ *      for discontinuous Galerkin methods, Preprint R07050, Laboratoire Jacques-Louis Lions & HAL Preprint
+ */
+template <class GV>
+struct ESV2007DiffusionProblem
+{
+  static_assert(XT::Grid::is_view<GV>::value, "");
+  static_assert(GV::dimension == 2, "");
+
+  static constexpr size_t d = GV::dimension;
+  using E = XT::Grid::extract_entity_t<GV>;
+  using I = XT::Grid::extract_intersection_t<GV>;
+  using G = typename GV::Grid;
+
+  // We can only reproduce the results from ESV2007 by using a quadrature of order 3, which we obtain with a p1 DG space
+  // and a force of order 2.
+  ESV2007DiffusionProblem(int force_order = 2)
+    : diffusion(XT::LA::eye_matrix<XT::Common::FieldMatrix<double, d, d>>(d, d))
+    , dirichlet(0.)
+    , neumann(0.)
+    , force(XT::Functions::ESV2007::Testcase1Force<d, 1>(force_order))
+  {
+  }
+
+  XT::Grid::GridProvider<G> make_initial_grid() const
+  {
+    if (std::is_same<G, YASP_2D_EQUIDISTANT_OFFSET>::value) {
+      return XT::Grid::make_cube_grid<G>(-1, 1, 8);
+#if HAVE_DUNE_ALUGRID
+    } else if (std::is_same<G, ALU_2D_SIMPLEX_CONFORMING>::value) {
+      auto grid = XT::Grid::make_cube_grid<G>(-1, 1, 4);
+      grid.global_refine(2);
+      return grid;
+    } else if (std::is_same<G, ALU_2D_SIMPLEX_NONCONFORMING>::value) {
+      return XT::Grid::make_cube_grid<G>(-1, 1, 8);
+    } else if (std::is_same<G, ALU_2D_CUBE>::value) {
+      auto grid = XT::Grid::make_cube_grid<G>(-1, 1, 8);
+      grid.global_refine(1);
+      return grid;
+#endif // HAVE_DUNE_ALUGRID
+    } else
+      DUNE_THROW(XT::Common::Exceptions::wrong_input_given,
+                 "Please add a specialization for '" << XT::Common::Typename<G>::value() << "'!");
+  } // ... make_initial_grid(...)
+
+  const XT::Functions::GridFunction<E, d, d> diffusion;
+  const XT::Functions::GridFunction<E> dirichlet;
+  const XT::Functions::GridFunction<E> neumann;
+  const XT::Functions::GridFunction<E> force;
+  const XT::Grid::AllDirichletBoundaryInfo<I> boundary_info;
+}; // struct ESV2007DiffusionProblem
+
+
+} // namespace Data
+} // namespace GDT
+} // namespace Dune
+
+#endif // DUNE_GDT_DATA_STATIONARY_HEAT_EQUATION_HH

--- a/dune/gdt/data/stokes.hh
+++ b/dune/gdt/data/stokes.hh
@@ -1,0 +1,206 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Tobias Leibner (2019)
+
+#ifndef DUNE_GDT_DATA_STOKES_HH
+#define DUNE_GDT_DATA_STOKES_HH
+
+#include <cmath>
+#include <memory>
+
+#include <dune/common/fmatrix.hh>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/common/parameter.hh>
+#include <dune/xt/la/container/eye-matrix.hh>
+
+#include <dune/xt/grid/boundaryinfo/alldirichlet.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/xt/functions/base/function-as-grid-function.hh>
+#include <dune/xt/functions/constant.hh>
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/functions/interfaces/grid-function.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Data {
+
+
+/**
+ * \brief Problem data for a stationary Stokes problem with Dirichlet boundary values.
+ *
+ * gtest-free problem definition shared by the tests in dune/gdt/test/stokes/ and the
+ * benchmarks in benchmarks/.
+ */
+template <class GV>
+struct StokesDirichletProblem
+{
+  static_assert(XT::Grid::is_view<GV>::value, "");
+  static_assert(GV::dimension == 2, "");
+
+  static constexpr size_t d = GV::dimension;
+  using E = XT::Grid::extract_entity_t<GV>;
+  using I = XT::Grid::extract_intersection_t<GV>;
+  using G = typename GV::Grid;
+  using RangeField = double;
+  using ScalarGridFunction = XT::Functions::GridFunctionInterface<E, 1, 1>;
+  using VectorGridFunction = XT::Functions::GridFunctionInterface<E, d, 1>;
+  using DomainType = typename ScalarGridFunction::LocalFunctionType::DomainType;
+  using DiffusionTensor = XT::Functions::GridFunctionInterface<E, d, d, RangeField>;
+
+  StokesDirichletProblem(std::shared_ptr<const DiffusionTensor> diffusion_in = default_diffusion(),
+                         std::shared_ptr<const VectorGridFunction> rhs_f_in = default_rhs_f(),
+                         std::shared_ptr<const VectorGridFunction> rhs_g_in = default_rhs_g(),
+                         std::shared_ptr<const VectorGridFunction> dirichlet_in = default_dirichlet_values(),
+                         std::shared_ptr<const VectorGridFunction> reference_sol_u = nullptr,
+                         std::shared_ptr<const ScalarGridFunction> reference_sol_p = nullptr)
+    : diffusion_(diffusion_in)
+    , rhs_f_(rhs_f_in)
+    , rhs_g_(rhs_g_in)
+    , dirichlet_(dirichlet_in)
+    , reference_sol_u_(reference_sol_u)
+    , reference_sol_p_(reference_sol_p)
+    , boundary_info_()
+    , grid_(XT::Grid::make_cube_grid<G>(-1, 1, 20))
+    , grid_view_(grid_.leaf_view())
+  {
+  }
+
+  static std::shared_ptr<const DiffusionTensor> default_diffusion()
+  {
+    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, d>>(
+        XT::LA::eye_matrix<FieldMatrix<double, d, d>>(d, d), "isotropic_diffusion");
+  }
+
+  static std::shared_ptr<const VectorGridFunction> default_rhs_f()
+  {
+    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, 1>>(0., "zero rhs");
+  }
+
+  static std::shared_ptr<const VectorGridFunction> default_rhs_g()
+  {
+    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, 1>>(0., "zero rhs");
+  }
+
+  static std::shared_ptr<const VectorGridFunction> default_dirichlet_values()
+  {
+    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, 1>>(0., "dirichlet zero boundary values");
+  }
+
+  const GV& grid_view()
+  {
+    return grid_view_;
+  }
+
+  const XT::Functions::GridFunctionInterface<E, d, d>& diffusion()
+  {
+    return *diffusion_;
+  }
+
+  const VectorGridFunction& rhs_f()
+  {
+    return *rhs_f_;
+  }
+
+  const VectorGridFunction& rhs_g()
+  {
+    return *rhs_g_;
+  }
+
+  const VectorGridFunction& dirichlet()
+  {
+    return *dirichlet_;
+  }
+
+  const VectorGridFunction& reference_solution_u()
+  {
+    DUNE_THROW_IF(!reference_sol_u_, Dune::InvalidStateException, "No reference solution provided!");
+    return *reference_sol_u_;
+  }
+
+  const ScalarGridFunction& reference_solution_p()
+  {
+    DUNE_THROW_IF(!reference_sol_p_, Dune::InvalidStateException, "No reference solution provided!");
+    return *reference_sol_p_;
+  }
+
+  const XT::Grid::BoundaryInfo<I>& boundary_info()
+  {
+    return boundary_info_;
+  }
+
+  std::shared_ptr<const DiffusionTensor> diffusion_;
+  std::shared_ptr<const VectorGridFunction> rhs_f_;
+  std::shared_ptr<const VectorGridFunction> rhs_g_;
+  std::shared_ptr<const VectorGridFunction> dirichlet_;
+  std::shared_ptr<const VectorGridFunction> reference_sol_u_;
+  std::shared_ptr<const ScalarGridFunction> reference_sol_p_;
+  const XT::Grid::AllDirichletBoundaryInfo<I> boundary_info_;
+  const XT::Grid::GridProvider<G> grid_;
+  const GV grid_view_;
+}; // struct StokesDirichletProblem
+
+
+/**
+ * \brief Analytic Dirichlet boundary values for the Stokes "testcase 1" (also the exact velocity).
+ */
+template <class GV>
+std::shared_ptr<const typename StokesDirichletProblem<GV>::VectorGridFunction> stokes_testcase1_dirichlet()
+{
+  using Problem = StokesDirichletProblem<GV>;
+  static constexpr size_t d = Problem::d;
+  using E = typename Problem::E;
+  using DomainType = typename Problem::DomainType;
+  using VectorGridFunction = typename Problem::VectorGridFunction;
+  static const XT::Functions::GenericFunction<d, d, 1> dirichlet_values(
+      50, [](const DomainType& xx, const XT::Common::Parameter&) {
+        typename VectorGridFunction::LocalFunctionType::RangeReturnType ret;
+        auto x = xx[0];
+        auto y = xx[1];
+        ret[0] = -std::exp(x) * (y * std::cos(y) + std::sin(y));
+        ret[1] = std::exp(x) * y * std::sin(y);
+        return ret;
+      });
+  return std::make_shared<XT::Functions::FunctionAsGridFunctionWrapper<E, d, 1, double>>(dirichlet_values);
+}
+
+/// \brief Exact velocity for the Stokes "testcase 1" (identical to the Dirichlet values).
+template <class GV>
+std::shared_ptr<const typename StokesDirichletProblem<GV>::VectorGridFunction> stokes_testcase1_exact_solution_u()
+{
+  return stokes_testcase1_dirichlet<GV>();
+}
+
+/// \brief Exact pressure for the Stokes "testcase 1".
+template <class GV>
+std::shared_ptr<const typename StokesDirichletProblem<GV>::ScalarGridFunction> stokes_testcase1_exact_solution_p()
+{
+  using Problem = StokesDirichletProblem<GV>;
+  static constexpr size_t d = Problem::d;
+  using E = typename Problem::E;
+  using DomainType = typename Problem::DomainType;
+  using ScalarGridFunction = typename Problem::ScalarGridFunction;
+  static const XT::Functions::GenericFunction<d, 1, 1> exact_sol_p(
+      50, [](const DomainType& xx, const XT::Common::Parameter&) {
+        typename ScalarGridFunction::LocalFunctionType::RangeReturnType ret;
+        auto x = xx[0];
+        auto y = xx[1];
+        ret[0] = 2. * std::exp(x) * std::sin(y);
+        return ret;
+      });
+  return std::make_shared<XT::Functions::FunctionAsGridFunctionWrapper<E, 1, 1, double>>(exact_sol_p);
+}
+
+
+} // namespace Data
+} // namespace GDT
+} // namespace Dune
+
+#endif // DUNE_GDT_DATA_STOKES_HH

--- a/dune/gdt/test/burgers/base.hh
+++ b/dune/gdt/test/burgers/base.hh
@@ -18,6 +18,7 @@
 #include <dune/xt/functions/generic/function.hh>
 #include <dune/xt/grid/gridprovider/cube.hh>
 
+#include <dune/gdt/data/burgers.hh>
 #include <dune/gdt/interpolations.hh>
 #include <dune/gdt/spaces/interface.hh>
 #include <dune/gdt/test/instationary-eocstudies/hyperbolic-nonconforming.hh>
@@ -26,44 +27,9 @@ namespace Dune {
 namespace GDT {
 
 
-template <class G>
-struct BurgersProblem
-{
-  static constexpr size_t d = G::dimension;
-  static_assert(d == 1, "Not implemented yet!");
-  //  using DomainType = XT::Common::FieldVector<double, d>;
-
-  const XT::Functions::GenericFunction<1, d, 1> flux;
-  const double T_end;
-
-  BurgersProblem()
-    : flux(
-          2,
-          [&](const auto& u, const auto& /*param*/) { return 0.5 * u * u; },
-          "burgers",
-          {},
-          [&](const auto& u, const auto& /*param*/) { return u; })
-    , T_end(1.)
-  {
-  }
-
-  XT::Grid::GridProvider<G> make_initial_grid() const
-  {
-    return XT::Grid::make_cube_grid<G>(0., 1., 16u);
-  }
-
-  template <class Vector, class GV>
-  DiscreteFunction<Vector, GV> make_initial_values(const SpaceInterface<GV, 1>& space) const
-  {
-    // TODO: Use generic interpolate once implemented?
-    return default_interpolation<Vector>(
-        3,
-        [&](const auto& xx, const auto& /*mu*/) {
-          return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
-        },
-        space);
-  }
-}; // struct BurgersProblem
+// The gtest-free problem definition now lives in dune/gdt/data/burgers.hh and is shared
+// with the benchmarks; keep the historical name available in this namespace.
+using Data::BurgersProblem;
 
 
 template <class G>

--- a/dune/gdt/test/stationary-heat-equation/ESV2007.hh
+++ b/dune/gdt/test/stationary-heat-equation/ESV2007.hh
@@ -10,7 +10,6 @@
 #ifndef DUNE_GDT_TEST_STATIONARY_HEAT_EQUATION_ESV2007_HH
 #define DUNE_GDT_TEST_STATIONARY_HEAT_EQUATION_ESV2007_HH
 
-#include <dune/xt/test/gtest/gtest.h>
 #include <dune/xt/common/type_traits.hh>
 #include <dune/xt/la/container/eye-matrix.hh>
 #include <dune/xt/grid/boundaryinfo/alldirichlet.hh>
@@ -21,6 +20,7 @@
 #include <dune/xt/functions/constant.hh>
 #include <dune/xt/functions/grid-function.hh>
 
+#include <dune/gdt/data/stationary_heat_equation.hh>
 #include <dune/gdt/interpolations/default.hh>
 #include <dune/gdt/test/stationary-eocstudies/diffusion-ipdg.hh>
 
@@ -29,59 +29,9 @@ namespace GDT {
 namespace Test {
 
 
-/**
- * \brief Problem definition from [1], Section 8.1
- *
- * [1]: Ern, Stephansen, Vohralik, 2007, Improved energy norm a posteriori error estimation based on flux reconstruction
- *      for discontinuous Galerkin methods, Preprint R07050, Laboratoire Jacques-Louis Lions & HAL Preprint
- */
-template <class GV>
-struct ESV2007DiffusionProblem
-{
-  static_assert(XT::Grid::is_view<GV>::value, "");
-  static_assert(GV::dimension == 2, "");
-
-  static constexpr size_t d = GV::dimension;
-  using E = XT::Grid::extract_entity_t<GV>;
-  using I = XT::Grid::extract_intersection_t<GV>;
-  using G = typename GV::Grid;
-
-  // We can only reproduce the results from ESV2007 by using a quadrature of order 3, which we obtain with a p1 DG space
-  // and a force of order 2.
-  ESV2007DiffusionProblem(int force_order = 2)
-    : diffusion(XT::LA::eye_matrix<XT::Common::FieldMatrix<double, d, d>>(d, d))
-    , dirichlet(0.)
-    , neumann(0.)
-    , force(XT::Functions::ESV2007::Testcase1Force<d, 1>(force_order))
-  {
-  }
-
-  XT::Grid::GridProvider<G> make_initial_grid() const
-  {
-    if (std::is_same<G, YASP_2D_EQUIDISTANT_OFFSET>::value) {
-      return XT::Grid::make_cube_grid<G>(-1, 1, 8);
-#if HAVE_DUNE_ALUGRID
-    } else if (std::is_same<G, ALU_2D_SIMPLEX_CONFORMING>::value) {
-      auto grid = XT::Grid::make_cube_grid<G>(-1, 1, 4);
-      grid.global_refine(2);
-      return grid;
-    } else if (std::is_same<G, ALU_2D_SIMPLEX_NONCONFORMING>::value) {
-      return XT::Grid::make_cube_grid<G>(-1, 1, 8);
-    } else if (std::is_same<G, ALU_2D_CUBE>::value) {
-      auto grid = XT::Grid::make_cube_grid<G>(-1, 1, 8);
-      grid.global_refine(1);
-      return grid;
-#endif // HAVE_DUNE_ALUGRID
-    } else
-      EXPECT_TRUE(false) << "Please add a specialization for '" << XT::Common::Typename<G>::value << "'!";
-  } // ... make_initial_grid(...)
-
-  const XT::Functions::GridFunction<E, d, d> diffusion;
-  const XT::Functions::GridFunction<E> dirichlet;
-  const XT::Functions::GridFunction<E> neumann;
-  const XT::Functions::GridFunction<E> force;
-  const XT::Grid::AllDirichletBoundaryInfo<I> boundary_info;
-}; // class ESV2007DiffusionProblem
+// The gtest-free problem definition now lives in dune/gdt/data/stationary_heat_equation.hh
+// and is shared with the benchmarks; keep the historical name available in this namespace.
+using Data::ESV2007DiffusionProblem;
 
 
 /**

--- a/dune/gdt/test/stokes/stokes-taylorhood.hh
+++ b/dune/gdt/test/stokes/stokes-taylorhood.hh
@@ -41,118 +41,16 @@
 #include <dune/gdt/tools/dirichlet-constraints.hh>
 #include <dune/gdt/tools/sparsity-pattern.hh>
 
+#include <dune/gdt/data/stokes.hh>
+
 namespace Dune {
 namespace GDT {
 namespace Test {
 
 
-template <class GV>
-struct StokesDirichletProblem
-{
-  static_assert(XT::Grid::is_view<GV>::value, "");
-  static_assert(GV::dimension == 2, "");
-
-  static constexpr size_t d = GV::dimension;
-  using E = XT::Grid::extract_entity_t<GV>;
-  using I = XT::Grid::extract_intersection_t<GV>;
-  using G = typename GV::Grid;
-  using RangeField = double;
-  using ScalarGridFunction = XT::Functions::GridFunctionInterface<E, 1, 1>;
-  using VectorGridFunction = XT::Functions::GridFunctionInterface<E, d, 1>;
-  using DomainType = typename ScalarGridFunction::LocalFunctionType::DomainType;
-  using DiffusionTensor = XT::Functions::GridFunctionInterface<E, d, d, RangeField>;
-
-  StokesDirichletProblem(std::shared_ptr<const DiffusionTensor> diffusion_in = default_diffusion,
-                         std::shared_ptr<const VectorGridFunction> rhs_f_in = default_rhs_f(),
-                         std::shared_ptr<const VectorGridFunction> rhs_g_in = default_rhs_g(),
-                         std::shared_ptr<const VectorGridFunction> dirichlet_in = default_dirichlet_values(),
-                         std::shared_ptr<const VectorGridFunction> reference_sol_u = nullptr,
-                         std::shared_ptr<const ScalarGridFunction> reference_sol_p = nullptr)
-    : diffusion_(diffusion_in)
-    , rhs_f_(rhs_f_in)
-    , rhs_g_(rhs_g_in)
-    , dirichlet_(dirichlet_in)
-    , reference_sol_u_(reference_sol_u)
-    , reference_sol_p_(reference_sol_p)
-    , boundary_info_()
-    , grid_(XT::Grid::make_cube_grid<G>(-1, 1, 20))
-    , grid_view_(grid_.leaf_view())
-  {
-  }
-
-  static std::shared_ptr<const DiffusionTensor> default_diffusion()
-  {
-    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, d>>(
-        XT::LA::eye_matrix<FieldMatrix<double, d, d>>(d, d), "isotropic_diffusion");
-  }
-
-  static std::shared_ptr<const VectorGridFunction> default_rhs_f()
-  {
-    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, 1>>(0., "zero rhs");
-  }
-
-  static std::shared_ptr<const VectorGridFunction> default_rhs_g()
-  {
-    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, 1>>(0., "zero rhs");
-  }
-
-  static std::shared_ptr<const VectorGridFunction> default_dirichlet_values()
-  {
-    return std::make_shared<const XT::Functions::ConstantGridFunction<E, d, 1>>(0., "dirichlet zero boundary values");
-  }
-
-  const GV& grid_view()
-  {
-    return grid_view_;
-  }
-
-  const XT::Functions::GridFunctionInterface<E, d, d>& diffusion()
-  {
-    return *diffusion_;
-  }
-
-  const VectorGridFunction& rhs_f()
-  {
-    return *rhs_f_;
-  }
-
-  const VectorGridFunction& rhs_g()
-  {
-    return *rhs_g_;
-  }
-
-  const VectorGridFunction& dirichlet()
-  {
-    return *dirichlet_;
-  }
-
-  const VectorGridFunction& reference_solution_u()
-  {
-    DUNE_THROW_IF(!reference_sol_u_, Dune::InvalidStateException, "No reference solution provided!");
-    return *reference_sol_u_;
-  }
-
-  const ScalarGridFunction& reference_solution_p()
-  {
-    DUNE_THROW_IF(!reference_sol_p_, Dune::InvalidStateException, "No reference solution provided!");
-    return *reference_sol_p_;
-  }
-
-  const XT::Grid::BoundaryInfo<I>& boundary_info()
-  {
-    return boundary_info_;
-  }
-
-  std::shared_ptr<const DiffusionTensor> diffusion_;
-  std::shared_ptr<const VectorGridFunction> rhs_f_;
-  std::shared_ptr<const VectorGridFunction> rhs_g_;
-  std::shared_ptr<const VectorGridFunction> dirichlet_;
-  std::shared_ptr<const VectorGridFunction> reference_sol_u_;
-  std::shared_ptr<const ScalarGridFunction> reference_sol_p_;
-  const XT::Grid::AllDirichletBoundaryInfo<I> boundary_info_;
-  const XT::Grid::GridProvider<G> grid_;
-  const GV grid_view_;
-}; // class StokesDirichletProblem
+// The gtest-free problem definition now lives in dune/gdt/data/stokes.hh and is shared
+// with the benchmarks; keep the historical name available in this namespace.
+using Data::StokesDirichletProblem;
 
 
 template <class G>
@@ -341,34 +239,17 @@ public:
 
   static std::shared_ptr<const VectorGridFunction> dirichlet()
   {
-    static const XT::Functions::GenericFunction<d, d, 1> dirichlet_values(
-        50, [](const DomainType& xx, const XT::Common::Parameter&) {
-          typename VectorGridFunction::LocalFunctionType::RangeReturnType ret;
-          auto x = xx[0];
-          auto y = xx[1];
-          ret[0] = -std::exp(x) * (y * std::cos(y) + std::sin(y));
-          ret[1] = std::exp(x) * y * std::sin(y);
-          return ret;
-        });
-    return std::make_shared<XT::Functions::FunctionAsGridFunctionWrapper<E, d, 1, double>>(dirichlet_values);
+    return Data::stokes_testcase1_dirichlet<typename G::LeafGridView>();
   }
 
   static std::shared_ptr<const VectorGridFunction> exact_sol_u()
   {
-    return dirichlet();
+    return Data::stokes_testcase1_exact_solution_u<typename G::LeafGridView>();
   }
 
   static std::shared_ptr<const ScalarGridFunction> exact_sol_p()
   {
-    static const XT::Functions::GenericFunction<d, 1, 1> exact_sol_p_(
-        50, [](const DomainType& xx, const XT::Common::Parameter&) {
-          typename ScalarGridFunction::LocalFunctionType::RangeReturnType ret;
-          auto x = xx[0];
-          auto y = xx[1];
-          ret[0] = 2. * std::exp(x) * std::sin(y);
-          return ret;
-        });
-    return std::make_shared<XT::Functions::FunctionAsGridFunctionWrapper<E, 1, 1, double>>(exact_sol_p_);
+    return Data::stokes_testcase1_exact_solution_p<typename G::LeafGridView>();
   }
 }; // struct StokesTestcase1
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -52,6 +52,7 @@
     "boost-serialization",
     "boost-timer",
     "gtest",
+    "nanobench",
     "pybind11",
     "eigen3",
     "tbb",


### PR DESCRIPTION
## What

Turns three end-to-end solves into **standalone** [nanobench](https://github.com/martinus/nanobench) benchmarks and wires up a CI workflow that publishes their JSON reports to a dedicated `benchmarks` branch.

The benchmarks are deliberately **independent** of the test machinery: each is a plain `int main()` program — no gtest, no `<dune/xt/test/main.hxx>`, no `DXTC_TEST_CONFIG`, no CTest registration. They drive the public dune-gdt / dune-xt API directly.

## Changes

### Shared, gtest-free problem data (`dune/gdt/data/`)
To avoid duplicating problem definitions, the gtest-free data functions and problem setups were refactored out of the test tree into a new header-only area `dune/gdt/data/` (namespace `Dune::GDT::Data`):

- `dune/gdt/data/burgers.hh` ← `BurgersProblem`
- `dune/gdt/data/stationary_heat_equation.hh` ← `ESV2007DiffusionProblem` (dropped the gtest include; replaced the unsupported-grid `EXPECT_TRUE(false)` with a `DUNE_THROW`)
- `dune/gdt/data/stokes.hh` ← `StokesDirichletProblem` + the Dirichlet / exact-solution factories (previously static members of `StokesTestcase1`)

The existing test headers now `#include` these and re-expose the names via `using Data::…`, so **test code is unchanged**. (`dune/gdt/data` is added to the `.gitignore` `data` exception list, mirroring the existing `!dune/xt/data`.)

### Benchmarks (`benchmarks/`)
- Any C++ file dropped in `benchmarks/` is auto-built as a plain `bench_<name>` executable (glob with `CONFIGURE_DEPENDS`), linked against `dunext` + grid libs + `nanobench::nanobench`, `EXCLUDE_FROM_ALL`.
- `benchmark_common.hh`: a tuned `make_bench()` and a `write_report()` that renders nanobench JSON to `${DUNE_GDT_BENCHMARK_OUTPUT_DIR}/<name>.json`.
- Three benchmarks:
  - `burgers__1d__explicit__fv.cpp` — FV + upwind flux, explicit-Euler time loop
  - `stationary_heat_equation__ESV2007.cpp` — p1 SIPDG assemble + linear solve (guarded by `HAVE_DUNE_ALUGRID`)
  - `stokes__taylorhood.cpp` — Taylor-Hood assemble + direct saddle-point solve (guarded by `HAVE_DUNE_ISTL`)
- CMake targets: `benchmarks` (build all) and `run_benchmarks` (run all, writing JSON reports).
- nanobench added to `vcpkg.json`.

### CI (`.github/workflows/benchmarks.yml`)
- Runs on push to `main` (+ `workflow_dispatch`), builds in **Release** (own cache key), runs `run_benchmarks`, uploads the JSON as an artifact, and pushes the reports onto an orphan `benchmarks` branch under `reports/<timestamp>-<sha>/` plus a refreshed `reports/latest/`. Pushing to `benchmarks` does not retrigger the workflow (it fires only on `main`).

## Notes
- Benchmarks stay out of normal CI: `EXCLUDE_FROM_ALL` + no CTest registration means a plain build and `ctest --preset=debug` never touch them.
- A follow-up issue tracks surfacing these reports in the documentation.

## Verification
The heat and Stokes benchmark bodies are near-verbatim copies of the existing fixture solve paths; the data refactor is mechanical (`using` aliases keep the test API intact). Full build/run validation happens in the new Release workflow on merge to `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HrVpJijZiM9jkpJQv9yof4)_