### PR TITLE
Finalize BilinearForm operator-assembly bindings (apply2/norm)

### DIFF
--- a/python/gdt/dune/gdt/operators/bilinear-form.cc
+++ b/python/gdt/dune/gdt/operators/bilinear-form.cc
@@ -66,18 +66,8 @@ public:
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    //    c.def_property_readonly("result", [](type& self) { return self.result(); });
-
-    // methods
-    //    c.def(
-    //        "append",
-    //        [](type& self,
-    //           const LocalElementBilinearFormType<E, r_r, 1, F, F, s_r, 1, F>& local_bilinear_form,
-    //           const XT::Common::Parameter& param,
-    //           const XT::Grid::ElementFilter<GV>& filter) { self.append(local_bilinear_form, param, filter); },
-    //        "local_element_bilinear_form"_a,
-    //        "param"_a = XT::Common::Parameter(),
-    //        "element_filter"_a = XT::Grid::ApplyOn::AllElements<GV>());
+    // Append local bilinear forms via "+=" (the finalized idiom). Pass a 2-tuple
+    // (local_form, filter) to restrict a form to a sub-set of elements/intersections.
     c.def("__iadd__", // function ptr signature required for the right return type
           (type & (type::*)(const LocalElementBilinearFormType&)) & type::operator+=,
           "local_element_bilinear_form"_a,
@@ -88,15 +78,6 @@ public:
             & type::operator+=,
         "tuple_of_localelementbilinearform_elementfilter"_a,
         py::is_operator());
-    //    c.def(
-    //        "append",
-    //        [](type& self,
-    //           const LocalCouplingIntersectionBilinearFormType& local_bilinear_form,
-    //           const XT::Common::Parameter& param,
-    //           const XT::Grid::IntersectionFilter<GV>& filter) { self.append(local_bilinear_form, param, filter); },
-    //        "local_coupling_intersection_bilinear_form"_a,
-    //        "param"_a = XT::Common::Parameter(),
-    //        "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<GV>());
     c.def("__iadd__", // function ptr signature required for the right return type
           (type & (type::*)(const LocalCouplingIntersectionBilinearFormType&)) & type::operator+=,
           "local_coupling_intersection_bilinear_form"_a,
@@ -108,15 +89,6 @@ public:
               & type::operator+=,
           "tuple_of_localcouplingintersectionbilinearform_intersectionfilter"_a,
           py::is_operator());
-    //    c.def(
-    //        "append",
-    //        [](type& self,
-    //           const LocalIntersectionBilinearFormInterface<I, r_r, 1, F, F, s_r, 1, F>& local_bilinear_form,
-    //           const XT::Common::Parameter& param,
-    //           const XT::Grid::IntersectionFilter<GV>& filter) { self.append(local_bilinear_form, param, filter); },
-    //        "local_intersection_bilinear_form"_a,
-    //        "param"_a = XT::Common::Parameter(),
-    //        "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<GV>());
     c.def("__iadd__", // function ptr signature required for the right return type
           (type & (type::*)(const LocalIntersectionBilinearFormType&)) & type::operator+=,
           "local_intersection_bilinear_form"_a,
@@ -128,11 +100,28 @@ public:
               & type::operator+=,
           "tuple_of_localintersectionbilinearform_intersectionfilter"_a,
           py::is_operator());
-    //    c.def(
-    //        "apply2",
-    //        [](type& self, const bool use_tbb) { return self.apply2(use_tbb); },
-    //        "parallel"_a = false,
-    //        py::call_guard<py::gil_scoped_release>());
+
+    // The supported way to evaluate the assembled bilinear form, e.g. a(u, u) for norms:
+    // apply2(range, source) walks the grid and returns the scalar a(range, source);
+    // norm(range) returns sqrt(apply2(range, range)). The argument types are the grid
+    // functions expected by the C++ apply2 (correct for both leaf and coupling views).
+    using RangeFunc = typename type::RangeFunctionType;
+    using SourceFunc = typename type::SourceFunctionType;
+    c.def(
+        "apply2",
+        [](type& self, RangeFunc range, SourceFunc source, const XT::Common::Parameter& param) {
+          return self.apply2(range, source, param);
+        },
+        "range"_a,
+        "source"_a,
+        "param"_a = XT::Common::Parameter(),
+        py::call_guard<py::gil_scoped_release>());
+    c.def(
+        "norm",
+        [](type& self, RangeFunc range, const XT::Common::Parameter& param) { return self.norm(range, param); },
+        "range"_a,
+        "param"_a = XT::Common::Parameter(),
+        py::call_guard<py::gil_scoped_release>());
   }
 
   static bound_type bind_leaf(pybind11::module& m,

--- a/python/gdt/dune/gdt/operators/matrix-based.hh
+++ b/python/gdt/dune/gdt/operators/matrix-based.hh
@@ -374,7 +374,11 @@ public:
     bindings::OperatorInterface<M, AGV, s, r, SGV, RGV>::addbind_methods(c);
 
     // additional methods
-    //    c.def("clear", [](type& self) { self.clear(); });
+    //
+    // The finalized idiom to fill a MatrixOperator with local bilinear forms is two-level:
+    // collect the local forms in a BilinearForm (via "+="), then append that whole form here
+    // (or via "+="). Local-form-by-local-form append directly onto the MatrixOperator is no
+    // longer part of the C++ API (see dune/gdt/operators/matrix.hh).
     c.def(
         "append",
         [](type& self, const BilinearFormType& bilinear_form, const XT::Common::Parameter& param) {
@@ -387,78 +391,6 @@ public:
           "bilinear_form"_a,
           "param"_a = XT::Common::Parameter(),
           py::is_operator());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const std::tuple<const BilinearFormType&,
-    //                                        const XT::Common::Parameter&,
-    //                                        const XT::Grid::ElementFilter<AGV>&>&))
-    //              & type::operator+=,
-    //          "tuple_of_bilinearform_param_elementfilter"_a,
-    //          py::is_operator());
-    //    c.def(
-    //        "append",
-    //        [](type& self,
-    //           const LocalIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>& local_intersection_bilinear_form,
-    //           const XT::Common::Parameter& param) {
-    //          self.append(local_intersection_bilinear_form, param);
-    //        },
-    //        "local_intersection_bilinear_form"_a,
-    //        "param"_a = XT::Common::Parameter(),
-    //        "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const LocalIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&,
-    //                       const XT::Common::Parameter&,
-    //                       const XT::Grid::IntersectionFilter<AGV>&))
-    //              & type::append,
-    //          "local_intersection_bilinear_form"_a,
-    //          "param"_a = XT::Common::Parameter(),
-    //          "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>(),
-    //          py::is_operator());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const std::tuple<const LocalIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&,
-    //                                        const XT::Common::Parameter&,
-    //                                        const XT::Grid::IntersectionFilter<AGV>&>&))
-    //              & type::operator+=,
-    //          "tuple_of_localintersectionbilinearform_param_elementfilter"_a,
-    //          py::is_operator());
-    //    c.def(
-    //        "append",
-    //        [](type& self,
-    //           const LocalCouplingIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&
-    //               local_coupling_intersection_bilinear_form,
-    //           const XT::Common::Parameter& param,
-    //           const XT::Grid::IntersectionFilter<AGV>& intersection_filter) {
-    //          self.append(local_coupling_intersection_bilinear_form, param, intersection_filter);
-    //        },
-    //        "local_coupling_intersection_bilinear_form"_a,
-    //        "param"_a = XT::Common::Parameter(),
-    //        "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const LocalCouplingIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&,
-    //                       const XT::Common::Parameter&,
-    //                       const XT::Grid::IntersectionFilter<AGV>&))
-    //              & type::append,
-    //          "local_coupling_intersection_bilinear_form"_a,
-    //          "param"_a = XT::Common::Parameter(),
-    //          "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>(),
-    //          py::is_operator());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const std::tuple<const LocalCouplingIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1,
-    //           F>&,
-    //                                        const XT::Common::Parameter&,
-    //                                        const XT::Grid::IntersectionFilter<AGV>&>&))
-    //              & type::operator+=,
-    //          "tuple_of_localcouplingintersectionbilinearform_param_elementfilter"_a,
-    //          py::is_operator());
-    //    c.def(
-    //        "assemble",
-    //        [](type& self, const bool use_tbb) { self.assemble(use_tbb); },
-    //        "parallel"_a = false,
-    //        py::call_guard<py::gil_scoped_release>());
     return c;
   } // ... bind_leaf_type(...)
 
@@ -548,8 +480,7 @@ public:
     // methods from operator base, to allow for overloads
     bindings::OperatorInterface<M, AGV, s, r, SGV, RGV>::addbind_methods(c);
 
-    // additional methods
-    //    c.def("clear", [](type& self) { self.clear(); });
+    // additional methods (see bind_leaf_type for the finalized two-level assembly idiom)
     c.def(
         "append",
         [](type& self, const BilinearFormType& bilinear_form, const XT::Common::Parameter& param) {
@@ -562,78 +493,6 @@ public:
           "bilinear_form"_a,
           "param"_a = XT::Common::Parameter(),
           py::is_operator());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const std::tuple<const BilinearFormType&,
-    //                                        const XT::Common::Parameter&,
-    //                                        const XT::Grid::ElementFilter<AGV>&>&))
-    //              & type::operator+=,
-    //          "tuple_of_bilinearform_param_elementfilter"_a,
-    //          py::is_operator());
-    //    c.def(
-    //        "append",
-    //        [](type& self,
-    //           const LocalIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>& local_intersection_bilinear_form,
-    //           const XT::Common::Parameter& param) {
-    //          self.append(local_intersection_bilinear_form, param);
-    //        },
-    //        "local_intersection_bilinear_form"_a,
-    //        "param"_a = XT::Common::Parameter(),
-    //        "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const LocalIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&,
-    //                       const XT::Common::Parameter&,
-    //                       const XT::Grid::IntersectionFilter<AGV>&))
-    //              & type::append,
-    //          "local_intersection_bilinear_form"_a,
-    //          "param"_a = XT::Common::Parameter(),
-    //          "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>(),
-    //          py::is_operator());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const std::tuple<const LocalIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&,
-    //                                        const XT::Common::Parameter&,
-    //                                        const XT::Grid::IntersectionFilter<AGV>&>&))
-    //              & type::operator+=,
-    //          "tuple_of_localintersectionbilinearform_param_elementfilter"_a,
-    //          py::is_operator());
-    //    c.def(
-    //        "append",
-    //        [](type& self,
-    //           const LocalCouplingIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&
-    //               local_coupling_intersection_bilinear_form,
-    //           const XT::Common::Parameter& param,
-    //           const XT::Grid::IntersectionFilter<AGV>& intersection_filter) {
-    //          self.append(local_coupling_intersection_bilinear_form, param, intersection_filter);
-    //        },
-    //        "local_coupling_intersection_bilinear_form"_a,
-    //        "param"_a = XT::Common::Parameter(),
-    //        "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const LocalCouplingIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1, F>&,
-    //                       const XT::Common::Parameter&,
-    //                       const XT::Grid::IntersectionFilter<AGV>&))
-    //              & type::append,
-    //          "local_coupling_intersection_bilinear_form"_a,
-    //          "param"_a = XT::Common::Parameter(),
-    //          "intersection_filter"_a = XT::Grid::ApplyOn::AllIntersections<AGV>(),
-    //          py::is_operator());
-    //    c.def("__iadd__", // function ptr signature required for the right return type
-    //          (type
-    //           & (type::*)(const std::tuple<const LocalCouplingIntersectionBilinearFormInterface<I, r, 1, F, F, s, 1,
-    //           F>&,
-    //                                        const XT::Common::Parameter&,
-    //                                        const XT::Grid::IntersectionFilter<AGV>&>&))
-    //              & type::operator+=,
-    //          "tuple_of_localcouplingintersectionbilinearform_param_elementfilter"_a,
-    //          py::is_operator());
-    //    c.def(
-    //        "assemble",
-    //        [](type& self, const bool use_tbb) { self.assemble(use_tbb); },
-    //        "parallel"_a = false,
-    //        py::call_guard<py::gil_scoped_release>());
     return c;
   } // ... bind_coupling_type(...)
 

--- a/python/gdt/test/test_bilinear_form_apply2.py
+++ b/python/gdt/test/test_bilinear_form_apply2.py
@@ -1,0 +1,75 @@
+# This file is part of the dune-gdt project:
+#   https://github.com/dune-community/dune-gdt
+# Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+
+# flake8: noqa
+
+import numpy as np
+
+from dune.xt.grid import Dim, Simplex, make_cube_grid
+from dune.xt.functions import ExpressionFunction, GridFunction as GF
+
+
+def _products(grid):
+    from dune.gdt import (
+        BilinearForm,
+        LocalElementIntegralBilinearForm,
+        LocalElementProductIntegrand,
+        LocalLaplaceIntegrand,
+    )
+
+    d = grid.dimension
+
+    L2_product = BilinearForm(grid)
+    L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+
+    H1_semi_product = BilinearForm(grid)
+    H1_semi_product += LocalElementIntegralBilinearForm(
+        LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d))))
+    )
+
+    H1_product = BilinearForm(grid)
+    H1_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+    H1_product += LocalElementIntegralBilinearForm(
+        LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d))))
+    )
+
+    return L2_product, H1_semi_product, H1_product
+
+
+def test_bilinear_form_apply2_and_norm():
+    grid = make_cube_grid(Dim(2), Simplex(), lower_left=[0, 0], upper_right=[1, 1], num_elements=[4, 4])
+    grid.global_refine(1)
+    d = grid.dimension
+
+    from dune.gdt import ContinuousLagrangeSpace, default_interpolation
+
+    space = ContinuousLagrangeSpace(grid, order=1)
+    u_h = default_interpolation(
+        GF(grid, ExpressionFunction(dim_domain=Dim(d), variable="x", order=2, expression="x[0]*x[1]", name="u")),
+        space,
+    )
+    # wrap the DiscreteFunction as a GridFunction (the argument type expected by apply2/norm)
+    u = GF(grid, u_h)
+
+    L2_product, H1_semi_product, H1_product = _products(grid)
+
+    # apply2(u, u) computes a(u, u); each product is symmetric positive (semi-)definite
+    l2 = L2_product.apply2(u, u)
+    h1_semi = H1_semi_product.apply2(u, u)
+    h1 = H1_product.apply2(u, u)
+
+    assert l2 > 0
+    assert h1_semi > 0
+    assert h1 > 0
+
+    # H1 product is the sum of the L2 product and the H1 semi product
+    assert np.isclose(l2 + h1_semi, h1)
+
+    # norm(u) == sqrt(apply2(u, u))
+    assert np.isclose(L2_product.norm(u), np.sqrt(l2))
+    assert np.isclose(H1_semi_product.norm(u), np.sqrt(h1_semi))
+    assert np.isclose(H1_product.norm(u), np.sqrt(h1))

--- a/python/gdt/test/test_bilinear_form_apply2.py
+++ b/python/gdt/test/test_bilinear_form_apply2.py
@@ -24,7 +24,9 @@ def _products(grid):
     d = grid.dimension
 
     L2_product = BilinearForm(grid)
-    L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+    L2_product += LocalElementIntegralBilinearForm(
+        LocalElementProductIntegrand(GF(grid, 1))
+    )
 
     H1_semi_product = BilinearForm(grid)
     H1_semi_product += LocalElementIntegralBilinearForm(
@@ -32,7 +34,9 @@ def _products(grid):
     )
 
     H1_product = BilinearForm(grid)
-    H1_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
+    H1_product += LocalElementIntegralBilinearForm(
+        LocalElementProductIntegrand(GF(grid, 1))
+    )
     H1_product += LocalElementIntegralBilinearForm(
         LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d))))
     )
@@ -41,7 +45,9 @@ def _products(grid):
 
 
 def test_bilinear_form_apply2_and_norm():
-    grid = make_cube_grid(Dim(2), Simplex(), lower_left=[0, 0], upper_right=[1, 1], num_elements=[4, 4])
+    grid = make_cube_grid(
+        Dim(2), Simplex(), lower_left=[0, 0], upper_right=[1, 1], num_elements=[4, 4]
+    )
     grid.global_refine(1)
     d = grid.dimension
 
@@ -49,7 +55,16 @@ def test_bilinear_form_apply2_and_norm():
 
     space = ContinuousLagrangeSpace(grid, order=1)
     u_h = default_interpolation(
-        GF(grid, ExpressionFunction(dim_domain=Dim(d), variable="x", order=2, expression="x[0]*x[1]", name="u")),
+        GF(
+            grid,
+            ExpressionFunction(
+                dim_domain=Dim(d),
+                variable="x",
+                order=2,
+                expression="x[0]*x[1]",
+                name="u",
+            ),
+        ),
         space,
     )
     # wrap the DiscreteFunction as a GridFunction (the argument type expected by apply2/norm)

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -65,11 +65,14 @@ nb_execution_show_tb = True
 # if any executed notebook wrote an error report (see non_docker_build.yml).
 nb_execution_raise_on_error = False
 # These notebooks (and the helper-free tutorials) still rely on dune-gdt python
-# bindings that are currently commented out in the C++ sources (direct
-# `MatrixOperator += local_form`, `BilinearForm.result`/`apply2`, the
-# oswald/IPDG-flux-reconstruction operators). They are restored and rendered, but
-# not executed, until the bindings are restored / the notebooks are migrated to the
-# current API. Tracked in #127 (blocked on #126).
+# bindings that remain commented out in the C++ sources, namely the
+# oswald/IPDG-flux-reconstruction operators. They are restored and rendered, but
+# not executed, until those bindings are restored / the notebooks are migrated to
+# the current API. Tracked in #127 (blocked on #126).
+#
+# The `BilinearForm` product/norm bindings used for `a(u, u)` have been finalized
+# (`BilinearForm.apply2(u, u)` / `BilinearForm.norm(u)`), so
+# example__prolongations_products_and_norms.md is migrated and executed again.
 nb_execution_excludepatterns = [
     "*dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md",
     "*dune_gdt_tutorial_on_data_functions_and_interpolation.md",
@@ -77,7 +80,6 @@ nb_execution_excludepatterns = [
     "*example__MNS2002_estimates.md",
     "*example__gmsh_grid.md",
     "*example__ipdg_heat_equation.md",
-    "*example__prolongations_products_and_norms.md",
 ]
 
 bibtex_bibfiles = ["bibliography.bib"]

--- a/tutorials/source/example__prolongations_products_and_norms.md
+++ b/tutorials/source/example__prolongations_products_and_norms.md
@@ -101,11 +101,10 @@ $$
 $$
 
 
-Either comupte all in one grid walk ...
+We collect the local integrands of each product in a `BilinearForm` (via `+=`) and evaluate
+`a(u, u)` with `apply2(u, u)`, which walks the grid and returns the scalar:
 
 ```{code-cell}
-from dune.xt.grid import Walker
-
 from dune.gdt import (
     BilinearForm,
     LocalElementProductIntegrand,
@@ -113,46 +112,35 @@ from dune.gdt import (
     LocalLaplaceIntegrand,
 )
 
-L2_product = BilinearForm(grid, u, u)
+L2_product = BilinearForm(grid)
 L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
 
-H1_semi_product = BilinearForm(grid, u, u)
+H1_semi_product = BilinearForm(grid)
 H1_semi_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
 
-H1_product = BilinearForm(grid, u, u)
+H1_product = BilinearForm(grid)
 H1_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
 H1_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
 
-walker = Walker(grid)
-walker.append(L2_product)
-walker.append(H1_semi_product)
-walker.append(H1_product)
-walker.walk()
+l2 = L2_product.apply2(u, u)
+h1_semi = H1_semi_product.apply2(u, u)
+h1 = H1_product.apply2(u, u)
 
-print(f'|| u ||_L2 = {np.sqrt(L2_product.result)}')
-print(f' | u |_H1  = {np.sqrt(H1_semi_product.result)}')
-print(f'|| u ||_H1 = {np.sqrt(H1_product.result)}')
+print(f'|| u ||_L2 = {np.sqrt(l2)}')
+print(f' | u |_H1  = {np.sqrt(h1_semi)}')
+print(f'|| u ||_H1 = {np.sqrt(h1)}')
 ```
 
 ```{code-cell}
-np.allclose(L2_product.result + H1_semi_product.result, H1_product.result)
+np.allclose(l2 + h1_semi, h1)
 ```
 
-... or let each product do the grid walking in `apply2` (possibly less runtime efficient, but maybe more intuitive)
+Equivalently, `norm` returns the induced norm directly (`norm(u) == sqrt(apply2(u, u))`):
 
 ```{code-cell}
-L2_product = BilinearForm(grid, u, u)
-L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
-print(f'|| u ||_L2 = {np.sqrt(L2_product.apply2())}')
-
-H1_semi_product = BilinearForm(grid, u, u)
-H1_semi_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
-print(f' | u |_H1  = {np.sqrt(H1_semi_product.apply2())}')
-
-H1_product = BilinearForm(grid, u, u)
-H1_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
-H1_product += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(GF(grid, 1, dim_range=(Dim(d), Dim(d)))))
-print(f'|| u ||_H1 = {np.sqrt(H1_product.apply2())}')
+print(f'|| u ||_L2 = {L2_product.norm(u)}')
+print(f' | u |_H1  = {H1_semi_product.norm(u)}')
+print(f'|| u ||_H1 = {H1_product.norm(u)}')
 ```
 
 ## 3: computing errors w.r.t. a known reference solution
@@ -170,9 +158,9 @@ u_h = prolong(u_H, V_h)
 error = GF(grid, u - u_h)
 
 # compute norms on reference grid
-L2_product = BilinearForm(reference_grid, error, error)
+L2_product = BilinearForm(reference_grid)
 L2_product += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(GF(grid, 1)))
-print(f'|| error ||_L2 = {np.sqrt(L2_product.apply2())}')
+print(f'|| error ||_L2 = {L2_product.norm(error)}')
 ```
 
 Download the code:


### PR DESCRIPTION
Resolves the operator-assembly part of #126.

## Decision: finalize the new API (not re-enable)

The issue offered two options — (1) re-enable the commented-out overloads, or (2) finalize the new two-level API and provide replacements. Investigation shows **option 1 is infeasible**: every commented-out binding targets an *older* C++ API that has since been refactored and would no longer compile:

- `matrix-based.hh` — the commented `__iadd__`/`append(local form)` overloads call `MatrixOperator` methods that no longer exist (C++ only has `append(BilinearForm)` plus FD-jacobian `append(LocalOperator, source, …)`).
- `bilinear-form.cc` — the commented `apply2(use_tbb)` / `result` bindings don't match the current C++ `BilinearForm::apply2(range, source, param)` (and `result()` now lives on the assembler, not the form).
- the old `BilinearForm(grid, source, ansatz)` ctor is gone; only `BilinearForm(grid, logging_prefix)` remains.

So this PR finalizes **option 2**. The good news: the supported `a(u, u)` already exists in C++ and just needed binding.

## Changes

- **Bind `BilinearForm.apply2(range, source)` and `BilinearForm.norm(range)`** against the current C++ `BilinearForm`/`BilinearFormInterface`. `apply2` walks the grid and returns the scalar `a(range, source)`; `norm(range)` returns `sqrt(apply2(range, range))`. This is the supported way to compute `a(u, u)` for norms — the gap explicitly called out in #126. Argument types use `type::RangeFunctionType`/`SourceFunctionType` so they are correct for both leaf and coupling grid views.
- **Remove the dead commented-out `+=` / `append(local form)` overloads** in `matrix-based.hh` and `bilinear-form.cc` that referenced removed C++ methods, and document the finalized two-level `MatrixOperator` idiom (collect local forms in a `BilinearForm`, then `matrix_operator.append(form)` / `+=`).
- **Migrate `example__prolongations_products_and_norms`** to the finalized API (`BilinearForm(grid)` + `apply2(u, u)` / `norm(u)`) and re-enable its execution in `tutorials/source/conf.py`.
- **Add `python/gdt/test/test_bilinear_form_apply2.py`** covering `apply2`/`norm` and the `||u||_H1² = ||u||_L2² + |u|_H1²` identity.

## Out of scope (follow-up)

The `oswald_interpolation` and `LaplaceIpdgFluxReconstructionOperator` bindings (needed by `example__ESV2007_estimates`) remain deferred: their C++ APIs also changed (flux reconstruction re-templated to `<AGV,F,V,SGV,RGV>`, now a `ForwardOperatorInterface`; oswald's whole bind block is under `#if 0` with an open "still broken" TODO). Tracked under #126/#127.

## Verification

- CI `non_docker_build` compiles the bindings (catches the new `apply2`/`norm` binding + any signature mismatch), runs the python tests via `ctest`, and executes the migrated tutorial notebook via myst-nb.
- In a configured dune-gdt build: `make _operators_bilinear_form && python -m pytest python/gdt/test/test_bilinear_form_apply2.py` — expect the test to pass and the tutorial's `np.allclose(l2 + h1_semi, h1)` check to be `True`.

Refs #126, #127, #41

https://claude.ai/code/session_01XyFEzwScqArWtPW2ocT97Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyFEzwScqArWtPW2ocT97Y)_