### PR TITLE
Add assembly-density measurement benchmarks

### DIFF
--- a/benchmarks/assembly_kernels__continuous_lagrange.cpp
+++ b/benchmarks/assembly_kernels__continuous_lagrange.cpp
@@ -1,0 +1,110 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+//
+// Microbenchmark of the element-local assembly kernels in isolation: a continuous-Lagrange H1
+// space on a structured (YaspGrid) cube grid, assembling a stiffness (LocalLaplaceIntegrand) and
+// a mass (LocalElementProductIntegrand) bilinear form. There is no DG coupling and no linear
+// solve, so the measurement is dominated by the per-element quadrature loop, basis evaluation and
+// local-to-global scatter -- the hot path targeted by the assembly-density work (see issue #151).
+//
+// The grid is affine (cubes), the case that the affine fast-path and precomputed shape-function
+// table work is meant to accelerate, so this benchmark is the primary before/after yardstick.
+//
+// FE order (1/2/3) and grid refinement are swept to expose how the kernels scale with the local
+// matrix size and the number of quadrature points. YaspGrid is always available, so this benchmark
+// needs no optional grid module.
+
+#include "config.h"
+
+#include <string>
+#include <vector>
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <dune/xt/common/parallel/threadmanager.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/walker.hh>
+#include <dune/xt/la/container/istl.hh>
+
+#include <dune/gdt/local/bilinear-forms/integrals.hh>
+#include <dune/gdt/local/integrands/laplace.hh>
+#include <dune/gdt/local/integrands/product.hh>
+#include <dune/gdt/operators/bilinear-form.hh>
+#include <dune/gdt/operators/matrix.hh>
+#include <dune/gdt/spaces/h1/continuous-lagrange.hh>
+
+#include "benchmark_common.hh"
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+namespace {
+
+
+// Assemble a single element bilinear form (no intersection terms, no solve) into a sparse matrix.
+// The assembled matrix norm is fed to doNotOptimizeAway so the optimizer cannot elide the work.
+template <class GV, class Integrand>
+void assemble_element_form(const GV& grid_view, const int order, Integrand integrand)
+{
+  using E = XT::Grid::extract_entity_t<GV>;
+  using M = XT::LA::IstlRowMajorSparseMatrix<double>;
+
+  const ContinuousLagrangeSpace<GV> space(grid_view, order);
+  auto form = make_bilinear_form(grid_view);
+  form += LocalElementIntegralBilinearForm<E>(std::move(integrand));
+  auto matrix_op = make_matrix_operator<M>(space);
+  matrix_op.append(form);
+  auto walker = XT::Grid::make_walker(grid_view);
+  walker.append(matrix_op);
+  walker.walk(/*parallel=*/false);
+  ankerl::nanobench::doNotOptimizeAway(matrix_op.matrix().sup_norm());
+}
+
+
+template <class G>
+void run_for_grid(ankerl::nanobench::Bench& bench,
+                  const std::string& dim_tag,
+                  const unsigned int elements_per_dim,
+                  const std::vector<int>& orders)
+{
+  using GV = typename G::LeafGridView;
+  using E = XT::Grid::extract_entity_t<GV>;
+
+  auto grid = XT::Grid::make_cube_grid<G>(0., 1., elements_per_dim);
+  const GV grid_view = grid.leaf_view();
+
+  for (const int order : orders) {
+    bench.run(dim_tag + "__laplace__p" + std::to_string(order),
+              [&]() { assemble_element_form(grid_view, order, LocalLaplaceIntegrand<E>()); });
+    bench.run(dim_tag + "__product__p" + std::to_string(order),
+              [&]() { assemble_element_form(grid_view, order, LocalElementProductIntegrand<E>()); });
+  }
+}
+
+
+} // namespace
+
+
+int main(int argc, char** argv)
+{
+  MPIHelper::instance(argc, argv);
+  XT::Common::threadManager().set_max_threads(1);
+
+  auto bench = Benchmark::make_bench("assembly_kernels__continuous_lagrange");
+  // higher epoch counts than the heavy e2e benchmarks: a single element-assembly sweep is cheap
+  bench.warmup(1).epochs(5).minEpochIterations(1);
+
+  // 2D: 128x128 cells; 3D: 24x24x24 cells -- comparable element counts, kept modest so a sweep
+  // over orders finishes quickly while still amortizing per-walk overhead.
+  run_for_grid<YASP_2D_EQUIDISTANT_OFFSET>(bench, "2d", 128u, {1, 2, 3});
+  run_for_grid<YASP_3D_EQUIDISTANT_OFFSET>(bench, "3d", 24u, {1, 2, 3});
+
+  Benchmark::write_report(bench, "assembly_kernels__continuous_lagrange");
+  return 0;
+}

--- a/benchmarks/assembly_kernels__sipdg.cpp
+++ b/benchmarks/assembly_kernels__sipdg.cpp
@@ -1,0 +1,122 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+//
+// Assembly-only microbenchmark of the SIPDG system for the stationary heat equation (ESV2007
+// testcase). This is the assembly half of benchmarks/stationary_heat_equation__ESV2007.cpp with
+// the linear solve removed, so the measurement isolates the element- and intersection-local
+// assembly kernels (the hot path targeted by the assembly-density work, see issue #151) from the
+// solver. It exercises the DG coupling/penalty integrands that the continuous-Lagrange element
+// benchmark does not.
+//
+// Requires a simplex grid (dune-alugrid); a no-op otherwise, matching the e2e benchmark.
+
+#include "config.h"
+
+#include <functional>
+
+#include <dune/common/parallel/mpihelper.hh>
+
+#include <dune/xt/common/parallel/threadmanager.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/grid/boundaryinfo/types.hh>
+#include <dune/xt/grid/filters/intersection.hh>
+#include <dune/xt/grid/walker.hh>
+#include <dune/xt/la/container/istl.hh>
+
+#include <dune/gdt/data/stationary_heat_equation.hh>
+#include <dune/gdt/functionals/vector-based.hh>
+#include <dune/gdt/local/bilinear-forms/integrals.hh>
+#include <dune/gdt/local/functionals/integrals.hh>
+#include <dune/gdt/local/integrands/ipdg.hh>
+#include <dune/gdt/local/integrands/laplace.hh>
+#include <dune/gdt/local/integrands/laplace-ipdg.hh>
+#include <dune/gdt/local/integrands/product.hh>
+#include <dune/gdt/operators/bilinear-form.hh>
+#include <dune/gdt/operators/matrix.hh>
+#include <dune/gdt/spaces/l2/discontinuous-lagrange.hh>
+
+#include "benchmark_common.hh"
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+#if HAVE_DUNE_ALUGRID
+
+int main(int argc, char** argv)
+{
+  MPIHelper::instance(argc, argv);
+  XT::Common::threadManager().set_max_threads(1);
+
+  using G = ALU_2D_SIMPLEX_CONFORMING;
+  using GV = typename G::LeafGridView;
+  static constexpr size_t d = G::dimension;
+  using E = XT::Grid::extract_entity_t<GV>;
+  using I = XT::Grid::extract_intersection_t<GV>;
+  using M = XT::LA::IstlRowMajorSparseMatrix<double>;
+  using V = XT::LA::IstlDenseVector<double>;
+
+  // SIPDG parameters as used by the ESV2007 testcase
+  const double inner_penalty = 8.;
+  const double dirichlet_penalty = 14.;
+  const std::function<double(const I&)> intersection_diameter = [](const I& intersection) {
+    return intersection.geometry().volume();
+  };
+
+  const Data::ESV2007DiffusionProblem<GV> problem(/*force_order=*/2);
+  auto grid = problem.make_initial_grid();
+  grid.global_refine(2); // extra refinement on top of the testcase grid for a meaningful workload
+  const GV grid_view = grid.leaf_view();
+
+  const DiscontinuousLagrangeSpace<GV> space(grid_view, /*order=*/1);
+
+  auto bench = Benchmark::make_bench("assembly_kernels__sipdg");
+  bench.run("sipdg_p1__assemble_only", [&]() {
+    // assemble the SIPDG bilinear form (weight == diffusion); no linear solve
+    auto lhs = make_bilinear_form(space.grid_view());
+    lhs += LocalElementIntegralBilinearForm<E>(LocalLaplaceIntegrand<E>(problem.diffusion));
+    lhs += {LocalCouplingIntersectionIntegralBilinearForm<I>(
+                LocalLaplaceIPDGIntegrands::InnerCoupling<I>(1., problem.diffusion, problem.diffusion)),
+            XT::Grid::ApplyOn::InnerIntersectionsOnce<GV>()};
+    lhs += {LocalCouplingIntersectionIntegralBilinearForm<I>(
+                LocalIPDGIntegrands::InnerPenalty<I>(inner_penalty, problem.diffusion, intersection_diameter)),
+            XT::Grid::ApplyOn::InnerIntersectionsOnce<GV>()};
+    lhs +=
+        {LocalIntersectionIntegralBilinearForm<I>(
+             LocalLaplaceIPDGIntegrands::DirichletCoupling<I>(1., problem.diffusion)),
+         XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info, new XT::Grid::DirichletBoundary())};
+    lhs +=
+        {LocalIntersectionIntegralBilinearForm<I>(
+             LocalIPDGIntegrands::BoundaryPenalty<I>(dirichlet_penalty, problem.diffusion, intersection_diameter)),
+         XT::Grid::ApplyOn::CustomBoundaryIntersections<GV>(problem.boundary_info, new XT::Grid::DirichletBoundary())};
+    auto matrix_op = make_matrix_operator<M>(space);
+    matrix_op.append(lhs);
+    // assemble the right hand side functional
+    auto rhs_func = make_vector_functional<V>(space);
+    rhs_func.append(LocalElementIntegralFunctional<E>(LocalProductIntegrand<E>().with_ansatz(problem.force)));
+    // assemble everything in one grid walk (no solve)
+    auto walker = XT::Grid::make_walker(space.grid_view());
+    walker.append(matrix_op);
+    walker.append(rhs_func);
+    walker.walk(/*parallel=*/false);
+    ankerl::nanobench::doNotOptimizeAway(matrix_op.matrix().sup_norm());
+    ankerl::nanobench::doNotOptimizeAway(rhs_func.vector().sup_norm());
+  });
+  Benchmark::write_report(bench, "assembly_kernels__sipdg");
+
+  return 0;
+}
+
+#else // HAVE_DUNE_ALUGRID
+
+int main()
+{
+  // The ESV2007 benchmark requires a simplex grid (dune-alugrid); nothing to do otherwise.
+  return 0;
+}
+
+#endif // HAVE_DUNE_ALUGRID


### PR DESCRIPTION
## What

First step of the assembly-kernel computational-density work tracked in #151: a tight, repeatable **measurement harness** so density changes can be evaluated before/after. No assembly kernel code is changed in this PR.

Adds two standalone nanobench benchmarks under `benchmarks/` (picked up automatically by the existing `benchmarks/` CMake glob, reusing `benchmark_common.hh`):

- **`assembly_kernels__continuous_lagrange.cpp`** — element-only assembly of a stiffness form (`LocalLaplaceIntegrand`) and a mass form (`LocalElementProductIntegrand`) on structured `YaspGrid` cubes, swept over FE order (p1/p2/p3) in 2D and 3D. No DG coupling and no linear solve, so the measurement is dominated by the per-element quadrature loop, basis evaluation, and local→global scatter. The cube geometry is affine — exactly the case the planned affine fast-path and precomputed shape-function table work targets — so this is the primary yardstick. `YaspGrid` is always available, so it needs no optional grid module.
- **`assembly_kernels__sipdg.cpp`** — the SIPDG ESV2007 assembly (a copy of `stationary_heat_equation__ESV2007.cpp`) with the linear solve removed, isolating the element- and intersection-local DG coupling/penalty integrands. Guarded by `HAVE_DUNE_ALUGRID`, matching the e2e benchmark.

## Why

The roadmap in #151 (affine fast paths, precomputed shape-function tables, contiguous/aligned local storage, SIMD-friendly loops, and the more invasive batched-integrand path) is only meaningful against a baseline that isolates the assembly hot path from the solver. These benchmarks provide that baseline and the regression yardstick.

## Notes / verification

- Build with the `benchmarks` target; run with `run_benchmarks` (writes nanobench JSON per benchmark).
- ⚠️ I could **not** compile-verify these in the dev container: its CMake is 3.28.3 but the project requires ≥ 3.29 (`CMakeLists.txt:16`), and a configure would trigger a full vcpkg bootstrap. The code mirrors the proven `stationary_heat_equation__ESV2007.cpp` and uses only APIs verified against the codebase, but a CI build is the real check.

Follow-up (separate PRs, per #151): Plan A — release-flag option → affine fast path → precomputed reference tables → contiguous scratch → SIMD-friendly loops.

Closes part of #151.

https://claude.ai/code/session_01To6DyVfZvsc6HNcVWF93Fr

---
_Generated by [Claude Code](https://claude.ai/code/session_01To6DyVfZvsc6HNcVWF93Fr)_