### PR TITLE
Re-enable column-matrix conversion check in fvector test

### DIFF
--- a/dune/xt/test/common/fvector.cc
+++ b/dune/xt/test/common/fvector.cc
@@ -59,17 +59,20 @@ GTEST_TEST(dune_xt_common_field_vector, creation_and_calculations)
   RowMatrixType row_mat = test_vec;
   for (size_t ii = 0; ii < 4; ++ii)
     EXPECT_EQ(row_mat[0][ii], ii);
-  // TODO: reenable this test
-  //  ColMatrixType col_mat = test_vec;
-  //  for (size_t ii = 0; ii < 4; ++ii)
-  //    EXPECT_EQ(col_mat[ii][0], ii);
+  // The implicit conversion to a column matrix (ColMatrixType col_mat = test_vec;) cannot be used: Dune::FieldMatrix
+  // has a greedy converting constructor FieldMatrix(const T&), which is enabled whenever HasDenseMatrixAssigner<
+  // FieldMatrix, T> holds. For a column matrix the rows are FieldVector<K, 1>, and since a scalar is implicitly
+  // convertible to FieldVector<K, 1>, that constructor is preferred over our conversion operator and then fails to
+  // compile deep inside dune-common (it treats the vector's scalar entries as rows). Direct-initialization and
+  // static_cast pick the same constructor and fail likewise. The row matrix above is unaffected because a scalar is
+  // not convertible to FieldVector<K, 4>, so there the greedy constructor is disabled and our conversion operator is
+  // used. We therefore invoke the conversion operator explicitly here, which exercises exactly the same code path.
+  ColMatrixType col_mat = test_vec.operator ColMatrixType();
+  for (size_t ii = 0; ii < 4; ++ii)
+    EXPECT_EQ(col_mat[ii][0], ii);
   ArrayType array = test_vec;
   for (size_t ii = 0; ii < 4; ++ii)
     EXPECT_EQ(array[ii], ii);
-  // TODO: remove this when the construction above is reenabled
-  ColMatrixType col_mat;
-  for (auto ii = 0; ii < 4; ++ii)
-    col_mat[ii][0] = ii;
   EXPECT_DOUBLE_EQ(test_vec * test_vec, 14.);
   EXPECT_DOUBLE_EQ(test_vec * col_mat, 14.);
   for (size_t ii = 0; ii < 4; ++ii)


### PR DESCRIPTION
Closes #110.

## Background

`dune/xt/test/common/fvector.cc` had a long-standing `// TODO: reenable this test` (around line 62) for converting an `XT::Common::FieldVector<double, 4>` into a column matrix `FieldMatrix<double, 4, 1>`, plus a follow-up `// TODO: remove this when the construction above is reenabled` that built the matrix by hand as a temporary fallback.

## Investigation

The column-matrix conversion operator **exists and is correct** (`dune/xt/common/fvector-2.7.hh:128-135`), but it can never be reached through the natural conversion syntax — copy-init, direct-init, and `static_cast` all fail to compile.

Root cause: `Dune::FieldMatrix` provides a greedy converting constructor `FieldMatrix(const T&)`, enabled whenever `HasDenseMatrixAssigner<FieldMatrix, T>` holds. For a column matrix the rows are `FieldVector<K, 1>`, and since a scalar is implicitly convertible to `FieldVector<K, 1>`, the `DenseMatrixAssigner` specialization is enabled, so the greedy constructor is preferred over our user-defined conversion operator. It then hard-errors deep inside dune-common (`std::begin(double)` — it treats the vector's scalar entries as rows). Because the error is outside the SFINAE immediate context, it cannot be recovered.

The **row** matrix case (`FieldMatrix<double, 1, 4>`) is unaffected and keeps working, because a scalar is *not* implicitly convertible to `FieldVector<K, 4>`, which disables the greedy constructor there and lets the conversion operator be used.

This was verified by compiling a faithful minimal reproduction (same conversion operators, same types) against the exact pinned dune-common commit (`145a243…`, v2.10): the `= test_vec` / `(test_vec)` / `static_cast<…>(test_vec)` forms all fail, while explicit invocation of the conversion operator compiles and produces the correct result.

## Change

- Re-enable coverage of the column-matrix conversion operator by invoking it explicitly (`test_vec.operator ColMatrixType()`) — the one form that compiles — and source `col_mat` from `test_vec` again.
- Drop the temporary hand-built `col_mat` fallback.
- Replace the two bare `TODO`s with an in-place comment explaining the dune-common limitation, so the constraint is documented rather than silently worked around.

The downstream `EXPECT_DOUBLE_EQ(test_vec * col_mat, 14.)` check is preserved and now uses the converted matrix.

https://claude.ai/code/session_01WZ3vgbPrfDvyfHKTQTeRDS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ3vgbPrfDvyfHKTQTeRDS)_