### PR TITLE
CI: harden workflows (persist-credentials + SHA-pinning) — rebased

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,14 +23,17 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        # the publish step pushes from a separate temp clone whose origin URL
+        # already embeds ${GITHUB_TOKEN}, so this checkout's token is not used
+        persist-credentials: false
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
 
     - name: Restore build cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         # See non_docker_build.yml: the vcpkg toolchain in .vcpkg-root must be cached together with
         # build/, otherwise the restored CMake config points at a toolchain that no longer exists.
@@ -63,7 +66,7 @@ jobs:
 
     - name: Save build cache
       if: ${{ success() && steps.configure_cmake.outcome == 'success' }}
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           build

--- a/.github/workflows/check_markdown_links.yml
+++ b/.github/workflows/check_markdown_links.yml
@@ -10,12 +10,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout reposotiry
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # the link check only reads local files/git history; no token needed
+        persist-credentials: false
     - name: Check links in Markdown files
       # The link check already ran on the PR; in the merge queue this step is
       # skipped so the required "Markdown" check still resolves successfully.
       if: github.event_name == 'pull_request'
-      uses: renefritze/github-action-markdown-link-check@master
+      uses: renefritze/github-action-markdown-link-check@3ae27253639b22d1d6967db89f7c4da468f61763 # master
       with:
         use-verbose-mode: yes
         base-branch: main

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Fetch dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v3.1.0
+      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -21,14 +21,16 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        # this checkout's token is not used for any later git push/API call
+        persist-credentials: false
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
 
     - name: Restore build cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         # .vcpkg-root holds the vcpkg toolchain that VcpkgBootStrap.cmake bakes
         # into build/.../CMakeSystem.cmake. It must be cached together with build/,
@@ -74,7 +76,7 @@ jobs:
 
     - name: Save build cache
       if: ${{ success() && steps.configure_cmake.outcome == 'success' }}
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           build
@@ -99,8 +101,10 @@ jobs:
         python-version: ["3.13"] #, "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        # this checkout's token is not used for any later git push/API call
+        persist-credentials: false
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
@@ -132,17 +136,19 @@ jobs:
       PYTHON_VERSION: "3.13"
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        # this checkout's token is not used for any later git push/API call
+        persist-credentials: false
         fetch-tags: true
         fetch-depth: 0
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Download freshly built wheels
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: wheels_${{ env.PYTHON_VERSION }}
         path: wheelhouse/
@@ -221,7 +227,7 @@ jobs:
 
     steps:
     - name: Download wheels
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: wheels_*
         merge-multiple: true
@@ -230,7 +236,7 @@ jobs:
         ls -l wheels/*
       shell: bash
     - name: Upload wheels to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.14.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       id: upload-pypi_on_tag
       with:
         packages-dir: wheels/
@@ -250,7 +256,7 @@ jobs:
 
     steps:
     - name: Download wheels
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: wheels_*
         merge-multiple: true
@@ -259,7 +265,7 @@ jobs:
         ls -l wheels/*
       shell: bash
     - name: Upload wheels to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.14.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         packages-dir: wheels/
         verbose: true

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -12,7 +12,7 @@ jobs:
       # Only meaningful on a PR; in the merge queue this step is skipped so the
       # required "Block Autosquash Commits" check still resolves successfully.
       if: github.event_name == 'pull_request'
-      uses: xt0rted/block-autosquash-commits-action@v2
+      uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -24,6 +24,9 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # conflict detection only reads local git history; no token needed
+        persist-credentials: false
     - name: Detect merge conflicts
-      uses: olivernybroe/action-conflict-finder@v4.1
+      uses: olivernybroe/action-conflict-finder@1a949ebd954a9eaee58802229ea5f9c69fb93a50 # v4.1


### PR DESCRIPTION
Rebase of #158 onto current `main`.

The original branch (`claude/github-issue-157-nTbKb`) had conflicted with `main` (`mergeable_state: dirty`) after #155-related changes landed. This branch replays the single hardening commit cleanly on top of `main`.

## Conflict resolution

The only conflict was in `.github/workflows/benchmarks.yml`. Since #158 was opened, `main` (commit `91ae6b5`, "bump benchmarks workflow actions off Node 20 runtime") bumped the benchmarks job to `actions/checkout@v6.0.2` and `actions/cache@v5`, whereas the original PR intentionally left benchmarks on checkout v4 / cache v3 and pinned those older SHAs.

Resolution: keep `main`'s newer versions and apply the PR's hardening intent on top, so benchmarks is now unified with the rest of the workflows:

- `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v6.0.2 (+ `persist-credentials: false`)
- `actions/cache/restore` & `actions/cache/save` → `27d5ce7f107fe9357f9df03efb73ab90386fccae` # v5.0.5

These are the same SHA pins already used in `non_docker_build.yml`. (The "benchmarks stays on v4/v3" note in #158 is therefore now obsolete.)

## Unchanged from #158

Everything else applied without conflict — `persist-credentials: false` on every `actions/checkout`, and SHA-pinning across `non_docker_build.yml`, `check_markdown_links.yml`, `sanity_checks.yml`, and `dependabot.yml`.

Closes #157. Supersedes #158.

All six workflow files validate as YAML.

https://claude.ai/code/session_012a8ApU5nYkDZZKzXbWdF5J

---
_Generated by [Claude Code](https://claude.ai/code/session_012a8ApU5nYkDZZKzXbWdF5J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to pin GitHub Actions to specific commit hashes for improved consistency across benchmarks, builds, publishing, and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->