### PR TITLE
CI: harden workflows (persist-credentials + SHA-pinning)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,14 +23,17 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
+        # the publish step pushes from a separate temp clone whose origin URL
+        # already embeds ${GITHUB_TOKEN}, so this checkout's token is not used
+        persist-credentials: false
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
 
     - name: Restore build cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       with:
         # See non_docker_build.yml: the vcpkg toolchain in .vcpkg-root must be cached together with
         # build/, otherwise the restored CMake config points at a toolchain that no longer exists.
@@ -63,7 +66,7 @@ jobs:
 
     - name: Save build cache
       if: ${{ success() && steps.configure_cmake.outcome == 'success' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       with:
         path: |
           build

--- a/.github/workflows/check_markdown_links.yml
+++ b/.github/workflows/check_markdown_links.yml
@@ -10,12 +10,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout reposotiry
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # the link check only reads local files/git history; no token needed
+        persist-credentials: false
     - name: Check links in Markdown files
       # The link check already ran on the PR; in the merge queue this step is
       # skipped so the required "Markdown" check still resolves successfully.
       if: github.event_name == 'pull_request'
-      uses: renefritze/github-action-markdown-link-check@master
+      uses: renefritze/github-action-markdown-link-check@3ae27253639b22d1d6967db89f7c4da468f61763 # master
       with:
         use-verbose-mode: yes
         base-branch: main

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Fetch dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v3.1.0
+      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -21,14 +21,16 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        # this checkout's token is not used for any later git push/API call
+        persist-credentials: false
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
 
     - name: Restore build cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         # .vcpkg-root holds the vcpkg toolchain that VcpkgBootStrap.cmake bakes
         # into build/.../CMakeSystem.cmake. It must be cached together with build/,
@@ -74,7 +76,7 @@ jobs:
 
     - name: Save build cache
       if: ${{ success() && steps.configure_cmake.outcome == 'success' }}
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           build
@@ -99,8 +101,10 @@ jobs:
         python-version: ["3.13"] #, "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        # this checkout's token is not used for any later git push/API call
+        persist-credentials: false
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
@@ -132,17 +136,19 @@ jobs:
       PYTHON_VERSION: "3.13"
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        # this checkout's token is not used for any later git push/API call
+        persist-credentials: false
         fetch-tags: true
         fetch-depth: 0
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Download freshly built wheels
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: wheels_${{ env.PYTHON_VERSION }}
         path: wheelhouse/
@@ -221,7 +227,7 @@ jobs:
 
     steps:
     - name: Download wheels
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: wheels_*
         merge-multiple: true
@@ -230,7 +236,7 @@ jobs:
         ls -l wheels/*
       shell: bash
     - name: Upload wheels to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.14.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       id: upload-pypi_on_tag
       with:
         packages-dir: wheels/
@@ -250,7 +256,7 @@ jobs:
 
     steps:
     - name: Download wheels
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: wheels_*
         merge-multiple: true
@@ -259,7 +265,7 @@ jobs:
         ls -l wheels/*
       shell: bash
     - name: Upload wheels to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.14.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         packages-dir: wheels/
         verbose: true

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -12,7 +12,7 @@ jobs:
       # Only meaningful on a PR; in the merge queue this step is skipped so the
       # required "Block Autosquash Commits" check still resolves successfully.
       if: github.event_name == 'pull_request'
-      uses: xt0rted/block-autosquash-commits-action@v2
+      uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -24,6 +24,9 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # conflict detection only reads local git history; no token needed
+        persist-credentials: false
     - name: Detect merge conflicts
-      uses: olivernybroe/action-conflict-finder@v4.1
+      uses: olivernybroe/action-conflict-finder@1a949ebd954a9eaee58802229ea5f9c69fb93a50 # v4.1


### PR DESCRIPTION
## Summary

Hardens all GitHub Actions workflows consistently, addressing zizmor's `artipacked` and `unpinned-uses` findings surfaced from the CodeRabbit review on #155.

Closes #157.

### `persist-credentials: false`

Added to **every** `actions/checkout` step. Each checkout was audited — none of them rely on the persisted `GITHUB_TOKEN` for a later `git push`/API call:

- `non_docker_build.yml` (3 checkouts) — only build/test/versioneer + artifact upload, no token-authenticated git ops.
- `benchmarks.yml` — the publish step pushes from a **separate** temp clone whose origin URL already embeds `${GITHUB_TOKEN}`, so the checkout token is unused (per the issue notes).
- `sanity_checks.yml` (merge-conflict job) — `action-conflict-finder` only reads local git history.
- `check_markdown_links.yml` — the link check only reads local files/git history.

`dependabot.yml` and `gemini-review.yml` have no checkout step.

### SHA-pinning

All actions are now pinned to immutable commit SHAs with a `# vX.Y.Z` comment:

| Action | Pin |
|---|---|
| `actions/checkout` | `de0fac2…` # v6.0.2 |
| `actions/checkout` (benchmarks) | `34e1148…` # v4.3.1 |
| `actions/cache/{restore,save}` | `27d5ce7…` # v5.0.5 |
| `actions/cache/{restore,save}` (benchmarks) | `6f8efc2…` # v3.5.0 |
| `actions/setup-python` | `a309ff8…` # v6.2.0 |
| `actions/download-artifact` | `3e5f45b…` # v8.0.1 |
| `pypa/gh-action-pypi-publish` | `cef2210…` # v1.14.0 |
| `xt0rted/block-autosquash-commits-action` | `79880c3…` # v2.2.0 |
| `olivernybroe/action-conflict-finder` | `1a949eb…` # v4.1 |
| `dependabot/fetch-metadata` | `25dd0e3…` # v3.1.0 |
| `renefritze/github-action-markdown-link-check` | `3ae2725…` # master |

The version comments reflect the exact release each major/minor tag currently points to, so they stay meaningful. `actions/upload-artifact` (already SHA-pinned) and `actions/github-script` in `gemini-review.yml` were already compliant and left untouched.

### Dependabot

The `github-actions` ecosystem is already configured in `.github/dependabot.yml` with `dependency-type: all` and weekly updates. Dependabot's github-actions updater natively bumps SHA pins and rewrites the `# vX.Y.Z` comments, so no config change is needed.

## Notes

- Versions were intentionally **not** bumped (e.g. `benchmarks.yml` stays on checkout v4 / cache v3) — that's the scope of #155. This PR is purely hardening.
- All six workflow files validate as YAML.

https://claude.ai/code/session_01Q51mUdn5P8dvnexNbzmXyM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q51mUdn5P8dvnexNbzmXyM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations across all CI/CD pipelines including benchmarks, markdown link validation, dependency management, build processes, and sanity checks. Multiple actions now reference specific commit hashes instead of version tags, affecting checkout, cache operations, Python setup, artifact downloads, and publishing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->