### PR TITLE
docs: plot benchmark reports via a Plotly Sphinx extension (#142)

### DIFF
--- a/.ci/fetch_benchmark_reports.sh
+++ b/.ci/fetch_benchmark_reports.sh
@@ -24,7 +24,12 @@ fi
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
-git clone --depth 1 --branch "${branch}" "${remote}" "${tmp}"
+# This data source is optional: a transient clone/network failure must not fail the docs job, so
+# treat it like the missing-branch path and let the docs render a placeholder.
+if ! git clone --depth 1 --branch "${branch}" "${remote}" "${tmp}"; then
+  echo "failed to clone '${branch}' from ${remote}; skipping benchmark data fetch"
+  exit 0
+fi
 
 mkdir -p "${dest}"
 if [ -d "${tmp}/reports" ]; then

--- a/.ci/fetch_benchmark_reports.sh
+++ b/.ci/fetch_benchmark_reports.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Fetch the published nanobench JSON reports from the orphan `benchmarks` branch into a local
+# directory, so that the documentation build (the `benchmark-plots` Sphinx directive) can render
+# them. The destination directory ends up holding the per-run report directories directly, e.g.
+#
+#   <dest>/20260607-095800-abc1234/burgers__1d__explicit__fv.json
+#   <dest>/latest/...
+#
+# Usage: fetch_benchmark_reports.sh <dest-dir> [remote-url] [branch]
+#
+# If the branch does not exist yet (no benchmark run has happened on `main`), the script exits 0
+# without creating anything; the docs then render a placeholder note instead of failing.
+set -euo pipefail
+
+dest="${1:?usage: $0 <dest-dir> [remote-url] [branch]}"
+remote="${2:-https://github.com/${GITHUB_REPOSITORY:-dune-gdt/dune-gdt}.git}"
+branch="${3:-benchmarks}"
+
+if ! git ls-remote --exit-code --heads "${remote}" "${branch}" >/dev/null 2>&1; then
+  echo "benchmark branch '${branch}' not found at ${remote}; skipping (docs will show a placeholder)"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+git clone --depth 1 --branch "${branch}" "${remote}" "${tmp}"
+
+mkdir -p "${dest}"
+if [ -d "${tmp}/reports" ]; then
+  cp -r "${tmp}/reports/." "${dest}/"
+  echo "copied benchmark reports from ${branch} into ${dest}"
+else
+  echo "no reports/ directory on branch '${branch}'; nothing to copy"
+fi

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -71,6 +71,10 @@ jobs:
         key: ${{ runner.os }}-bench-release-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
 
     - name: Run benchmarks
+      # the commit being benchmarked is embedded into each JSON report's "meta" block so the
+      # documentation plots can label every data point (see benchmarks/benchmark_common.hh)
+      env:
+        DUNE_GDT_BENCHMARK_GIT_REVISION: ${{ github.sha }}
       run: cmake --build --preset=release --target run_benchmarks
 
     - name: Upload benchmark reports artifact

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -168,6 +168,13 @@ jobs:
         # rendering when the wheels were built with K3D).
         python -m pip install --find-links wheelhouse/ "dune-gdt[docs,visualisation]"
 
+    - name: Fetch published benchmark reports
+      # The benchmark-plots Sphinx directive reads the per-run nanobench JSON reports from this
+      # directory. They live on the orphan `benchmarks` branch; if that branch does not exist yet
+      # the script is a no-op and the docs render a placeholder note.
+      run: |
+        ./.ci/fetch_benchmark_reports.sh "${GITHUB_WORKSPACE}/build/benchmark_data"
+
     - name: Build tutorials (sphinx + myst-nb notebook execution)
       # Run from a neutral directory so the repo-root `dune/` source tree does not
       # shadow the installed bindings. Notebook execution is the actual test: myst-nb
@@ -175,6 +182,8 @@ jobs:
       # writes <out>/reports/<name>.err.log instead of aborting, and we fail the job
       # on those below. We intentionally do NOT pass sphinx -W, because intersphinx
       # inventory fetches emit network-dependent warnings unrelated to the tutorials.
+      env:
+        DUNE_GDT_BENCHMARK_DATA: ${{ github.workspace }}/build/benchmark_data
       run: |
         cd "${RUNNER_TEMP}"
         OUT="${GITHUB_WORKSPACE}/build/tutorials_html"

--- a/benchmarks/benchmark_common.hh
+++ b/benchmarks/benchmark_common.hh
@@ -9,7 +9,9 @@
 #define DUNE_GDT_BENCHMARKS_BENCHMARK_COMMON_HH
 
 #include <cstdlib>
+#include <ctime>
 #include <fstream>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -38,17 +40,57 @@ inline ankerl::nanobench::Bench make_bench(const std::string& title)
 
 
 /**
+ * \brief Return the current UTC time as an ISO-8601 timestamp, e.g. "2026-06-07T09:58:00Z".
+ */
+inline std::string utc_timestamp()
+{
+  const std::time_t now = std::time(nullptr);
+  std::tm tm_utc{};
+#if defined(_WIN32)
+  gmtime_s(&tm_utc, &now);
+#else
+  gmtime_r(&now, &tm_utc);
+#endif
+  char buf[32];
+  std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
+  return std::string(buf);
+}
+
+
+/**
  * \brief Render the nanobench results as JSON to ${DUNE_GDT_BENCHMARK_OUTPUT_DIR}/<name>.json
  *        (or ./<name>.json if the environment variable is unset).
+ *
+ * The nanobench JSON document (a top-level object with a "results" array) is augmented with a
+ * "meta" object so that downstream consumers (e.g. the documentation plots) have reliable date
+ * metadata to plot runtime over time. The capture date is the UTC wall-clock time at which the
+ * report is written; the optional git revision is taken from ${DUNE_GDT_BENCHMARK_GIT_REVISION}.
  */
 inline void write_report(const ankerl::nanobench::Bench& bench, const std::string& name)
 {
   const char* dir = std::getenv("DUNE_GDT_BENCHMARK_OUTPUT_DIR");
   const std::string path = (dir && dir[0] != '\0' ? std::string(dir) + "/" : std::string()) + name + ".json";
+
+  // Render nanobench's JSON to a string so that we can inject the metadata block right after the
+  // opening brace. The nanobench json template always starts the document with '{'.
+  std::ostringstream rendered;
+  ankerl::nanobench::render(ankerl::nanobench::templates::json(), bench, rendered);
+  std::string json = rendered.str();
+  const auto brace = json.find('{');
+  if (brace == std::string::npos)
+    throw std::runtime_error("unexpected nanobench JSON output (no opening brace) for: " + name);
+
+  std::ostringstream meta;
+  meta << "\n \"meta\": {\n  \"date\": \"" << utc_timestamp() << "\"";
+  if (const char* rev = std::getenv("DUNE_GDT_BENCHMARK_GIT_REVISION"); rev && rev[0] != '\0')
+    meta << ",\n  \"git_revision\": \"" << rev << "\"";
+  meta << "\n },";
+  json.insert(brace + 1, meta.str());
+
   std::ofstream out(path);
   if (!out)
     throw std::runtime_error("failed to open benchmark report file for writing: " + path);
-  ankerl::nanobench::render(ankerl::nanobench::templates::json(), bench, out);
+  out << json;
 }
 
 

--- a/python/xt/setup.py.in
+++ b/python/xt/setup.py.in
@@ -28,7 +28,7 @@ requires=['ipython','numpy', 'scipy']
 # also keeps the flattened 'all' extra from forcing 2022.2.0 project-wide.
 visualization_packages = [ 'k3d>=2.15.2', 'vtk', 'ipywidgets', 'lxml', 'xmljson',
                             'matplotlib', 'wurlitzer',]
-docs_packages = ['python-slugify', 'sphinxcontrib-bibtex', 'furo', 'myst-nb>=0.16', 'pymor']
+docs_packages = ['python-slugify', 'sphinxcontrib-bibtex', 'furo', 'myst-nb>=0.16', 'pymor', 'plotly']
 examples_packages = ['pymor==2022.2.0; python_version < "3.11"',
                      'pymor; python_version >= "3.11"']
 

--- a/tutorials/source/_ext/benchmark_plots.py
+++ b/tutorials/source/_ext/benchmark_plots.py
@@ -1,0 +1,271 @@
+"""A minimal Sphinx extension that renders nanobench JSON reports as Plotly plots.
+
+The extension provides a single directive, ``benchmark-plots``, which reads the per-run nanobench
+JSON reports produced by the ``Benchmarks`` workflow (and published onto the orphan ``benchmarks``
+branch) and renders, into the static HTML page:
+
+* a summary table of the most recent timings, and
+* one interactive Plotly plot per benchmark *series* (a ``title``/``name`` pair, i.e. one
+  ``bench.run(...)`` call), showing the median runtime over the report date.
+
+Data location
+-------------
+The directive reads the directory configured via the ``benchmark_data_dir`` Sphinx config value,
+which defaults to the ``DUNE_GDT_BENCHMARK_DATA`` environment variable and, failing that, to
+``<confdir>/_benchmark_data``. That directory is expected to contain the report layout used on the
+``benchmarks`` branch::
+
+    <data-dir>/
+      20260607-095800-abc1234/   # one directory per run (<UTCstamp>-<shortsha>)
+        burgers__1d__explicit__fv.json
+        stokes__taylorhood.json
+        ...
+      20260608-101500-def5678/
+        ...
+      latest/                    # ignored here (a copy of the most recent run)
+
+Each JSON file is a nanobench document (a top-level object with a ``results`` array) augmented with
+a ``meta`` block carrying ``date`` (and optionally ``git_revision``); see
+``benchmarks/benchmark_common.hh``. The run-directory name is used as a fallback when a report
+predates the metadata or lacks it.
+
+Robustness
+----------
+When no data is available (the ``benchmarks`` branch has not produced reports yet, or Plotly is not
+installed) the directive renders an informational note instead of failing the build. This keeps the
+``-W`` (warnings-as-errors) docs build green.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+# nanobench renders elapsed time in seconds per operation; pick a human-friendly unit for the axis.
+_TIME_UNITS = [(1.0, "s"), (1e-3, "ms"), (1e-6, "µs"), (1e-9, "ns")]
+
+
+def _resolve_data_dir(env) -> Path | None:
+    """Return the configured benchmark data directory, or ``None`` if it does not exist."""
+    configured = env.config.benchmark_data_dir
+    if not configured:
+        configured = os.environ.get("DUNE_GDT_BENCHMARK_DATA")
+    if configured:
+        path = Path(configured).expanduser()
+    else:
+        path = Path(env.app.confdir) / "_benchmark_data"
+    return path if path.is_dir() else None
+
+
+def _parse_date(report: dict, run_name: str) -> datetime | None:
+    """Determine the date of a report, preferring the embedded metadata over the directory name."""
+    meta_date = (report.get("meta") or {}).get("date")
+    if meta_date:
+        try:
+            return datetime.fromisoformat(str(meta_date).replace("Z", "+00:00"))
+        except ValueError:
+            logger.info("benchmark-plots: could not parse meta date %r", meta_date)
+    # fall back to the "<YYYYmmdd>-<HHMMSS>-<sha>" run directory name
+    parts = run_name.split("-")
+    if len(parts) >= 2:
+        try:
+            return datetime.strptime(f"{parts[0]}-{parts[1]}", "%Y%m%d-%H%M%S").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            pass
+    return None
+
+
+def _revision(report: dict, run_name: str) -> str:
+    rev = (report.get("meta") or {}).get("git_revision")
+    if rev:
+        return str(rev)[:12]
+    parts = run_name.split("-")
+    return parts[2] if len(parts) >= 3 else ""
+
+
+def _collect_series(data_dir: Path) -> dict[tuple[str, str], list[dict]]:
+    """Collect ``{(title, name): [point, ...]}`` across all run directories, sorted by date.
+
+    Each point is ``{"date", "elapsed", "error", "rev", "unit"}`` where ``elapsed`` is the median
+    runtime in seconds.
+    """
+    series: dict[tuple[str, str], list[dict]] = {}
+    run_dirs = sorted(
+        d for d in data_dir.iterdir() if d.is_dir() and d.name != "latest"
+    )
+    for run in run_dirs:
+        for jf in sorted(run.glob("*.json")):
+            try:
+                report = json.loads(jf.read_text())
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "benchmark-plots: skipping unreadable report %s: %s", jf, exc
+                )
+                continue
+            date = _parse_date(report, run.name)
+            if date is None:
+                logger.info("benchmark-plots: no date for %s, skipping", jf)
+                continue
+            rev = _revision(report, run.name)
+            for result in report.get("results", []):
+                title = result.get("title") or jf.stem
+                name = result.get("name", "")
+                elapsed = result.get("median(elapsed)")
+                if elapsed is None:
+                    continue
+                key = (title, name)
+                series.setdefault(key, []).append(
+                    {
+                        "date": date,
+                        "elapsed": float(elapsed),
+                        "error": result.get("medianAbsolutePercentError(elapsed)"),
+                        "rev": rev,
+                        "unit": result.get("unit", "op"),
+                    }
+                )
+    for points in series.values():
+        points.sort(key=lambda p: p["date"])
+    return series
+
+
+def _scale_for(max_elapsed: float) -> tuple[float, str]:
+    """Pick a (divisor, label) so that runtimes read in a friendly unit."""
+    for factor, label in _TIME_UNITS:
+        if max_elapsed >= factor:
+            return factor, label
+    return _TIME_UNITS[-1]
+
+
+def _note(text: str) -> list[nodes.Node]:
+    note = nodes.note()
+    note += nodes.paragraph(text=text)
+    return [note]
+
+
+def _summary_table(series: dict[tuple[str, str], list[dict]]) -> nodes.Node:
+    """A docutils table of the most recent timing for every series."""
+    table = nodes.table()
+    tgroup = nodes.tgroup(cols=4)
+    table += tgroup
+    for width in (4, 2, 1, 2):
+        tgroup += nodes.colspec(colwidth=width)
+    header = nodes.thead()
+    tgroup += header
+    header_row = nodes.row()
+    header += header_row
+    for label in ("Benchmark", "Median runtime", "Error", "Date"):
+        entry = nodes.entry()
+        entry += nodes.paragraph(text=label)
+        header_row += entry
+    body = nodes.tbody()
+    tgroup += body
+    for (title, name), points in sorted(series.items()):
+        latest = points[-1]
+        factor, unit = _scale_for(latest["elapsed"])
+        err = latest["error"]
+        cells = [
+            f"{title} / {name}" if name else title,
+            f"{latest['elapsed'] / factor:.3f} {unit}",
+            f"{err:.1f} %" if err is not None else "—",
+            latest["date"].strftime("%Y-%m-%d"),
+        ]
+        row = nodes.row()
+        body += row
+        for cell in cells:
+            entry = nodes.entry()
+            entry += nodes.paragraph(text=cell)
+            row += entry
+    return table
+
+
+def _plot_html(title: str, name: str, points: list[dict], include_js: bool) -> str:
+    import plotly.graph_objects as go
+
+    factor, unit = _scale_for(max(p["elapsed"] for p in points))
+    dates = [p["date"] for p in points]
+    values = [p["elapsed"] / factor for p in points]
+    # nanobench reports the median-absolute-percent-error; turn it into an absolute error band
+    errors = [
+        (p["error"] / 100.0) * (p["elapsed"] / factor)
+        if p["error"] is not None
+        else 0.0
+        for p in points
+    ]
+    revs = [p["rev"] for p in points]
+    fig = go.Figure(
+        go.Scatter(
+            x=dates,
+            y=values,
+            error_y=dict(type="data", array=errors, visible=True),
+            mode="lines+markers",
+            customdata=revs,
+            hovertemplate=(
+                "%{x|%Y-%m-%d %H:%M} UTC<br>%{y:.3f} "
+                + unit
+                + "<br>%{customdata}<extra></extra>"
+            ),
+        )
+    )
+    heading = f"{title} / {name}" if name else title
+    fig.update_layout(
+        title=heading,
+        xaxis_title="date",
+        yaxis_title=f"median runtime [{unit}]",
+        margin=dict(l=60, r=20, t=50, b=40),
+        height=380,
+    )
+    return fig.to_html(
+        full_html=False,
+        include_plotlyjs="cdn" if include_js else False,
+        default_width="100%",
+    )
+
+
+class BenchmarkPlotsDirective(Directive):
+    has_content = False
+
+    def run(self) -> list[nodes.Node]:
+        env = self.state.document.settings.env
+        data_dir = _resolve_data_dir(env)
+        if data_dir is None:
+            return _note(
+                "No benchmark data available. Reports are published onto the `benchmarks` branch "
+                "by the Benchmarks workflow; once present they will be plotted here."
+            )
+        series = _collect_series(data_dir)
+        if not series:
+            return _note(f"No benchmark reports found under {data_dir}.")
+
+        try:
+            import plotly.graph_objects  # noqa: F401
+        except ImportError:
+            logger.info(
+                "benchmark-plots: plotly is not installed; rendering the table only"
+            )
+            return [_summary_table(series)]
+
+        result: list[nodes.Node] = [_summary_table(series)]
+        for index, ((title, name), points) in enumerate(sorted(series.items())):
+            html = _plot_html(title, name, points, include_js=(index == 0))
+            result.append(nodes.raw("", html, format="html"))
+        return result
+
+
+def setup(app):
+    app.add_config_value("benchmark_data_dir", None, "env")
+    app.add_directive("benchmark-plots", BenchmarkPlotsDirective)
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tutorials/source/_ext/benchmark_plots.py
+++ b/tutorials/source/_ext/benchmark_plots.py
@@ -70,7 +70,12 @@ def _parse_date(report: dict, run_name: str) -> datetime | None:
     meta_date = (report.get("meta") or {}).get("date")
     if meta_date:
         try:
-            return datetime.fromisoformat(str(meta_date).replace("Z", "+00:00"))
+            parsed = datetime.fromisoformat(str(meta_date).replace("Z", "+00:00"))
+            # normalize to UTC-aware so that mixing reports with and without an explicit offset
+            # does not raise when sorting the series chronologically
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
         except ValueError:
             logger.info("benchmark-plots: could not parse meta date %r", meta_date)
     # fall back to the "<YYYYmmdd>-<HHMMSS>-<sha>" run directory name
@@ -252,7 +257,12 @@ class BenchmarkPlotsDirective(Directive):
             logger.info(
                 "benchmark-plots: plotly is not installed; rendering the table only"
             )
-            return [_summary_table(series)]
+            return [
+                _summary_table(series),
+                *_note(
+                    "Plotly is not installed; rendering the benchmark summary table only."
+                ),
+            ]
 
         result: list[nodes.Node] = [_summary_table(series)]
         for index, ((title, name), points) in enumerate(sorted(series.items())):

--- a/tutorials/source/benchmarks.md
+++ b/tutorials/source/benchmarks.md
@@ -1,0 +1,15 @@
+# Benchmarks
+
+These plots track the runtime of the standalone [nanobench](https://github.com/martinus/nanobench)
+benchmarks in [`benchmarks/`](https://github.com/dune-gdt/dune-gdt/tree/main/benchmarks). The
+`Benchmarks` workflow builds them in `Release` on every push to `main`, runs them, and publishes the
+per-benchmark JSON reports onto the orphan `benchmarks` branch. The documentation build fetches
+those reports and renders, for each benchmark series, the median runtime over the report date so
+that performance regressions become visible.
+
+The table shows the most recent measurement for every series; each plot below it shows that series'
+history. Error bars correspond to nanobench's median-absolute-percent-error; hover over a point to
+see the commit it was measured at.
+
+```{benchmark-plots}
+```

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -22,6 +22,7 @@ this_dir = Path(__file__).resolve().parent
 src_dir = (this_dir / ".." / ".." / "src").resolve()
 sys.path.insert(0, str(src_dir))
 sys.path.insert(0, str(this_dir))
+sys.path.insert(0, str(this_dir / "_ext"))
 branch = os.environ.get("CI_COMMIT_REF_NAME", "main")
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
@@ -36,6 +37,7 @@ extensions = [
     "myst_nb",
     "sphinx.ext.mathjax",
     "sphinxcontrib.bibtex",
+    "benchmark_plots",
 ]
 # this enables:
 # substitutions-with-jinja2, direct-latex-math and definition-lists

--- a/tutorials/source/index.md
+++ b/tutorials/source/index.md
@@ -8,5 +8,6 @@ A subset of the API is exposed as Python-bindings using [pybind11](https://githu
 ```{toctree}
 tutorials
 examples
+benchmarks
 bibliography
 ```

--- a/tutorials/test_benchmark_plots.py
+++ b/tutorials/test_benchmark_plots.py
@@ -1,0 +1,129 @@
+"""Unit tests for the ``benchmark_plots`` Sphinx extension (see source/_ext/benchmark_plots.py).
+
+These exercise the report parsing / aggregation independently of a full Sphinx build, so they run
+fast and without the dune-gdt bindings.
+"""
+
+import json
+import sys
+from datetime import timezone
+from pathlib import Path
+
+import pytest
+
+EXT_DIR = Path(__file__).resolve().parent / "source" / "_ext"
+sys.path.insert(0, str(EXT_DIR))
+
+import benchmark_plots as bp  # noqa: E402
+
+
+def _write_report(directory: Path, filename: str, payload: dict) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / filename).write_text(json.dumps(payload))
+
+
+def _make_data(root: Path) -> None:
+    _write_report(
+        root / "20260601-100000-aaaa111",
+        "burgers__1d__explicit__fv.json",
+        {
+            "meta": {"date": "2026-06-01T10:00:00Z", "git_revision": "aaaa111"},
+            "results": [
+                {
+                    "title": "burgers__1d__explicit__fv",
+                    "name": "explicit_euler__upwind",
+                    "unit": "op",
+                    "median(elapsed)": 0.0123,
+                    "medianAbsolutePercentError(elapsed)": 2.5,
+                }
+            ],
+        },
+    )
+    # second run, two series in one file, and no meta block (exercises directory-name fallback)
+    _write_report(
+        root / "20260605-100000-bbbb222",
+        "burgers__1d__explicit__fv.json",
+        {
+            "meta": {"date": "2026-06-05T10:00:00Z", "git_revision": "bbbb222"},
+            "results": [
+                {
+                    "title": "burgers__1d__explicit__fv",
+                    "name": "explicit_euler__upwind",
+                    "median(elapsed)": 0.0131,
+                    "medianAbsolutePercentError(elapsed)": 1.8,
+                }
+            ],
+        },
+    )
+    _write_report(
+        root / "20260605-100000-bbbb222",
+        "stokes__taylorhood.json",
+        {
+            "results": [
+                {
+                    "title": "stokes__taylorhood",
+                    "name": "solve",
+                    "median(elapsed)": 1.2,
+                },
+            ]
+        },
+    )
+    # a "latest" copy that must be ignored by the aggregation
+    _write_report(
+        root / "latest",
+        "burgers__1d__explicit__fv.json",
+        {"meta": {"date": "2026-06-05T10:00:00Z"}, "results": []},
+    )
+
+
+def test_collect_series_groups_and_sorts(tmp_path):
+    _make_data(tmp_path)
+    series = bp._collect_series(tmp_path)
+
+    burgers = ("burgers__1d__explicit__fv", "explicit_euler__upwind")
+    assert burgers in series
+    points = series[burgers]
+    assert [p["elapsed"] for p in points] == [0.0123, 0.0131]  # sorted by date
+    assert [p["rev"] for p in points] == ["aaaa111", "bbbb222"]
+
+    # the "latest" directory must not contribute an extra run
+    assert all(p["date"].year == 2026 for p in points)
+    assert ("stokes__taylorhood", "solve") in series
+
+
+def test_parse_date_prefers_meta_then_dirname():
+    meta_date = bp._parse_date({"meta": {"date": "2026-06-05T10:00:00Z"}}, "ignored")
+    assert meta_date.tzinfo is not None
+    assert meta_date.astimezone(timezone.utc).hour == 10
+
+    fallback = bp._parse_date({}, "20260605-100000-bbbb222")
+    assert fallback.year == 2026 and fallback.month == 6 and fallback.day == 5
+
+    assert bp._parse_date({}, "not-a-date") is None
+
+
+def test_revision_falls_back_to_dirname():
+    assert bp._revision({"meta": {"git_revision": "deadbeef"}}, "x") == "deadbeef"
+    assert bp._revision({}, "20260605-100000-bbbb222") == "bbbb222"
+    assert bp._revision({}, "nofields") == ""
+
+
+def test_scale_for_picks_human_unit():
+    assert bp._scale_for(1.5)[1] == "s"
+    assert bp._scale_for(0.012)[1] == "ms"
+    assert bp._scale_for(5e-6)[1] == "µs"
+
+
+def test_plot_html_renders_plotly(tmp_path):
+    pytest.importorskip("plotly")
+    _make_data(tmp_path)
+    series = bp._collect_series(tmp_path)
+    key = ("burgers__1d__explicit__fv", "explicit_euler__upwind")
+    html = bp._plot_html(*key, series[key], include_js=True)
+    assert "plotly" in html.lower()
+    # the embedded data must reference the measured commits
+    assert "aaaa111" in html and "bbbb222" in html
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))

--- a/tutorials/test_benchmark_plots.py
+++ b/tutorials/test_benchmark_plots.py
@@ -96,6 +96,12 @@ def test_parse_date_prefers_meta_then_dirname():
     assert meta_date.tzinfo is not None
     assert meta_date.astimezone(timezone.utc).hour == 10
 
+    # a timezone-less meta date must still come back UTC-aware so it can be sorted alongside the
+    # directory-name fallback (which is always UTC-aware)
+    naive = bp._parse_date({"meta": {"date": "2026-06-05T10:00:00"}}, "ignored")
+    assert naive.tzinfo is not None
+    assert naive.astimezone(timezone.utc).hour == 10
+
     fallback = bp._parse_date({}, "20260605-100000-bbbb222")
     assert fallback.year == 2026 and fallback.month == 6 and fallback.day == 5
 


### PR DESCRIPTION
Closes #142.

Surfaces the standalone nanobench benchmark reports (published onto the orphan `benchmarks` branch by the `Benchmarks` workflow) in the documentation as **runtime-over-date** plots, one per benchmark series.

## What this does

- **Date metadata in reports** — `benchmarks/benchmark_common.hh::write_report` now wraps the nanobench JSON document (`{"results": [...]}`) with a `"meta"` block carrying an ISO-8601 UTC capture `date` and, when `DUNE_GDT_BENCHMARK_GIT_REVISION` is set, the `git_revision`. The result stays a strict superset of the nanobench format (the `results` array is untouched). The `Benchmarks` workflow now passes `${{ github.sha }}` via that env var when running the benchmarks.

- **Minimal Sphinx extension** — `tutorials/source/_ext/benchmark_plots.py` adds a `benchmark-plots` directive that reads the per-run reports and renders, into the static HTML page:
  - a summary table of the most recent timing for every series, and
  - one interactive **Plotly** plot per series (`title`/`name` pair), median runtime over date, with error bars (nanobench's median-absolute-percent-error) and the per-point commit on hover.

  The date is taken from the embedded `meta.date`, falling back to the `<UTCstamp>-<sha>` run-directory name for older reports. When no data is present (the `benchmarks` branch hasn't produced reports yet) or Plotly isn't installed, the directive renders an informational note rather than failing — keeping the `-W` docs build green.

- **Docs page** — new `tutorials/source/benchmarks.md`, wired into the `index` toctree.

- **Data fetching** — `.ci/fetch_benchmark_reports.sh` clones the `reports/` tree from the `benchmarks` branch into a local data dir (no-op if the branch doesn't exist yet). The docs CI job (`build_tutorials`) pre-creates that dir and points the extension at it via `DUNE_GDT_BENCHMARK_DATA`.

- **Deps & tests** — `plotly` added to the `docs` extra; `tutorials/test_benchmark_plots.py` unit-tests the report aggregation, date/revision fallbacks, unit scaling, and Plotly rendering.

## Verification

- `ruff check` / `ruff format --check`, `shellcheck`, and `clang-format --dry-run --Werror` all pass on the changed files.
- The C++ metadata injection was compiled (`-Wall -Wextra`) against a simulated nanobench document and validated to produce valid JSON.
- The directive was exercised end-to-end with a minimal `sphinx-build -W` against synthetic reports: the summary table and one Plotly plot per series render, and the no-data / empty-data paths build cleanly with only an informational note.
- `tutorials/test_benchmark_plots.py` passes (5 tests).

## Notes / follow-ups

- The plots reference Plotly via CDN (`include_plotlyjs="cdn"`), loaded once on the first figure.
- A regression gate (compare `latest` against the previous run) remains out of scope, as noted in the issue; the accumulated history makes it possible later.

https://claude.ai/code/session_017gzgn76okhk3Vq79cJy2kK

---
_Generated by [Claude Code](https://claude.ai/code/session_017gzgn76okhk3Vq79cJy2kK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation build now fetches published benchmark data and embeds it in tutorials.
  * Benchmark reports include timestamps and commit identifiers; visualizations use these for series over time.

* **Documentation**
  * Added interactive benchmark plots and a new benchmarks docs page with explanations and examples.

* **Tests**
  * Added tests covering report parsing, series aggregation/sorting, unit scaling, and plot rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->