### PR TITLE
CI: bump benchmarks workflow actions off Node 20 runtime

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,14 +23,14 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
 
     - name: Restore build cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v5
       with:
         # See non_docker_build.yml: the vcpkg toolchain in .vcpkg-root must be cached together with
         # build/, otherwise the restored CMake config points at a toolchain that no longer exists.
@@ -63,7 +63,7 @@ jobs:
 
     - name: Save build cache
       if: ${{ success() && steps.configure_cmake.outcome == 'success' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v5
       with:
         path: |
           build
@@ -75,7 +75,7 @@ jobs:
 
     - name: Upload benchmark reports artifact
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: benchmark-reports
         path: build/release/benchmarks/reports/*.json


### PR DESCRIPTION
## Summary

Follow-up to #135, which bumped the GitHub Actions across most workflows but missed `.github/workflows/benchmarks.yml`. That file still pinned the deprecated Node 20 actions flagged in #112.

This brings `benchmarks.yml` in line with the versions #135 settled on:

- `actions/checkout` `v4` → `v6.0.2`
- `actions/cache/restore` `v3` → `v5`
- `actions/cache/save` `v3` → `v5`
- `actions/upload-artifact` `v4` → `v7.0.1` (same commit pin used elsewhere)

With this, no workflow under `.github/workflows/` references a Node 20 action anymore, so CI should be warning-free.

Closes #112.

https://claude.ai/code/session_01KFkzxw7JagkC19mzFjWgSq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFkzxw7JagkC19mzFjWgSq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions in the benchmark workflow, including checkout, build cache management, and artifact upload actions, to latest stable releases for improved functionality and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->