### PR TITLE
[doc] Document "missing everything" headers in dune/xt (#165, bucket 1)

### DIFF
--- a/dune/xt/common/compiler.hh
+++ b/dune/xt/common/compiler.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2015 - 2016, 2018 - 2019)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Defines the DXTC_GNUC_VERSION macro encoding the GCC compiler version.
+
 #ifndef DUNE_XT_COMMON_COMPILER_HH
 #define DUNE_XT_COMMON_COMPILER_HH
 

--- a/dune/xt/common/densevector.hh
+++ b/dune/xt/common/densevector.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Provides scalar multiplication and division operators for Dune::DenseVector.
+
 #ifndef DUNE_XT_COMMON_DENSEVECTOR_HH
 #define DUNE_XT_COMMON_DENSEVECTOR_HH
 
@@ -19,6 +22,7 @@
 namespace Dune {
 
 
+/// \brief Returns the product of a scalar and a dense vector.
 template <class S, class V>
 typename std::enable_if<Dune::XT::Common::is_arithmetic<S>::value || Dune::XT::Common::is_complex<S>::value,
                         typename DenseVector<V>::derived_type>::type
@@ -30,6 +34,7 @@ operator*(const S& alpha, const DenseVector<V>& vec)
 }
 
 
+/// \brief Returns the product of a dense vector and a scalar.
 template <class V, class S>
 typename std::enable_if<Dune::XT::Common::is_arithmetic<S>::value || Dune::XT::Common::is_complex<S>::value,
                         typename DenseVector<V>::derived_type>::type
@@ -41,6 +46,7 @@ operator*(const DenseVector<V>& vec, const S& alpha)
 }
 
 
+/// \brief Returns the quotient of a dense vector divided by a scalar.
 template <class V, class S>
 typename std::enable_if<Dune::XT::Common::is_arithmetic<S>::value || Dune::XT::Common::is_complex<S>::value,
                         typename DenseVector<V>::derived_type>::type

--- a/dune/xt/common/disable_warnings.hh
+++ b/dune/xt/common/disable_warnings.hh
@@ -10,6 +10,9 @@
 //   René Fritze     (2011 - 2012, 2014 - 2019)
 //   Tobias Leibner  (2014, 2016 - 2020)
 
+/// \file
+/// \brief Pushes the diagnostic state and disables a list of compiler warnings.
+
 #include <boost/config.hpp>
 
 // Please sort these alphabetically!

--- a/dune/xt/common/float_cmp_internal.hh
+++ b/dune/xt/common/float_cmp_internal.hh
@@ -11,6 +11,9 @@
 //   Tim Keil         (2018)
 //   Tobias Leibner   (2017 - 2020)
 
+/// \file
+/// \brief Internal helper traits and dispatchers backing the float comparison routines.
+
 #ifndef DUNE_XT_COMMON_FLOAT_CMP_INTERNAL_HH
 #define DUNE_XT_COMMON_FLOAT_CMP_INTERNAL_HH
 

--- a/dune/xt/common/float_cmp_style.hh
+++ b/dune/xt/common/float_cmp_style.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2015 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Defines the float comparison Style enum and its conversion to Dune::FloatCmp::CmpStyle.
+
 #ifndef DUNE_XT_COMMON_FLOAT_CMP_STYLE_HH
 #define DUNE_XT_COMMON_FLOAT_CMP_STYLE_HH
 
@@ -22,6 +25,7 @@
 
 namespace Dune::XT::Common::FloatCmp {
 
+/// \brief Selects the comparison method used by the float comparison routines.
 enum class Style
 {
   numpy,

--- a/dune/xt/common/fmatrix.hh
+++ b/dune/xt/common/fmatrix.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2014, 2018 - 2020)
 
+/// \file
+/// \brief Includes the dune-common version-specific dune-xt FieldMatrix extensions.
+
 #ifndef DUNE_XT_COMMON_FMATRIX_HH
 #define DUNE_XT_COMMON_FMATRIX_HH
 

--- a/dune/xt/common/fvector.hh
+++ b/dune/xt/common/fvector.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2014, 2016 - 2020)
 
+/// \file
+/// \brief Includes the dune-common version-specific dune-xt FieldVector extensions.
+
 #ifndef DUNE_XT_COMMON_FVECTOR_HH
 #define DUNE_XT_COMMON_FVECTOR_HH
 

--- a/dune/xt/common/localization-study.hh
+++ b/dune/xt/common/localization-study.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2015 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Provides the LocalizationStudy base class for comparing localization indicators against a reference.
+
 #ifndef DUNE_XT_COMMON_LOCALIZATION_STUDY_HH
 #define DUNE_XT_COMMON_LOCALIZATION_STUDY_HH
 
@@ -23,23 +26,31 @@
 
 namespace Dune::XT::Common {
 
+/// \brief Base class to compare provided localization indicators against reference indicators.
 class LocalizationStudy
 {
 public:
+  /// \brief Constructs the study, optionally restricting it to the given indicators.
   LocalizationStudy(std::vector<std::string> only_these_indicators = {});
 
   virtual ~LocalizationStudy();
 
+  /// \brief Returns a name identifying this study.
   virtual std::string identifier() const = 0;
 
+  /// \brief Computes the reference indicators the provided indicators are compared against.
   virtual DynamicVector<double> compute_reference_indicators() const = 0;
 
+  /// \brief Returns the names of all indicators provided by this study.
   virtual std::vector<std::string> provided_indicators() const = 0;
 
+  /// \brief Computes the indicator of the given type.
   virtual DynamicVector<double> compute_indicators(const std::string type) const = 0;
 
+  /// \brief Returns the provided indicators actually used by this study.
   std::vector<std::string> used_indicators() const;
 
+  /// \brief Runs the study and prints the comparison of each indicator against the reference to out.
   /*std::map< std::string, std::vector< double > >*/ void run(std::ostream& out = std::cout) const;
 
 private:

--- a/dune/xt/common/numeric.hh
+++ b/dune/xt/common/numeric.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2020)
 //   Tobias Leibner (2019 - 2020)
 
+/// \file
+/// \brief Provides reduce and transform_reduce with fallbacks for compilers lacking C++17 parallel algorithms.
+
 #ifndef DUNE_XT_COMMON_NUMERIC_HH
 #define DUNE_XT_COMMON_NUMERIC_HH
 
@@ -22,8 +25,8 @@
 namespace Dune::XT::Common {
 
 
-// Uses std::reduce if available, and falls back to std::accumulate on older compilers.
-// The std::reduce versions with an execution policy as first argument are not supported.
+/// \brief Uses std::reduce if available, and falls back to std::accumulate on older compilers.
+/// The std::reduce versions with an execution policy as first argument are not supported.
 template <class... Args>
 decltype(auto) reduce(Args&&... args)
 {
@@ -34,8 +37,8 @@ decltype(auto) reduce(Args&&... args)
 #endif
 }
 
-// Uses std::transform_reduce if available, and falls back to std::inner_product on older compilers.
-// The std::transform_reduce versions with an execution policy as first argument are not supported.
+/// \brief Uses std::transform_reduce if available, and falls back to std::inner_product on older compilers.
+/// The std::transform_reduce versions with an execution policy as first argument are not supported.
 template <class... Args>
 decltype(auto) transform_reduce(Args&&... args)
 {

--- a/dune/xt/common/python.hh
+++ b/dune/xt/common/python.hh
@@ -11,6 +11,9 @@
 //
 // Created by r_milk01 on 4/25/18.
 
+/// \file
+/// \brief Provides guarded_bind to register pybind11 bindings while tolerating duplicate registration.
+
 #ifndef DUNE_XT_COMMON_PYTHON_HH
 #define DUNE_XT_COMMON_PYTHON_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::Common::bindings {
 
 
+/// \brief Runs the given binding registrar, guarding against errors from already registered types.
 void guarded_bind(const std::function<void()>& registrar);
 
 

--- a/dune/xt/common/reenable_warnings.hh
+++ b/dune/xt/common/reenable_warnings.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2011 - 2012, 2015 - 2016, 2018 - 2019)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Restores the diagnostic state previously saved by disable_warnings.hh.
+
 #include <boost/config.hpp>
 
 #if defined(BOOST_INTEL) && BOOST_INTEL

--- a/dune/xt/common/string_internal.hh
+++ b/dune/xt/common/string_internal.hh
@@ -11,6 +11,9 @@
 //   Sven Kaulmann   (2011 - 2012)
 //   Tobias Leibner  (2014 - 2015, 2017 - 2020)
 
+/// \file
+/// \brief Internal helpers backing the string conversion and tokenization routines.
+
 #ifndef DUNE_XT_COMMON_STRING_INTERNAL_HH
 #define DUNE_XT_COMMON_STRING_INTERNAL_HH
 

--- a/dune/xt/common/unused.hh
+++ b/dune/xt/common/unused.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2015 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2020 - 2021)
 
+/// \file
+/// \brief Defines the DXTC_DEBUG_ONLY and DXTC_MPI_ONLY macros to mark conditionally unused entities.
+
 #ifndef DXTC_UNUSED_HH
 #define DXTC_UNUSED_HH
 

--- a/dune/xt/common/vector_statistics.hh
+++ b/dune/xt/common/vector_statistics.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2017 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Provides standard_deviation for dune-xt vector types.
+
 #ifndef DUNE_XT_COMMON_VECTOR_STATISTICS_HH
 #define DUNE_XT_COMMON_VECTOR_STATISTICS_HH
 
@@ -21,6 +24,7 @@
 
 namespace Dune::XT::Common {
 
+/// \brief Returns the standard deviation of the entries of the given vector.
 template <class VectorType>
 typename std::enable_if<is_vector<VectorType>::value, typename VectorAbstraction<VectorType>::S>::type
 standard_deviation(const VectorType& vector)

--- a/dune/xt/functions/base/combined.hh
+++ b/dune/xt/functions/base/combined.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2014, 2017)
 
+/// \file
+/// \brief Internal helpers for combining grid functions via binary/unary operations.
+
 #ifndef DUNE_XT_FUNCTIONS_BASE_COMBINED_HH
 #define DUNE_XT_FUNCTIONS_BASE_COMBINED_HH
 

--- a/dune/xt/functions/base/derivatives-of-grid-functions.hh
+++ b/dune/xt/functions/base/derivatives-of-grid-functions.hh
@@ -8,6 +8,9 @@
 //   Felix Schindler (2020)
 //   René Fritze     (2020)
 
+/// \file
+/// \brief Grid functions representing derivatives (gradient, divergence) of other grid functions.
+
 #ifndef DUNE_XT_FUNCTIONS_BASE_DERIVATIVES_OF_GRID_FUNCTIONS_HH
 #define DUNE_XT_FUNCTIONS_BASE_DERIVATIVES_OF_GRID_FUNCTIONS_HH
 
@@ -23,6 +26,7 @@
 namespace Dune::XT::Functions {
 
 
+/// \brief Grid function representing a derivative (selected by DerivativeType) of a given grid function.
 template <class GridFunctionType, DerivativeType derivative>
 class DerivativeGridFunction
   : public GridFunctionInterface<typename internal::DerivativeElementFunctionHelper<GridFunctionType, derivative>::E,
@@ -95,6 +99,7 @@ private:
 }; // class DerivativeGridFunction
 
 
+/// \brief Grid function representing the divergence of a given grid function.
 template <class GridFunctionType>
 class DivergenceGridFunction : public DerivativeGridFunction<GridFunctionType, DerivativeType::divergence>
 {
@@ -109,6 +114,7 @@ public:
 }; // class DivergenceGridFunction
 
 
+/// \brief Grid function representing the gradient of a given grid function.
 template <class GridFunctionType>
 class GradientGridFunction : public DerivativeGridFunction<GridFunctionType, DerivativeType::gradient>
 {

--- a/dune/xt/functions/base/function-as-flux-function.hh
+++ b/dune/xt/functions/base/function-as-flux-function.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2019 - 2020)
 //   Tobias Leibner (2019 - 2020)
 
+/// \file
+/// \brief Wraps a state-dependent function f(u) as a flux function f(x, u).
+
 #ifndef DUNE_XT_FUNCTIONS_BASE_FUNCTION_AS_FLUX_FUNCTION_HH
 #define DUNE_XT_FUNCTIONS_BASE_FUNCTION_AS_FLUX_FUNCTION_HH
 
@@ -21,7 +24,7 @@
 namespace Dune::XT::Functions {
 
 
-// wraps a function f(u) as flux function f(x, u)
+/// \brief Wraps a state function f(u) as a flux function f(x, u), ignoring the spatial argument.
 template <class E, size_t s, size_t r, size_t rC, class R>
 class StateFunctionAsFluxFunctionWrapper : public FluxFunctionInterface<E, s, r, rC, R>
 {

--- a/dune/xt/functions/base/function-as-grid-function.hh
+++ b/dune/xt/functions/base/function-as-grid-function.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2017, 2019 - 2020)
 
+/// \file
+/// \brief Wraps a (spatial) function as a grid function.
+
 #ifndef DUNE_XT_FUNCTIONS_BASE_FUNCTION_AS_GRID_FUNCTION_HH
 #define DUNE_XT_FUNCTIONS_BASE_FUNCTION_AS_GRID_FUNCTION_HH
 
@@ -23,6 +26,7 @@
 namespace Dune::XT::Functions {
 
 
+/// \brief Wraps a FunctionInterface as a GridFunctionInterface, evaluating it at the global coordinates.
 template <class E, size_t r, size_t rC, class R>
 class FunctionAsGridFunctionWrapper : public GridFunctionInterface<E, r, rC, R>
 {

--- a/dune/xt/functions/base/visualization.hh
+++ b/dune/xt/functions/base/visualization.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2014, 2019 - 2020)
 
+/// \file
+/// \brief Visualizers and VTK adapters for visualizing grid functions.
+
 #ifndef DUNE_XT_FUNCTIONS_BASE_VISUALIZATION_HH
 #define DUNE_XT_FUNCTIONS_BASE_VISUALIZATION_HH
 
@@ -35,6 +38,7 @@ template <class Element, size_t rangeDim, size_t rangeDimCols, class RangeField>
 class GridFunctionInterface;
 
 
+/// \brief Interface for visualizers that map a function range value to one or more scalar components for output.
 template <size_t r, size_t rC, class R = double>
 class VisualizerInterface
 {
@@ -50,7 +54,7 @@ public:
 }; // class VisualizerInterface
 
 
-// visualizes all components of the function
+/// \brief Default visualizer: visualizes all components of the function (or its Frobenius norm for matrix-valued).
 template <size_t r, size_t rC, class R = double>
 class DefaultVisualizer : public VisualizerInterface<r, rC, R>
 {
@@ -101,6 +105,7 @@ private:
   }; // struct helper<..., 1>
 }; // class DefaultVisualizer
 
+/// \brief Returns a reference to a static DefaultVisualizer instance for the given dimensions.
 template <size_t r, size_t rC, class R = double>
 const DefaultVisualizer<r, rC, R>& default_visualizer()
 {
@@ -108,6 +113,7 @@ const DefaultVisualizer<r, rC, R>& default_visualizer()
   return default_visualizer_instance_;
 }
 
+/// \brief Visualizer that outputs the sum of all components of the function range value.
 template <size_t r, size_t rC = 1, class R = double>
 class SumVisualizer : public VisualizerInterface<r, rC, R>
 {
@@ -130,6 +136,7 @@ public:
 }; // class SumVisualizer
 
 
+/// \brief Visualizer that outputs a single, fixed component of the function range value.
 template <size_t r, size_t rC = 1, class R = double>
 class ComponentVisualizer : public VisualizerInterface<r, rC, R>
 {
@@ -160,6 +167,7 @@ private:
 }; // class ComponentVisualizer
 
 
+/// \brief Visualizer driven by a user-provided evaluation lambda and component count.
 template <size_t r, size_t rC = 1, class R = double>
 class GenericVisualizer : public VisualizerInterface<r, rC, R>
 {
@@ -191,6 +199,7 @@ private:
 }; // class GenericVisualizer
 
 
+/// \brief VTKFunction adapter that visualizes a grid function using a given visualizer.
 template <class GridViewType, size_t range_dim, size_t range_dim_cols, class RangeField>
 class VisualizationAdapter : public VTKFunction<GridViewType>
 {
@@ -254,6 +263,7 @@ private:
 }; // class VisualizationAdapter
 
 
+/// \brief VTKFunction adapter that visualizes the gradient of a scalar grid function.
 template <class GridViewType, size_t range_dim, size_t range_dim_cols, class RangeField>
 class GradientVisualizationAdapter : public VTKFunction<GridViewType>
 {

--- a/dune/xt/functions/constant.hh
+++ b/dune/xt/functions/constant.hh
@@ -11,6 +11,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2014 - 2015, 2017, 2019 - 2020)
 
+/// \file
+/// \brief Constant function, grid function and flux function implementations.
+
 #ifndef DUNE_XT_FUNCTIONS_CONSTANT_HH
 #define DUNE_XT_FUNCTIONS_CONSTANT_HH
 
@@ -26,6 +29,7 @@
 namespace Dune::XT::Functions {
 
 
+/// \brief Function that returns a constant value everywhere (with zero jacobian).
 template <size_t d, size_t r = 1, size_t rC = 1, class R = double>
 class ConstantFunction : public FunctionInterface<d, r, rC, R>
 {
@@ -105,6 +109,7 @@ public:
 }; // class ConstantFunction
 
 
+/// \brief Grid function that returns a constant value everywhere.
 template <class E, size_t r = 1, size_t rC = 1, class R = double>
 class ConstantGridFunction : public FunctionAsGridFunctionWrapper<E, r, rC, R>
 {
@@ -136,6 +141,7 @@ private:
 }; // class ConstantGridFunction
 
 
+/// \brief Flux function that returns a constant value, independent of position and state.
 template <class E, size_t stateDim, size_t r = 1, size_t rC = 1, class R = double>
 class ConstantFluxFunction : public FluxFunctionInterface<E, stateDim, r, rC, R>
 {

--- a/dune/xt/functions/derivatives.hh
+++ b/dune/xt/functions/derivatives.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2019 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Free functions to form divergence and gradient of element and grid functions.
+
 #ifndef DUNE_XT_FUNCTIONS_DERIVATIVES_HH
 #define DUNE_XT_FUNCTIONS_DERIVATIVES_HH
 
@@ -20,6 +23,7 @@
 namespace Dune::XT::Functions {
 
 
+/// \brief Returns the divergence of a (mutable) vector-valued element function.
 template <class E, class R>
 DivergenceElementFunction<ElementFunctionInterface<E, E::dimension, 1, R>>
 divergence(ElementFunctionInterface<E, E::dimension, 1, R>& func)
@@ -27,6 +31,7 @@ divergence(ElementFunctionInterface<E, E::dimension, 1, R>& func)
   return DivergenceElementFunction<ElementFunctionInterface<E, E::dimension, 1, R>>(func);
 }
 
+/// \brief Returns the divergence of a (const) vector-valued element function.
 template <class E, class R>
 DivergenceElementFunction<ElementFunctionInterface<E, E::dimension, 1, R>>
 divergence(const ElementFunctionInterface<E, E::dimension, 1, R>& func)
@@ -34,6 +39,7 @@ divergence(const ElementFunctionInterface<E, E::dimension, 1, R>& func)
   return DivergenceElementFunction<ElementFunctionInterface<E, E::dimension, 1, R>>(func);
 }
 
+/// \brief Returns the divergence of a vector-valued grid function.
 template <class E, class R>
 DivergenceGridFunction<GridFunctionInterface<E, E::dimension, 1, R>>
 divergence(const GridFunctionInterface<E, E::dimension, 1, R>& func)
@@ -42,12 +48,14 @@ divergence(const GridFunctionInterface<E, E::dimension, 1, R>& func)
 }
 
 
+/// \brief Returns the gradient of a scalar element function.
 template <class E, class R>
 GradientElementFunction<ElementFunctionInterface<E, 1, 1, R>> gradient(const ElementFunctionInterface<E, 1, 1, R>& func)
 {
   return GradientElementFunction<ElementFunctionInterface<E, 1, 1, R>>(func);
 }
 
+/// \brief Returns the gradient of a scalar grid function.
 template <class E, class R>
 GradientGridFunction<GridFunctionInterface<E, 1, 1, R>> gradient(const GridFunctionInterface<E, 1, 1, R>& func)
 {

--- a/dune/xt/functions/elementwise-diameter.hh
+++ b/dune/xt/functions/elementwise-diameter.hh
@@ -8,6 +8,9 @@
 //   Felix Schindler (2020)
 //   René Fritze     (2020)
 
+/// \file
+/// \brief Grid function returning the diameter of each grid element.
+
 #ifndef DUNE_XT_FUNCTIONS_ELEMENTWISE_DIAMETER_HH
 #define DUNE_XT_FUNCTIONS_ELEMENTWISE_DIAMETER_HH
 
@@ -17,6 +20,7 @@
 namespace Dune::XT::Functions {
 
 
+/// \brief Scalar grid function that is constant on each element and equals that element's diameter.
 template <class E>
 class ElementwiseDiameterFunction : public GridFunctionInterface<E>
 {

--- a/dune/xt/functions/elementwise-minimum.hh
+++ b/dune/xt/functions/elementwise-minimum.hh
@@ -8,6 +8,9 @@
 //   Felix Schindler (2020)
 //   René Fritze     (2020)
 
+/// \file
+/// \brief Grid function returning the elementwise minimum of another function.
+
 #ifndef DUNE_XT_FUNCTIONS_ELEMENTWISE_MINIMUM_HH
 #define DUNE_XT_FUNCTIONS_ELEMENTWISE_MINIMUM_HH
 
@@ -83,6 +86,7 @@ public:
 } // namespace internal
 
 
+/// \brief Scalar grid function that is constant on each element and equals the minimum of another function there.
 /// \todo Consider searching the elements corners!
 template <class SomeFunction>
 class ElementwiseMinimumFunction : public GridFunctionInterface<typename SomeFunction::E>

--- a/dune/xt/functions/exceptions.hh
+++ b/dune/xt/functions/exceptions.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Exception types used throughout dune-xt-functions.
+
 #ifndef DUNE_XT_FUNCTIONS_EXCEPTIONS_HH
 #define DUNE_XT_FUNCTIONS_EXCEPTIONS_HH
 
@@ -19,33 +22,43 @@
 namespace Dune::XT::Functions::Exceptions {
 
 
+/// \brief Thrown when a function receives invalid input.
 class wrong_input_given : public Common::Exceptions::wrong_input_given
 {};
 
+/// \brief Thrown when a local function is evaluated before being bound to an element.
 class not_bound_to_an_element_yet : public Grid::Exceptions::not_bound_to_an_element_yet
 {};
 
+/// \brief Thrown when reinterpreting a function (e.g. its dimensions) fails.
 class reinterpretation_error : public Dune::Exception
 {};
 
+/// \brief Thrown on errors related to function parameters.
 class parameter_error : public Common::Exceptions::parameter_error
 {};
 
+/// \brief Thrown when a required SPE10 data file is missing.
 class spe10_data_file_missing : public Dune::IOError
 {};
 
+/// \brief Thrown on errors within an element function.
 class element_function_error : public Dune::Exception
 {};
 
+/// \brief Thrown on errors when combining functions.
 class combined_error : public Dune::Exception
 {};
 
+/// \brief Thrown on errors within a function.
 class function_error : public Dune::Exception
 {};
 
+/// \brief Thrown on errors within a grid function.
 class grid_function_error : public Dune::Exception
 {};
 
+/// \brief Thrown on errors within a flux function.
 class flux_function_error : public Dune::Exception
 {};
 

--- a/dune/xt/functions/expression.hh
+++ b/dune/xt/functions/expression.hh
@@ -11,6 +11,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2014 - 2017, 2020)
 
+/// \file
+/// \brief Include aggregator for the expression-based function implementations.
+
 #ifndef DUNE_XT_FUNCTIONS_EXPRESSION_HH
 #define DUNE_XT_FUNCTIONS_EXPRESSION_HH
 

--- a/dune/xt/functions/expression/mathexpr.hh
+++ b/dune/xt/functions/expression/mathexpr.hh
@@ -19,6 +19,9 @@ This software comes with absolutely no warranty.
 
 */
 
+/// \file
+/// \brief Bundled third-party (Yann Ollivier) math expression parser used by the expression functions.
+
 #ifndef DUNE_XT_FUNCTIONS_NONPARAMETRIC_EXPRESSION_MATHEXPRESSION_HH
 #define DUNE_XT_FUNCTIONS_NONPARAMETRIC_EXPRESSION_MATHEXPRESSION_HH
 
@@ -49,6 +52,7 @@ const double ErrVal = DBL_MAX;
 
 // Class definitions for operations
 
+/// \brief Named variable bound to a value, part of the bundled math expression parser.
 class RVar
 {
 public:
@@ -106,6 +110,7 @@ typedef ROperation* PROperation;
 class RFunction;
 typedef RFunction* PRFunction;
 
+/// \brief Parsed expression tree that can be evaluated and differentiated (part of the bundled math expression parser).
 class ROperation
 {
   pfoncld* pinstr;
@@ -164,6 +169,7 @@ public:
   ROperation Substitute(const RVar&, const ROperation&) const;
 };
 
+/// \brief User-defined function over one or more variables, part of the bundled math expression parser.
 class RFunction
 {
   double* buf;

--- a/dune/xt/functions/expression/parametric.hh
+++ b/dune/xt/functions/expression/parametric.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2017 - 2020)
 
+/// \file
+/// \brief Function defined by string expressions that may depend on parameters.
+
 #ifndef DUNE_XT_FUNCTIONS_EXPRESSION_PARAMETRIC_HH
 #define DUNE_XT_FUNCTIONS_EXPRESSION_PARAMETRIC_HH
 
@@ -24,6 +27,7 @@
 namespace Dune::XT::Functions {
 
 
+/// \brief Function evaluated from string expressions of the spatial variable and parameters.
 template <size_t d, size_t r = 1, size_t rC = 1, class R = double>
 class ParametricExpressionFunction : public FunctionInterface<d, r, rC, R>
 {
@@ -35,6 +39,7 @@ public:
 };
 
 
+/// \brief Vector-valued parametric expression function (specialization for rC == 1).
 template <size_t d, size_t r, class R>
 class ParametricExpressionFunction<d, r, 1, R> : public FunctionInterface<d, r, 1, R>
 {

--- a/dune/xt/functions/indicator.hh
+++ b/dune/xt/functions/indicator.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2017, 2019 - 2020)
 
+/// \file
+/// \brief Indicator (piecewise constant on axis-aligned subdomains) function and grid function.
+
 #ifndef DUNE_XT_FUNCTIONS_INDICATOR_HH
 #define DUNE_XT_FUNCTIONS_INDICATOR_HH
 
@@ -24,6 +27,7 @@
 namespace Dune::XT::Functions {
 
 
+/// \brief Grid function that sums the values of all axis-aligned subdomains containing an element's center.
 template <class E, size_t r, size_t rC = 1, class R = double>
 class IndicatorGridFunction : public GridFunctionInterface<E, r, rC, R>
 {
@@ -199,6 +203,7 @@ private:
 }; // class IndicatorGridFunction
 
 
+/// \brief Function that sums the values of all axis-aligned subdomains containing the evaluation point.
 template <size_t d, size_t r = 1, size_t rC = 1, class R = double>
 class IndicatorFunction : public FunctionInterface<d, r, rC, R>
 {

--- a/dune/xt/functions/inverse.hh
+++ b/dune/xt/functions/inverse.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2019 - 2020)
 //   Tobias Leibner  (2019 - 2020)
 
+/// \file
+/// \brief Functions and grid functions representing the (scalar or matrix) inverse of another function.
+
 #ifndef DUNE_XT_FUNCTIONS_INVERSE_HH
 #define DUNE_XT_FUNCTIONS_INVERSE_HH
 
@@ -71,6 +74,7 @@ public:
 } // namespace internal
 
 
+/// \brief Element function that returns the (scalar or matrix) inverse of another element function's value.
 template <class ElementFunctionType>
 class InverseElementFunction
   : public ElementFunctionInterface<typename ElementFunctionType::E,
@@ -134,6 +138,7 @@ private:
 }; // class InverseElementFunction
 
 
+/// \brief Function that returns the (scalar or matrix) inverse of another function's value.
 template <class FunctionType>
 class InverseFunction
   : public FunctionInterface<FunctionType::d,
@@ -205,6 +210,7 @@ private:
 }; // class InverseFunction
 
 
+/// \brief Grid function that returns the (scalar or matrix) inverse of another grid function's value.
 /**
  * \todo Write custom local function to hold a copy af this!
  */
@@ -284,6 +290,7 @@ private:
 }; // class InverseGridFunction
 
 
+/// \brief Creates an InverseElementFunction wrapping the given element function.
 template <class E, size_t r, size_t rC, class R>
 auto inverse(ElementFunctionInterface<E, r, rC, R>& func, const int order)
 {
@@ -295,6 +302,7 @@ auto inverse(ElementFunctionInterface<E, r, rC, R>& func, const int order)
 }
 
 
+/// \brief Creates an InverseFunction wrapping the given function.
 template <size_t d, size_t r, size_t rC, class R>
 auto inverse(const FunctionInterface<d, r, rC, R>& func, const int order)
 {
@@ -306,6 +314,7 @@ auto inverse(const FunctionInterface<d, r, rC, R>& func, const int order)
 }
 
 
+/// \brief Creates an InverseGridFunction wrapping the given grid function.
 template <class E, size_t r, size_t rC, class R>
 auto inverse(const GridFunctionInterface<E, r, rC, R>& func, const int order)
 {

--- a/dune/xt/functions/print.hh
+++ b/dune/xt/functions/print.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017, 2020)
 
+/// \file
+/// \brief Pulls the Common print and repr utilities into the Functions namespace.
+
 #ifndef DUNE_XT_FUNCTIONS_PRINT_HH
 #define DUNE_XT_FUNCTIONS_PRINT_HH
 

--- a/dune/xt/functions/spe10/model2.hh
+++ b/dune/xt/functions/spe10/model2.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2017 - 2020)
 
+/// \file
+/// \brief Grid function providing the permeability field of the SPE10 model 2 benchmark.
+
 #ifndef DUNE_XT_FUNCTIONS_SPE10_MODEL2_HH
 #define DUNE_XT_FUNCTIONS_SPE10_MODEL2_HH
 
@@ -32,6 +35,7 @@ static constexpr double model_2_length_z = 1.417;
 } // namespace internal
 
 
+/// \brief Grid function for the SPE10 model 2 permeability field (primary template, only the 3x3 case is available).
 // default, to allow for specialization
 template <class E, size_t r, size_t rC = 1, class R = double>
 class Model2Function : public GridFunctionInterface<E, r, rC, R>
@@ -43,6 +47,7 @@ class Model2Function : public GridFunctionInterface<E, r, rC, R>
 };
 
 
+/// \brief Checkerboard grid function reading the matrix-valued SPE10 model 2 permeability data from file.
 template <class E, class R>
 class Model2Function<E, 3, 3, R> : public CheckerboardFunction<E, 3, 3, R>
 {

--- a/dune/xt/grid/bound-object.hh
+++ b/dune/xt/grid/bound-object.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2019 - 2020)
 
+/// \file
+/// \brief Base classes for objects that can be bound to a grid element or intersection.
+
 #ifndef DUNE_XT_GRID_BOUND_OBJECTS_HH
 #define DUNE_XT_GRID_BOUND_OBJECTS_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Holds a copy of a grid element and allows rebinding to other elements.
 template <class Element>
 class ElementBoundObject /*: Common::EnableDebugLoggingForCtors<ElementBoundObject<Element>>*/
 {
@@ -114,6 +118,7 @@ protected:
 }; // class ElementBoundObject
 
 
+/// \brief Holds a copy of a grid intersection and allows rebinding to other intersections.
 template <class Intersection>
 class IntersectionBoundObject
 {

--- a/dune/xt/grid/boundaryinfo.hh
+++ b/dune/xt/grid/boundaryinfo.hh
@@ -10,6 +10,9 @@
 //   Sven Kaulmann   (2013 - 2014)
 //   Tobias Leibner  (2014, 2017, 2020)
 
+/// \file
+/// \brief Convenience header aggregating all boundary info implementations and the factory.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_HH
 

--- a/dune/xt/grid/boundaryinfo/alldirichlet.hh
+++ b/dune/xt/grid/boundaryinfo/alldirichlet.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2016 - 2020)
 //   Tobias Leibner  (2016 - 2017, 2019 - 2020)
 
+/// \file
+/// \brief Boundary info treating every boundary intersection as Dirichlet boundary.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_ALLDIRICHLET_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_ALLDIRICHLET_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Default configuration for AllDirichletBoundaryInfo.
 static inline Common::Configuration alldirichlet_boundaryinfo_default_config()
 {
   return Common::Configuration({"type"}, {"xt.grid.boundaryinfo.alldirichlet"});
@@ -33,6 +37,7 @@ static inline Common::Configuration alldirichlet_boundaryinfo_default_config()
 #  pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #  pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
 #endif
+/// \brief Boundary info that marks every boundary intersection as Dirichlet boundary.
 template <class IntersectionImp>
 class AllDirichletBoundaryInfo : public BoundaryInfo<IntersectionImp>
 {
@@ -57,6 +62,7 @@ public:
 #  pragma GCC diagnostic pop
 #endif
 
+/// \brief Creates an AllDirichletBoundaryInfo for the given intersection type.
 template <class I>
 std::unique_ptr<AllDirichletBoundaryInfo<I>>
 make_alldirichlet_boundaryinfo(const Common::Configuration& /*cfg*/ = Common::Configuration())
@@ -64,6 +70,7 @@ make_alldirichlet_boundaryinfo(const Common::Configuration& /*cfg*/ = Common::Co
   return std::make_unique<AllDirichletBoundaryInfo<I>>();
 }
 
+/// \brief Creates an AllDirichletBoundaryInfo for the intersection type of the given grid view.
 template <class GV>
 std::unique_ptr<AllDirichletBoundaryInfo<extract_intersection_t<GV>>>
 make_alldirichlet_boundaryinfo(GV, const Common::Configuration& /*cfg*/ = Common::Configuration())
@@ -71,6 +78,7 @@ make_alldirichlet_boundaryinfo(GV, const Common::Configuration& /*cfg*/ = Common
   return std::make_unique<AllDirichletBoundaryInfo<extract_intersection_t<GV>>>();
 }
 
+/// \brief Boundary info that marks process (inter-rank) boundaries as Dirichlet boundary.
 template <class IntersectionImp>
 class ProcessBoundaryInfo : public BoundaryInfo<IntersectionImp>
 {

--- a/dune/xt/grid/boundaryinfo/allneumann.hh
+++ b/dune/xt/grid/boundaryinfo/allneumann.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2016 - 2020)
 //   Tobias Leibner  (2016 - 2017, 2019 - 2020)
 
+/// \file
+/// \brief Boundary info treating every boundary intersection as Neumann boundary.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_ALLNEUMANN_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_ALLNEUMANN_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Default configuration for AllNeumannBoundaryInfo.
 static inline Common::Configuration allneumann_boundaryinfo_default_config()
 {
   return Common::Configuration({"type"}, {"xt.grid.boundaryinfo.allneumann"});
@@ -33,6 +37,7 @@ static inline Common::Configuration allneumann_boundaryinfo_default_config()
 #  pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #  pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
 #endif
+/// \brief Boundary info that marks every boundary intersection as Neumann boundary.
 template <class IntersectionImp>
 class AllNeumannBoundaryInfo : public BoundaryInfo<IntersectionImp>
 {
@@ -57,6 +62,7 @@ public:
 #  pragma GCC diagnostic pop
 #endif
 
+/// \brief Creates an AllNeumannBoundaryInfo for the given intersection type.
 template <class I>
 std::unique_ptr<AllNeumannBoundaryInfo<I>>
 make_allneumann_boundaryinfo(const Common::Configuration& /*cfg*/ = Common::Configuration())

--- a/dune/xt/grid/boundaryinfo/allreflecting.hh
+++ b/dune/xt/grid/boundaryinfo/allreflecting.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2016 - 2020)
 //   Tobias Leibner  (2016 - 2017, 2019 - 2020)
 
+/// \file
+/// \brief Boundary info treating every boundary intersection as reflecting boundary.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_ALLREFLECTING_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_ALLREFLECTING_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Default configuration for AllReflectingBoundaryInfo.
 static inline Common::Configuration allreflecting_boundaryinfo_default_config()
 {
   return Common::Configuration({"type"}, {"xt.grid.boundaryinfo.allreflecting"});
@@ -33,6 +37,7 @@ static inline Common::Configuration allreflecting_boundaryinfo_default_config()
 #  pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #  pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
 #endif
+/// \brief Boundary info that marks every boundary intersection as reflecting boundary.
 template <class IntersectionImp>
 class AllReflectingBoundaryInfo : public BoundaryInfo<IntersectionImp>
 {
@@ -57,6 +62,7 @@ public:
 #  pragma GCC diagnostic pop
 #endif
 
+/// \brief Creates an AllReflectingBoundaryInfo for the given intersection type.
 template <class I>
 std::unique_ptr<AllReflectingBoundaryInfo<I>>
 make_allreflecting_boundaryinfo(const Common::Configuration& /*cfg*/ = Common::Configuration())

--- a/dune/xt/grid/boundaryinfo/boundarysegment.hh
+++ b/dune/xt/grid/boundaryinfo/boundarysegment.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2017, 2019 - 2020)
 
+/// \file
+/// \brief Boundary info assigning boundary types based on boundary segment index ranges.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_BOUNDARYSEGMENT_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_BOUNDARYSEGMENT_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Default configuration for BoundarySegmentIndexBasedBoundaryInfo.
 static inline Common::Configuration boundarysegment_boundaryinfo_default_config()
 {
   Common::Configuration config;
@@ -39,6 +43,7 @@ static inline Common::Configuration boundarysegment_boundaryinfo_default_config(
 #  pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #  pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
 #endif
+/// \brief Boundary info assigning boundary types according to boundary segment index ranges.
 template <class IntersectionImp>
 class BoundarySegmentIndexBasedBoundaryInfo : public BoundaryInfo<IntersectionImp>
 {
@@ -113,6 +118,7 @@ private:
 #  pragma GCC diagnostic pop
 #endif
 
+/// \brief Creates a BoundarySegmentIndexBasedBoundaryInfo from the given configuration.
 template <class I>
 std::unique_ptr<BoundarySegmentIndexBasedBoundaryInfo<I>>
 make_boundarysegment_boundaryinfo(const Common::Configuration& cfg = boundarysegment_boundaryinfo_default_config())

--- a/dune/xt/grid/boundaryinfo/factory.hh
+++ b/dune/xt/grid/boundaryinfo/factory.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2016, 2018 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Factory creating boundary info instances from a configuration or type string.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_FACTORY_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_FACTORY_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Factory listing and creating the available BoundaryInfo implementations.
 template <class I>
 class BoundaryInfoFactory
 {

--- a/dune/xt/grid/boundaryinfo/functionbased.hh
+++ b/dune/xt/grid/boundaryinfo/functionbased.hh
@@ -7,6 +7,9 @@
 // Authors:
 //   Felix Schindler (2021)
 
+/// \file
+/// \brief Boundary info determining boundary types from registered grid functions.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_FUNCTIONBASED_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_FUNCTIONBASED_HH
 
@@ -32,6 +35,7 @@ namespace Dune::XT::Grid {
 #  pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
 #endif
 
+/// \brief Boundary info that assigns boundary types based on registered grid functions evaluated at the boundary.
 template <class I>
 class FunctionBasedBoundaryInfo : public BoundaryInfo<I>
 {

--- a/dune/xt/grid/boundaryinfo/interfaces.hh
+++ b/dune/xt/grid/boundaryinfo/interfaces.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2016, 2018 - 2020)
 //   Tobias Leibner  (2016 - 2020)
 
+/// \file
+/// \brief Interfaces for boundary types and boundary info classes.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_INTERFACE_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_INTERFACE_HH
 
@@ -28,6 +31,7 @@ namespace Dune::XT::Grid {
 #endif
 
 
+/// \brief Interface for a boundary type, identified by a string id.
 class BoundaryType
 {
 public:
@@ -52,6 +56,7 @@ public:
 #endif
 
 
+/// \brief Streams the id of a BoundaryType.
 std::ostream& operator<<(std::ostream& out, const BoundaryType& type);
 
 
@@ -59,6 +64,7 @@ template <class I>
 class BoundaryInfo;
 
 
+/// \brief Interface for classes mapping grid intersections to their boundary type.
 template <class IntersectionImp>
 class BoundaryInfo : public Common::WithLogger<BoundaryInfo<IntersectionImp>>
 {
@@ -107,6 +113,7 @@ public:
 }; // class BoundaryInfo
 
 
+/// \brief Streams the string representation of a BoundaryInfo.
 template <class I>
 std::ostream& operator<<(std::ostream& out, const BoundaryInfo<I>& bi)
 {

--- a/dune/xt/grid/boundaryinfo/types.hh
+++ b/dune/xt/grid/boundaryinfo/types.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2016, 2018 - 2020)
 //   Tobias Leibner  (2016 - 2020)
 
+/// \file
+/// \brief Concrete boundary type classes and a factory to create them by id.
+
 #ifndef DUNE_XT_GRID_BOUNDARYINFO_TYPES_HH
 #define DUNE_XT_GRID_BOUNDARYINFO_TYPES_HH
 
@@ -25,6 +28,7 @@ namespace Dune::XT::Grid {
 #endif
 
 
+/// \brief Boundary type denoting an intersection that is not a boundary.
 class NoBoundary : public BoundaryType
 {
 public:
@@ -40,6 +44,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting an unknown boundary.
 class UnknownBoundary : public BoundaryType
 {
 public:
@@ -55,6 +60,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting a Dirichlet boundary.
 class DirichletBoundary : public BoundaryType
 {
 public:
@@ -70,6 +76,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting a Neumann boundary.
 class NeumannBoundary : public BoundaryType
 {
 public:
@@ -85,6 +92,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting a Robin boundary.
 class RobinBoundary : public BoundaryType
 {
 public:
@@ -100,6 +108,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting a reflecting boundary.
 class ReflectingBoundary : public BoundaryType
 {
 public:
@@ -115,6 +124,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting an absorbing boundary.
 class AbsorbingBoundary : public BoundaryType
 {
 public:
@@ -130,6 +140,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting an inflow boundary.
 class InflowBoundary : public BoundaryType
 {
 public:
@@ -145,6 +156,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting an outflow boundary.
 class OutflowBoundary : public BoundaryType
 {
 public:
@@ -160,6 +172,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting a combined inflow/outflow boundary.
 class InflowOutflowBoundary : public BoundaryType
 {
 public:
@@ -175,6 +188,7 @@ public:
 };
 
 
+/// \brief Boundary type denoting an impermeable boundary.
 class ImpermeableBoundary : public BoundaryType
 {
 public:
@@ -195,6 +209,7 @@ public:
 #endif
 
 
+/// \brief Creates a new BoundaryType instance matching the given id string.
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline BoundaryType* make_boundary_type(const std::string& id)
 {

--- a/dune/xt/grid/capabilities.hh
+++ b/dune/xt/grid/capabilities.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2018 - 2020)
 
+/// \file
+/// \brief Grid capability traits, such as whether a grid supports boundary ids.
+
 #ifndef DUNE_XT_GRID_CAPABILITIES_HH
 #define DUNE_XT_GRID_CAPABILITIES_HH
 
@@ -19,6 +22,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Trait indicating whether a grid type supports boundary ids.
 template <class G>
 struct has_boundary_id
 {

--- a/dune/xt/grid/dd/glued.hh
+++ b/dune/xt/grid/dd/glued.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2017 - 2020)
 
+/// \file
+/// \brief Provides a domain decomposition grid glueing macro elements to refined local subdomain grids.
+
 #ifndef DUNE_XT_GRID_DD_GLUED_HH
 #define DUNE_XT_GRID_DD_GLUED_HH
 
@@ -48,6 +51,7 @@ namespace Dune::XT::Grid::DD {
 namespace Exceptions {
 
 
+/// \brief Exception thrown when a coupling intersection has a wrongly oriented normal.
 class intersection_orientation_is_broken : public Dune::InvalidStateException
 {};
 
@@ -58,6 +62,7 @@ class intersection_orientation_is_broken : public Dune::InvalidStateException
 #if HAVE_DUNE_GRID_GLUE
 
 
+/// \brief Counts the coupling intersections of a grid glue whose normal is not aligned with the local intersection.
 template <typename P0, typename P1>
 size_t check_for_broken_coupling_intersections(
     const GridGlue::GridGlue<P0, P1>& glue,
@@ -109,6 +114,7 @@ template <class MacroGridType, class LocalGridType, Layers layer = Layers::level
 class GluedVTKWriter;
 
 
+/// \brief Domain decomposition grid equipping each macro element with its own local grid, plus their couplings.
 template <class MacroGridImp, class LocalGridImp, Layers layer = Layers::level>
 class Glued
 {
@@ -1036,6 +1042,7 @@ private:
 }; // class Glued
 
 
+/// \brief Writes per-subdomain VTK output for the local grids of a Glued domain decomposition grid.
 template <class MacroGridType, class LocalGridType, Layers layer>
 class GluedVTKWriter
 {

--- a/dune/xt/grid/element.hh
+++ b/dune/xt/grid/element.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Helpers operating on grid elements (codim-0 entities).
+
 #ifndef DUNE_XT_GRID_ELEMENT_HH
 #define DUNE_XT_GRID_ELEMENT_HH
 
@@ -20,6 +23,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Returns the center of the i-th sub-entity of the given codimension of an element.
 template <int dim, class GridImp, template <int, int, class> class EntityImp, int cd = GridImp::dimension>
 FieldVector<typename GridImp::ctype, GridImp::dimension>
 sub_entity_center(const Dune::Entity<0, dim, GridImp, EntityImp> element, const int codim, const size_t i)

--- a/dune/xt/grid/entity.hh
+++ b/dune/xt/grid/entity.hh
@@ -10,6 +10,9 @@
 //   Sven Kaulmann   (2014)
 //   Tobias Leibner  (2014, 2016, 2020)
 
+/// \file
+/// \brief Free functions to print, measure and obtain reference elements of grid entities.
+
 #ifndef DUNE_XT_GRID_ENTITY_HH
 #define DUNE_XT_GRID_ENTITY_HH
 
@@ -28,6 +31,7 @@
 namespace Dune {
 
 
+/// \brief Streams a textual representation of an entity (including its corners) to an output stream.
 template <int cd, int dim, class GridImp, template <int, int, class> class EntityImp>
 std::ostream& operator<<(std::ostream& out, const Entity<cd, dim, GridImp, EntityImp>& entity)
 {
@@ -43,6 +47,7 @@ std::ostream& operator<<(std::ostream& out, const Entity<cd, dim, GridImp, Entit
 namespace XT::Grid {
 
 
+/// \brief Prints an entity and the coordinates of its corners to an output stream.
 template <class EntityType>
 void print_entity(const EntityType& entity,
                   const std::string& name = Common::Typename<EntityType>::value(),
@@ -57,6 +62,7 @@ void print_entity(const EntityType& entity,
 } // ... print_entity(...)
 
 
+/// \brief Computes the diameter of an entity as the maximum distance between any two of its corners.
 template <int codim, int worlddim, class GridImp, template <int, int, class> class EntityImp>
 double diameter(const Dune::Entity<codim, worlddim, GridImp, EntityImp>& entity)
 {
@@ -74,6 +80,7 @@ double diameter(const Dune::Entity<codim, worlddim, GridImp, EntityImp>& entity)
 } // diameter
 
 
+/// \brief Computes the diameter of an entity (alias for diameter()).
 template <int codim, int worlddim, class GridImp, template <int, int, class> class EntityImp>
 double entity_diameter(const Dune::Entity<codim, worlddim, GridImp, EntityImp>& entity)
 {
@@ -81,6 +88,7 @@ double entity_diameter(const Dune::Entity<codim, worlddim, GridImp, EntityImp>& 
 }
 
 
+/// \brief Returns the reference element associated with the given entity.
 template <int codim, int worlddim, class GridImp, template <int, int, class> class EntityImp>
 auto reference_element(const Dune::Entity<codim, worlddim, GridImp, EntityImp>& entity)
     -> decltype(ReferenceElements<typename GridImp::ctype, worlddim>::general(entity.type()))
@@ -88,6 +96,7 @@ auto reference_element(const Dune::Entity<codim, worlddim, GridImp, EntityImp>& 
   return ReferenceElements<typename GridImp::ctype, worlddim>::general(entity.type());
 }
 
+/// \brief Returns the reference element associated with the given geometry.
 template <int mydim, int cdim, class GridImp, template <int, int, class> class GeometryImp>
 auto reference_element(const Dune::Geometry<mydim, cdim, GridImp, GeometryImp>& geometry)
     -> decltype(ReferenceElements<typename GridImp::ctype, mydim>::general(geometry.type()))

--- a/dune/xt/grid/exceptions.hh
+++ b/dune/xt/grid/exceptions.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2012 - 2013, 2015 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2014, 2016, 2020)
 
+/// \file
+/// \brief Exception types used throughout the dune-xt grid module.
+
 #ifndef DUNE_XT_GRID_EXCEPTIONS_HH
 #define DUNE_XT_GRID_EXCEPTIONS_HH
 
@@ -17,21 +20,27 @@
 namespace Dune::XT::Grid::Exceptions {
 
 
+/// \brief Thrown when an invalid or unknown boundary type is encountered.
 class boundary_type_error : public Dune::Exception
 {};
 
+/// \brief Thrown when boundary information is invalid or inconsistent.
 class boundary_info_error : public Dune::Exception
 {};
 
+/// \brief Thrown when an object is accessed before being bound to an element.
 class not_bound_to_an_element_yet : public Dune::InvalidStateException
 {};
 
+/// \brief Thrown when a functor is used in an invalid state.
 class functor_error : public Dune::InvalidStateException
 {};
 
+/// \brief Thrown when an operation is attempted with an unexpected dimension.
 class wrong_dimension : public Dune::Exception
 {};
 
+/// \brief Thrown when an operation is attempted with an unexpected codimension.
 class wrong_codimension : public Dune::Exception
 {};
 

--- a/dune/xt/grid/functors/boundary-detector.hh
+++ b/dune/xt/grid/functors/boundary-detector.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2018 - 2020)
 
+/// \file
+/// \brief Functor that counts the intersections matching a given boundary type.
+
 #ifndef DUNE_XT_GRID_FUNCTORS_BOUNDARY_DETECTOR_HH
 #define DUNE_XT_GRID_FUNCTORS_BOUNDARY_DETECTOR_HH
 
@@ -23,6 +26,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Intersection functor counting the intersections of a given boundary type according to a BoundaryInfo.
 template <class GL>
 class BoundaryDetectorFunctor
   : public IntersectionFunctor<GL>

--- a/dune/xt/grid/functors/generic.hh
+++ b/dune/xt/grid/functors/generic.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2019 - 2020)
 
+/// \file
+/// \brief Generic functors that delegate prepare/apply/finalize to user-provided std::function callbacks.
+
 #ifndef DUNE_XT_GRID_FUNCTORS_GENERIC_HH
 #define DUNE_XT_GRID_FUNCTORS_GENERIC_HH
 
@@ -20,6 +23,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Element functor whose behaviour is defined by user-provided prepare/apply/finalize callbacks.
 template <class GL>
 class GenericElementFunctor : public ElementFunctor<GL>
 {
@@ -69,6 +73,7 @@ private:
 }; // class GenericElementFunctor
 
 
+/// \brief Intersection functor whose behaviour is defined by user-provided prepare/apply/finalize callbacks.
 template <class GL>
 class GenericIntersectionFunctor : public IntersectionFunctor<GL>
 {
@@ -122,6 +127,7 @@ private:
 }; // class GenericIntersectionFunctor
 
 
+/// \brief Combined element-and-intersection functor whose behaviour is defined by user-provided callbacks.
 template <class GL>
 class GenericElementAndIntersectionFunctor : public ElementAndIntersectionFunctor<GL>
 {

--- a/dune/xt/grid/gridprovider.hh
+++ b/dune/xt/grid/gridprovider.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Convenience header aggregating all grid provider implementations.
+
 #ifndef DUNE_XT_GRID_GRIDPROVIDER_HH
 #define DUNE_XT_GRID_GRIDPROVIDER_HH
 

--- a/dune/xt/grid/gridprovider/coupling.hh
+++ b/dune/xt/grid/gridprovider/coupling.hh
@@ -6,6 +6,9 @@
 //          with "runtime exception" (http://www.dune-project.org/license.html)
 // Authors:
 
+/// \file
+/// \brief Provides a grid provider wrapping a coupling grid view.
+
 #ifndef DUNE_XT_GRID_PROVIDER_COUPLING_HH
 #define DUNE_XT_GRID_PROVIDER_COUPLING_HH
 
@@ -19,6 +22,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Grid provider holding a coupling grid view between a macro and local grid.
 template <class CouplingGridViewImp>
 class CouplingGridProvider
 {

--- a/dune/xt/grid/gridprovider/cube.hh
+++ b/dune/xt/grid/gridprovider/cube.hh
@@ -12,6 +12,9 @@
 //   René Fritze      (2012 - 2020)
 //   Tobias Leibner   (2014, 2016, 2018, 2020)
 
+/// \file
+/// \brief Provides a grid provider factory and convenience functions for structured cube/simplex grids.
+
 #ifndef DUNE_XT_GRID_GRIDPROVIDER_CUBE_HH
 #define DUNE_XT_GRID_GRIDPROVIDER_CUBE_HH
 
@@ -36,12 +39,14 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Returns the identifier string of the cube grid provider.
 static inline std::string cube_gridprovider_id()
 {
   return "xt.grid.gridprovider.cube";
 }
 
 
+/// \brief Returns the default configuration for the cube grid provider.
 static inline Common::Configuration cube_gridprovider_default_config()
 {
   Common::Configuration config;
@@ -55,6 +60,7 @@ static inline Common::Configuration cube_gridprovider_default_config()
 }
 
 
+/// \brief Factory creating grid providers for structured cube or simplex grids.
 template <class GridType>
 class CubeGridProviderFactory
 {
@@ -213,6 +219,7 @@ public:
 }; // struct CubeGridProviderFactory
 
 
+/// \brief Creates a cube/simplex grid from corner vectors, element counts, refinements and overlap.
 template <class GridType>
 auto make_cube_grid(
     const FieldVector<typename GridType::ctype, GridType::dimension>& lower_left,
@@ -231,6 +238,7 @@ auto make_cube_grid(
 }
 
 
+/// \brief Creates a cube/simplex grid from scalar bounds applied uniformly in every dimension.
 template <class GridType>
 auto make_cube_grid(
     const typename GridType::ctype& lower_left,
@@ -249,6 +257,7 @@ auto make_cube_grid(
 }
 
 
+/// \brief Creates a cube/simplex grid from a configuration object.
 template <class GridType>
 auto make_cube_grid(const Common::Configuration& cfg = cube_gridprovider_default_config(),
                     MPIHelper::MPICommunicator mpi_comm = MPIHelper::getCommunicator())

--- a/dune/xt/grid/gridprovider/cube.lib.hh
+++ b/dune/xt/grid/gridprovider/cube.lib.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Declares extern-template instantiations of the cube grid provider factory methods for the Python bindings.
+
 #ifndef DUNE_XT_GRID_GRIDPROVIDER_CUBE_LIB_HH
 #define DUNE_XT_GRID_GRIDPROVIDER_CUBE_LIB_HH
 

--- a/dune/xt/grid/gridprovider/dgf.hh
+++ b/dune/xt/grid/gridprovider/dgf.hh
@@ -11,6 +11,9 @@
 //   René Fritze     (2012 - 2013, 2015 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2014, 2016, 2020)
 
+/// \file
+/// \brief Provides a grid provider factory and convenience functions for grids read from DGF files.
+
 #ifndef DUNE_XT_GRID_GRIDPROVIDER_DGF_HH
 #define DUNE_XT_GRID_GRIDPROVIDER_DGF_HH
 
@@ -31,12 +34,14 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Returns the identifier string of the DGF grid provider.
 static inline std::string dgf_gridprovider_id()
 {
   return "xt.grid.gridprovider.dgf";
 }
 
 
+/// \brief Returns the default configuration for the DGF grid provider.
 static inline Common::Configuration dgf_gridprovider_default_config()
 {
   Common::Configuration config;
@@ -46,6 +51,7 @@ static inline Common::Configuration dgf_gridprovider_default_config()
 }
 
 
+/// \brief Factory creating grid providers from DGF (Dune Grid Format) files.
 template <class GridType>
 class DgfGridProviderFactory
 {
@@ -78,6 +84,7 @@ public:
 }; // class DgfGridProviderFactory
 
 
+/// \brief Creates a grid from a DGF file given by filename.
 template <class GridType>
 auto make_dgf_grid(const std::string& filename, MPIHelper::MPICommunicator mpi_comm = MPIHelper::getCommunicator())
 {
@@ -86,6 +93,7 @@ auto make_dgf_grid(const std::string& filename, MPIHelper::MPICommunicator mpi_c
 }
 
 
+/// \brief Creates a grid from a DGF file specified by a configuration object.
 template <class GridType>
 auto make_dgf_grid(const Common::Configuration& cfg = DgfGridProviderFactory<GridType>::default_config(),
                    MPIHelper::MPICommunicator mpi_comm = MPIHelper::getCommunicator())

--- a/dune/xt/grid/gridprovider/factory.hh
+++ b/dune/xt/grid/gridprovider/factory.hh
@@ -10,6 +10,9 @@
 //   René Fritze     (2013 - 2020)
 //   Tobias Leibner  (2014, 2017 - 2020)
 
+/// \file
+/// \brief Provides a unified factory dispatching grid creation to the cube, DGF and gmsh providers by type.
+
 #ifndef DUNE_XT_GRID_PROVIDER_HH
 #define DUNE_XT_GRID_PROVIDER_HH
 
@@ -29,6 +32,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Factory creating grid providers by dispatching to the cube, DGF or gmsh provider based on a type string.
 template <class GridType>
 class GridProviderFactory
 {

--- a/dune/xt/grid/gridprovider/gmsh.hh
+++ b/dune/xt/grid/gridprovider/gmsh.hh
@@ -11,6 +11,9 @@
 //   René Fritze     (2012 - 2013, 2015 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2014 - 2016, 2020)
 
+/// \file
+/// \brief Provides a grid provider factory and convenience functions for grids read from gmsh files.
+
 #ifndef DUNE_XT_GRID_GRIDPROVIDER_GMSH_HH
 #define DUNE_XT_GRID_GRIDPROVIDER_GMSH_HH
 
@@ -30,12 +33,14 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Returns the identifier string of the gmsh grid provider.
 static inline std::string gmsh_gridprovider_id()
 {
   return "xt.grid.gridprovider.gmsh";
 }
 
 
+/// \brief Returns the default configuration for the gmsh grid provider.
 static inline Common::Configuration gmsh_gridprovider_default_config()
 {
   Common::Configuration config;
@@ -48,7 +53,7 @@ static inline Common::Configuration gmsh_gridprovider_default_config()
 template <class GridType>
 class GmshGridProviderFactory;
 
-//! Gmsh grid creation relies on unstructured grid factory -> disable yasp
+/// \brief Specialization disabling gmsh grid creation for YaspGrid (gmsh requires an unstructured grid factory).
 template <int dim, class Coordinates>
 class GmshGridProviderFactory<Dune::YaspGrid<dim, Coordinates>>
 {
@@ -73,6 +78,7 @@ public:
 }; // class GmshGridProviderFactory<Dune::YaspGrid<...>>
 
 
+/// \brief Factory creating grid providers from gmsh (.msh) mesh files.
 template <class GridType>
 class GmshGridProviderFactory
 {
@@ -111,6 +117,7 @@ public:
 }; // class GmshGridProviderFactory
 
 
+/// \brief Creates a grid from a gmsh file given by filename.
 template <class GridType>
 auto make_gmsh_grid(const std::string& filename, MPIHelper::MPICommunicator mpi_comm = MPIHelper::getCommunicator())
 {
@@ -119,6 +126,7 @@ auto make_gmsh_grid(const std::string& filename, MPIHelper::MPICommunicator mpi_
 }
 
 
+/// \brief Creates a grid from a gmsh file specified by a configuration object.
 template <class GridType>
 auto make_gmsh_grid(const Common::Configuration& cfg = GmshGridProviderFactory<GridType>::default_config(),
                     MPIHelper::MPICommunicator mpi_comm = MPIHelper::getCommunicator())

--- a/dune/xt/grid/gridprovider/provider.hh
+++ b/dune/xt/grid/gridprovider/provider.hh
@@ -12,6 +12,9 @@
 //   Sven Kaulmann   (2014)
 //   Tobias Leibner  (2014, 2016 - 2017, 2020 - 2021)
 
+/// \file
+/// \brief Provides the basic grid provider holding a grid and offering layer/view access and visualization.
+
 #ifndef DUNE_XT_GRID_PROVIDER_PROVIDER_HH
 #define DUNE_XT_GRID_PROVIDER_PROVIDER_HH
 
@@ -40,6 +43,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Holds a grid and provides access to its levels, views and refinement as well as visualization.
 template <class GridImp>
 class GridProvider
 {

--- a/dune/xt/grid/grids.hh
+++ b/dune/xt/grid/grids.hh
@@ -10,6 +10,9 @@
 //   Tim Keil        (2018)
 //   Tobias Leibner  (2016, 2020)
 
+/// \file
+/// \brief Includes the available Dune grid managers and defines convenient grid type aliases.
+
 #ifndef DUNE_XT_GRID_GRIDS_HH
 #define DUNE_XT_GRID_GRIDS_HH
 

--- a/dune/xt/grid/mapper.hh
+++ b/dune/xt/grid/mapper.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Provides a helper to map the index of a sub-entity of given codimension of an element.
+
 #ifndef DUNE_XT_GRID_MAPPER_HH
 #define DUNE_XT_GRID_MAPPER_HH
 
@@ -20,6 +23,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Returns the mapper index of the i-th sub-entity of given codimension of an element.
 template <typename G,
           typename MapperImp,
           typename IndexType,

--- a/dune/xt/grid/output/entity_visualization.hh
+++ b/dune/xt/grid/output/entity_visualization.hh
@@ -10,6 +10,9 @@
 //   Sven Kaulmann   (2013)
 //   Tobias Leibner  (2014, 2016, 2019 - 2020)
 
+/// \file
+/// \brief Provides functors and helpers to visualize per-element data of a grid as VTK output.
+
 #ifndef DUNE_XT_GRID_OUTPUT_ENTITY_VISUALIZATION_HH
 #define DUNE_XT_GRID_OUTPUT_ENTITY_VISUALIZATION_HH
 
@@ -32,6 +35,7 @@
 
 namespace Dune::XT::Grid {
 
+/// \brief Collection of functors and helpers to attach and write per-element data as VTK output.
 struct ElementVisualization
 {
   // demonstrate attaching data to elements
@@ -342,6 +346,7 @@ struct ElementVisualization
   }
 };
 
+/// \brief Writes the entity index of each element to VTK files, one per grid level.
 template <class GridType>
 void visualize_index_per_level(const GridType& grid_, const std::string& filename)
 {

--- a/dune/xt/grid/type_traits.hh
+++ b/dune/xt/grid/type_traits.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2016 - 2020)
 //   Tobias Leibner  (2016 - 2020)
 
+/// \file
+/// \brief Provides type traits to detect and extract types from Dune grids, views, entities and intersections.
+
 #ifndef DUNE_XT_GRID_TYPE_TRAITS_HH
 #define DUNE_XT_GRID_TYPE_TRAITS_HH
 
@@ -72,6 +75,7 @@ class CouplingIntersectionWithCorrectNormal;
 } // namespace internal
 
 
+/// \brief Trait determining whether T is a (grid or grid-glue) intersection and exposing its grid and element types.
 template <class T>
 struct is_intersection : public std::false_type
 {
@@ -114,6 +118,7 @@ template <class T>
 using extract_outside_element_t = typename is_intersection<T>::OutsideElementType;
 
 
+/// \brief Trait determining whether T is one of the supported Dune grid types.
 template <class T>
 struct is_grid : public std::false_type
 {};
@@ -164,6 +169,7 @@ struct is_grid<Dune::SPGrid<ct, dim, Ref, Comm>> : public std::true_type
 #endif // HAVE_DUNE_SPGRID
 
 
+/// \brief Trait determining whether T is a Dune entity of the given codimension.
 template <class T, int codim = 0>
 struct is_entity : public std::false_type
 {};
@@ -173,6 +179,7 @@ struct is_entity<Dune::Entity<cd, dim, GridImp, EntityImp>, cd> : public std::tr
 {};
 
 
+/// \brief Trait determining whether T is a Dune grid view.
 template <class T, bool candidate = internal::has_traits_helper<std::remove_const_t<T>>::is_candidate>
 struct is_view : public std::false_type
 {};
@@ -185,16 +192,19 @@ template <class T>
 struct is_view<T, true> : public std::is_base_of<Dune::GridView<typename T::Traits>, std::remove_const_t<T>>
 {};
 
+/// \brief Trait determining whether T is a Dune grid part.
 template <class T, bool is_candidate = internal::has_traits_helper<T>::is_candidate>
 struct is_part : public std::false_type
 {};
 
 
+/// \brief Trait determining whether T is a grid layer, i.e. either a grid view or a grid part.
 template <class T>
 struct is_layer : public std::integral_constant<bool, is_view<T>::value || is_part<T>::value>
 {};
 
 
+/// \brief Trait determining whether T is a Dune::YaspGrid.
 template <class T>
 struct is_yaspgrid : public std::false_type
 {};
@@ -203,6 +213,7 @@ template <int dim, class Coordinates>
 struct is_yaspgrid<YaspGrid<dim, Coordinates>> : public std::true_type
 {};
 
+/// \brief Trait determining whether T is a Dune::UGGrid.
 template <class T>
 struct is_uggrid : public std::false_type
 {};
@@ -216,18 +227,22 @@ struct is_uggrid<UGGrid<dim>> : public std::true_type
 #endif
 
 
+/// \brief Trait determining whether T is a Dune::ALUGrid.
 template <class T>
 struct is_alugrid : public std::false_type
 {};
 
+/// \brief Trait determining whether T is a conforming Dune::ALUGrid.
 template <class T>
 struct is_conforming_alugrid : public std::false_type
 {};
 
+/// \brief Trait determining whether T is a simplex Dune::ALUGrid.
 template <class T>
 struct is_simplex_alugrid : public std::false_type
 {};
 
+/// \brief Trait determining whether T is a cube Dune::ALUGrid.
 template <class T>
 struct is_cube_alugrid : public std::false_type
 {};
@@ -254,6 +269,7 @@ struct is_cube_alugrid<ALUGrid<dim, dimworld, ALUGridElementType::cube, refineTy
 #endif // HAVE_DUNE_ALUGRID
 
 
+/// \brief Extracts the grid type from a grid view, grid part, intersection or entity T.
 template <class T,
           bool view = is_view<T>::value,
           bool part = is_part<T>::value,
@@ -290,6 +306,7 @@ template <class T>
 using extract_grid_t = typename extract_grid<T>::type;
 
 
+/// \brief Extracts the collective communication type from a grid view or grid part T.
 template <class T, bool view = is_view<T>::value, bool part = is_part<T>::value>
 struct extract_collective_communication : public AlwaysFalse<T>
 {};
@@ -311,6 +328,7 @@ template <class T>
 using extract_collective_communication_t = typename extract_collective_communication<T>::type;
 
 
+/// \brief Extracts the index set type from a grid view or grid part T.
 template <class T, bool view = is_view<T>::value, bool part = is_part<T>::value>
 struct extract_index_set : public AlwaysFalse<T>
 {};
@@ -331,6 +349,7 @@ template <class T>
 using extract_index_set_t = typename extract_index_set<T>::type;
 
 
+/// \brief Extracts the intersection type from a grid view or grid part T.
 template <class T, bool view = is_view<T>::value, bool part = is_part<T>::value>
 struct extract_intersection : public AlwaysFalse<T>
 {};
@@ -351,6 +370,7 @@ template <class T>
 using extract_intersection_t = typename extract_intersection<T>::type;
 
 
+/// \brief Extracts the intersection iterator type from a grid view or grid part T.
 template <class T, bool view = is_view<T>::value, bool part = is_part<T>::value>
 struct extract_intersection_iterator : public AlwaysFalse<T>
 {};
@@ -371,6 +391,7 @@ template <class T>
 using extract_intersection_iterator_t = typename extract_intersection_iterator<T>::type;
 
 
+/// \brief Extracts the entity type of given codimension from a grid view, grid part or grid T.
 template <class T,
           size_t codim = 0,
           bool view = is_view<T>::value,
@@ -405,6 +426,7 @@ template <class T, size_t codim = 0>
 using extract_entity_t = typename extract_entity<T, codim>::type;
 
 
+/// \brief Extracts the local geometry type of given codimension from a grid view or grid part T.
 template <class T, size_t codim = 0, bool view = is_view<T>::value, bool part = is_part<T>::value>
 struct extract_local_geometry : public AlwaysFalse<T>
 {};
@@ -425,6 +447,7 @@ template <class T, size_t codim = 0>
 using extract_local_geometry_t = typename extract_local_geometry<T, codim>::type;
 
 
+/// \brief Extracts the geometry type of given codimension from a grid view or grid part T.
 template <class T, size_t codim = 0, bool view = is_view<T>::value, bool part = is_part<T>::value>
 struct extract_geometry : public AlwaysFalse<T>
 {};
@@ -445,6 +468,7 @@ template <class T, size_t codim = 0>
 using extract_geometry_t = typename extract_geometry<T, codim>::type;
 
 
+/// \brief Extracts the codim-c partition iterator type from a grid view or grid part T.
 template <class T,
           int c = 0,
           PartitionIteratorType pit = All_Partition,
@@ -468,7 +492,7 @@ struct extract_iterator<T, c, pit, false, true>
 template <class T, int c = 0, PartitionIteratorType pit = All_Partition>
 using extract_iterator_t = typename extract_iterator<T, c, pit>::type;
 
-//! struct to be used as comparison function e.g. in a std::map<Entity, EntityLess>
+/// \brief Comparison functor ordering entities by their index, e.g. for use as a std::map comparator.
 template <class GV>
 struct EntityLess
 {

--- a/dune/xt/grid/view/coupling.hh
+++ b/dune/xt/grid/view/coupling.hh
@@ -7,6 +7,9 @@
 // Authors:
 //   Tim Keil (2020 - 2021)
 
+/// \file
+/// \brief Provides a grid view over the coupling intersections between two glued subdomain grids.
+
 #ifndef DUNE_XT_GRID_VIEW_COUPLING_HH
 #define DUNE_XT_GRID_VIEW_COUPLING_HH
 
@@ -399,6 +402,7 @@ private:
 } // namespace internal
 
 
+/// \brief Grid view iterating over the coupling intersections of a grid glue between two local subdomain grids.
 template <class GridGlueImp>
 class CouplingGridView
   : XT::Common::StorageProvider<internal::CouplingGridViewWrapper<GridGlueImp>>
@@ -439,6 +443,7 @@ public:
 }; // class CouplingGridView
 
 
+/// \brief Creates a CouplingGridView for the coupling between two macro elements across a macro intersection.
 template <class GT, class E, class IT>
 static CouplingGridView<GT> make_coupling_grid_view(const E& ss, const E& nn, GT& dd_grid, const IT& macro_intersection)
 {

--- a/dune/xt/grid/view/from-part.hh
+++ b/dune/xt/grid/view/from-part.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Provides adapters yielding a temporary grid view from a grid layer that may be a view or a part.
+
 #ifndef DUNE_XT_GRID_VIEW_FROM_PART_HH
 #define DUNE_XT_GRID_VIEW_FROM_PART_HH
 
@@ -22,6 +25,7 @@
 namespace Dune::XT::Grid {
 
 
+/// \brief Provides const access to a grid view obtained from a grid layer, which may be a grid view or a grid part.
 template <class GridLayerType>
 class TemporaryConstView
 {
@@ -80,6 +84,7 @@ private:
 }; // class TemporaryConstView
 
 
+/// \brief Provides mutable access to a grid view obtained from a grid layer, which may be a grid view or a grid part.
 template <class GridLayerType>
 class TemporaryView : public TemporaryConstView<GridLayerType>
 {
@@ -139,12 +144,14 @@ private:
 }; // class TemporaryView
 
 
+/// \brief Creates a TemporaryConstView from a const grid layer.
 template <class GridLayerType>
 TemporaryConstView<GridLayerType> make_tmp_view(const GridLayerType& grid_layer)
 {
   return TemporaryConstView<GridLayerType>(grid_layer);
 }
 
+/// \brief Creates a TemporaryView from a mutable grid layer.
 template <class GridLayerType>
 TemporaryView<GridLayerType> make_tmp_view(GridLayerType& grid_layer)
 {

--- a/dune/xt/grid/walker.hh
+++ b/dune/xt/grid/walker.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2014 - 2020)
 //   Tobias Leibner  (2014 - 2015, 2017 - 2020)
 
+/// \file
+/// \brief Provides the Walker, which applies appended functors to the elements and intersections of a grid view.
+
 #ifndef DUNE_XT_GRID_WALKER_HH
 #define DUNE_XT_GRID_WALKER_HH
 
@@ -196,6 +199,7 @@ private:
 } // namespace internal
 
 
+/// \brief Walks a grid view and applies appended (filtered) element and intersection functors, optionally in parallel.
 template <class GV>
 class Walker : public ElementAndIntersectionFunctor<GV>
 {
@@ -755,6 +759,7 @@ protected:
       element_and_intersection_functor_wrappers_;
 }; // class Walker
 
+/// \brief Creates a Walker for the given grid view.
 template <class GV>
 Walker<GV> make_walker(GV grid_view)
 {

--- a/dune/xt/la/algorithms.hh
+++ b/dune/xt/la/algorithms.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017 - 2018, 2020)
 
+/// \file
+/// \brief Aggregator header including all dune-xt-la linear algebra algorithms.
+
 #ifndef DUNE_XT_LA_ALGORITHMS_HH
 #define DUNE_XT_LA_ALGORITHMS_HH
 

--- a/dune/xt/la/algorithms/cholesky.hh
+++ b/dune/xt/la/algorithms/cholesky.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2018 - 2020)
 //   Tobias Leibner (2017 - 2018, 2020)
 
+/// \file
+/// \brief Cholesky (LL^T) and tridiagonal LDL^T factorizations and corresponding solvers.
+
 #ifndef DUNE_XT_LA_ALGORITHMS_CHOLESKY_HH
 #define DUNE_XT_LA_ALGORITHMS_CHOLESKY_HH
 
@@ -296,12 +299,14 @@ struct LDLTSolver
 } // namespace internal
 
 
+/// \brief Computes the Cholesky (LL^T) factorization of a symmetric positive definite matrix in place.
 template <class MatrixType>
 typename std::enable_if_t<Common::is_matrix<MatrixType>::value, void> cholesky(MatrixType& A)
 {
   internal::CholeskySolver<MatrixType>::cholesky(A);
 } // void solve_lower_triangular(...)
 
+/// \brief Solves L L^T x = rhs in place given the Cholesky factor L (result overwrites rhs).
 template <class MatrixType, class VectorType>
 typename std::enable_if_t<Common::is_matrix<MatrixType>::value && Common::is_vector<VectorType>::value, void>
 solve_cholesky_factorized(const MatrixType& L, VectorType& rhs)
@@ -312,6 +317,7 @@ solve_cholesky_factorized(const MatrixType& L, VectorType& rhs)
 } // void solve_lower_triangular(...)
 
 
+/// \brief Computes the LDL^T factorization of a symmetric tridiagonal matrix in place (given diagonal and subdiagonal).
 template <class FirstVectorType, class SecondVectorType>
 typename std::enable_if_t<Common::is_vector<FirstVectorType>::value && Common::is_vector<SecondVectorType>::value, void>
 tridiagonal_ldlt(FirstVectorType& diag, SecondVectorType& subdiag)
@@ -320,6 +326,7 @@ tridiagonal_ldlt(FirstVectorType& diag, SecondVectorType& subdiag)
 } // void tridiagonal_ldlt(...)
 
 
+/// \brief Solves a tridiagonal system in place given its LDL^T factorization (rhs may be a vector or matrix).
 template <class FirstVectorType, class SecondVectorType, class RhsType>
 typename std::enable_if_t<Common::is_vector<FirstVectorType>::value && Common::is_vector<SecondVectorType>::value
                               && (Common::is_vector<RhsType>::value || Common::is_matrix<RhsType>::value),

--- a/dune/xt/la/container.hh
+++ b/dune/xt/la/container.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2015 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2017 - 2018, 2020)
 
+/// \file
+/// \brief Maps linear algebra backends to their vector/matrix container types and lists available types.
+
 #ifndef DUNE_XT_LA_CONTAINER_HH
 #define DUNE_XT_LA_CONTAINER_HH
 
@@ -25,6 +28,7 @@ namespace Dune::XT::LA {
 template <class ScalarType, Backends backend = default_backend>
 struct Container;
 
+/// \brief Vector and matrix container types for the common dense backend.
 template <class ScalarType>
 struct Container<ScalarType, Backends::common_dense>
 {
@@ -32,6 +36,7 @@ struct Container<ScalarType, Backends::common_dense>
   using MatrixType = CommonDenseMatrix<ScalarType>;
 }; // struct Container<..., common_dense>
 
+/// \brief Vector and matrix container types for the common sparse backend.
 template <class ScalarType>
 struct Container<ScalarType, Backends::common_sparse>
 {
@@ -39,6 +44,7 @@ struct Container<ScalarType, Backends::common_sparse>
   using MatrixType = CommonSparseMatrix<ScalarType>;
 }; // struct Container<..., common_sparse>
 
+/// \brief Vector and matrix container types for the Eigen dense backend.
 template <class ScalarType>
 struct Container<ScalarType, Backends::eigen_dense>
 {
@@ -46,6 +52,7 @@ struct Container<ScalarType, Backends::eigen_dense>
   using MatrixType = EigenDenseMatrix<ScalarType>;
 }; // struct Container<..., eigen_dense>
 
+/// \brief Vector and matrix container types for the Eigen sparse backend.
 template <class ScalarType>
 struct Container<ScalarType, Backends::eigen_sparse>
 {
@@ -53,6 +60,7 @@ struct Container<ScalarType, Backends::eigen_sparse>
   using MatrixType = EigenRowMajorSparseMatrix<ScalarType>;
 }; // struct Container<..., eigen_sparse>
 
+/// \brief Vector and matrix container types for the ISTL dense backend.
 template <class ScalarType>
 struct Container<ScalarType, Backends::istl_dense>
 {
@@ -60,6 +68,7 @@ struct Container<ScalarType, Backends::istl_dense>
   using MatrixType = IstlRowMajorSparseMatrix<ScalarType>;
 }; // struct Container<..., istl_dense>
 
+/// \brief Vector and matrix container types for the ISTL sparse backend.
 template <class ScalarType>
 struct Container<ScalarType, Backends::istl_sparse>
 {
@@ -68,6 +77,7 @@ struct Container<ScalarType, Backends::istl_sparse>
 }; // struct Container<..., istl_sparse>
 
 
+/// \brief Tuple of all available vector container types (depending on enabled backends).
 template <class S>
 using AvailableVectorTypes = std::tuple<CommonDenseVector<S>,
                                         IstlDenseVector<S>
@@ -78,6 +88,7 @@ using AvailableVectorTypes = std::tuple<CommonDenseVector<S>,
                                         >;
 
 
+/// \brief Tuple of all available dense matrix container types (depending on enabled backends).
 template <class S>
 using AvailableDenseMatrixTypes = std::tuple<CommonDenseMatrix<S>
 #if HAVE_EIGEN
@@ -87,6 +98,7 @@ using AvailableDenseMatrixTypes = std::tuple<CommonDenseMatrix<S>
                                              >;
 
 
+/// \brief Tuple of all available sparse matrix container types (depending on enabled backends).
 template <class S>
 using AvailableSparseMatrixTypes = std::tuple<CommonSparseMatrix<S>,
                                               IstlRowMajorSparseMatrix<S>

--- a/dune/xt/la/container/common.hh
+++ b/dune/xt/la/container/common.hh
@@ -10,6 +10,9 @@
 //   René Fritze      (2014 - 2016, 2018 - 2019)
 //   Tobias Leibner   (2014, 2016 - 2017, 2020)
 
+/// \file
+/// \brief Aggregator header for the common (built-in) vector and matrix containers.
+
 #ifndef DUNE_XT_LA_CONTAINER_COMMON_HH
 #define DUNE_XT_LA_CONTAINER_COMMON_HH
 

--- a/dune/xt/la/container/common/matrix.hh
+++ b/dune/xt/la/container/common/matrix.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017, 2020)
 
+/// \file
+/// \brief Aggregator header for the common dense and sparse matrix containers.
+
 #ifndef DUNE_XT_LA_CONTAINER_COMMON_MATRIX_HH
 #define DUNE_XT_LA_CONTAINER_COMMON_MATRIX_HH
 

--- a/dune/xt/la/container/common/vector.hh
+++ b/dune/xt/la/container/common/vector.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017, 2020)
 
+/// \file
+/// \brief Aggregator header for the common dense and sparse vector containers.
+
 #ifndef DUNE_XT_LA_CONTAINER_COMMON_VECTOR_HH
 #define DUNE_XT_LA_CONTAINER_COMMON_VECTOR_HH
 

--- a/dune/xt/la/container/eigen.hh
+++ b/dune/xt/la/container/eigen.hh
@@ -10,6 +10,9 @@
 //   Sven Kaulmann   (2014)
 //   Tobias Leibner  (2014, 2017, 2020)
 
+/// \file
+/// \brief Aggregator header for the Eigen-based dense and sparse containers.
+
 #ifndef DUNE_XT_LA_CONTAINER_EIGEN_HH
 #define DUNE_XT_LA_CONTAINER_EIGEN_HH
 

--- a/dune/xt/la/container/eye-matrix.hh
+++ b/dune/xt/la/container/eye-matrix.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Factory functions to create or fill identity matrices for arbitrary matrix types.
+
 #ifndef DUNE_XT_LA_CONTAINER_EYE_MATRIX_HH
 #define DUNE_XT_LA_CONTAINER_EYE_MATRIX_HH
 
@@ -34,6 +37,7 @@ typename std::enable_if<Common::is_matrix<MatrixType>::value, void>::type set_di
 } // namespace internal
 
 
+/// \brief Creates a rows x cols identity matrix of the given LA matrix type (optionally with a sparsity pattern).
 template <class MatrixType>
 typename std::enable_if<is_matrix<MatrixType>::value, MatrixType>::type
 eye_matrix(const size_t rows, const size_t cols, const SparsityPatternDefault& pattern = SparsityPatternDefault())
@@ -43,6 +47,7 @@ eye_matrix(const size_t rows, const size_t cols, const SparsityPatternDefault& p
   return mat;
 }
 
+/// \brief Overwrites the given matrix with the identity (zeros off-diagonal, ones on the diagonal).
 template <class MatrixType>
 typename std::enable_if<Common::is_matrix<MatrixType>::value, void>::type eye_matrix(MatrixType& matrix)
 {
@@ -50,6 +55,7 @@ typename std::enable_if<Common::is_matrix<MatrixType>::value, void>::type eye_ma
   internal::set_diagonal_to_one(matrix);
 }
 
+/// \brief Creates a rows x cols identity matrix for a generic (non-LA) matrix type.
 template <class MatrixType>
 typename std::enable_if<Common::is_matrix<MatrixType>::value && !is_matrix<MatrixType>::value, MatrixType>::type
 eye_matrix(const size_t rows, const size_t cols, const SparsityPatternDefault& /*pattern*/ = SparsityPatternDefault())
@@ -62,6 +68,7 @@ eye_matrix(const size_t rows, const size_t cols, const SparsityPatternDefault& /
 }
 
 
+/// \brief Creates a square size x size identity matrix of the given matrix type.
 template <class MatrixType>
 typename std::enable_if<Common::is_matrix<MatrixType>::value, MatrixType>::type
 eye_matrix(const size_t size, const SparsityPatternDefault& pattern = SparsityPatternDefault())

--- a/dune/xt/la/container/interfaces.hh
+++ b/dune/xt/la/container/interfaces.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2013 - 2016, 2018 - 2019)
 //   Tobias Leibner  (2014, 2017, 2020)
 
+/// \file
+/// \brief Aggregator header for the container, vector and matrix interfaces.
+
 #ifndef DUNE_XT_LA_CONTAINER_INTERFACES_HH
 #define DUNE_XT_LA_CONTAINER_INTERFACES_HH
 

--- a/dune/xt/la/container/io.hh
+++ b/dune/xt/la/container/io.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017, 2020)
 
+/// \file
+/// \brief Reading and writing of matrices and vectors from/to ASCII files.
+
 #ifndef DUNE_XT_LA_CONTAINER_IO_HH
 #define DUNE_XT_LA_CONTAINER_IO_HH
 
@@ -24,6 +27,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Writes a matrix to the given file (currently only 'ascii' mode is supported).
 template <class M>
 void to_file(const MatrixInterface<M>& matrix, const std::string& filename, const std::string& mode = "ascii")
 {
@@ -42,6 +46,7 @@ void to_file(const MatrixInterface<M>& matrix, const std::string& filename, cons
 } // ... to_file(...)
 
 
+/// \brief Writes a vector to the given file (currently only 'ascii' mode is supported).
 template <class V>
 void to_file(const VectorInterface<V>& vector, const std::string& filename, const std::string& mode = "ascii")
 {
@@ -57,6 +62,7 @@ void to_file(const VectorInterface<V>& vector, const std::string& filename, cons
 } // ... to_file(...)
 
 
+/// \brief Reads a matrix of type M from the given file (optionally enforcing minimum dimensions).
 template <class M>
 typename std::enable_if<is_matrix<M>::value, M>::type from_file(const std::string& filename,
                                                                 const ssize_t min_rows = -1,
@@ -108,6 +114,7 @@ typename std::enable_if<is_matrix<M>::value, M>::type from_file(const std::strin
 } // ... from_file(...)
 
 
+/// \brief Reads a vector of type V from the given file (optionally enforcing a minimum size).
 template <class V>
 typename std::enable_if<is_vector<V>::value, V>::type
 from_file(const std::string& filename, const ssize_t min_size = -1, const std::string& mode = "ascii")

--- a/dune/xt/la/container/matrix-market.hh
+++ b/dune/xt/la/container/matrix-market.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2020)
 //   Tobias Leibner (2019 - 2020)
 
+/// \file
+/// \brief Reading and writing of matrices in Matrix Market file format.
+
 #ifndef DUNE_XT_LA_CONTAINER_MATRIX_MARKET_HH
 #define DUNE_XT_LA_CONTAINER_MATRIX_MARKET_HH
 
@@ -189,6 +192,7 @@ MatrixType read_matrix_market_coordinate_format(std::ifstream& matrix_file,
 } // namespace internal
 
 
+/// \brief Reads a matrix from a Matrix Market file (array or coordinate format, real or complex).
 template <class MatrixType>
 MatrixType read_matrix_market(const std::string& filename)
 {
@@ -249,6 +253,7 @@ MatrixType read_matrix_market(const std::string& filename)
 }
 
 
+/// \brief Writes a matrix to a Matrix Market file (array format for dense, coordinate format for sparse).
 template <class MatrixType>
 void write_matrix_market(const MatrixType& mat, const std::string& filename, const int precision = 20)
 {

--- a/dune/xt/la/container/matrix-view.hh
+++ b/dune/xt/la/container/matrix-view.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2019 - 2020)
 //   Tobias Leibner (2019 - 2020)
 
+/// \file
+/// \brief Read-only and read-write views onto a rectangular sub-block of a matrix.
+
 #ifndef DUNE_XT_LA_CONTAINER_MATRIX_VIEW_HH
 #define DUNE_XT_LA_CONTAINER_MATRIX_VIEW_HH
 
@@ -63,6 +66,7 @@ MatrixImp& empty_matrix_ref()
 } // namespace internal
 
 
+/// \brief Read-only view onto a rectangular sub-block of an existing matrix.
 template <class MatrixImp>
 class ConstMatrixView
   : public MatrixInterface<internal::ConstMatrixViewTraits<MatrixImp>, typename MatrixImp::ScalarType>
@@ -288,6 +292,7 @@ private:
   mutable std::shared_ptr<SparsityPatternDefault> pattern_;
 }; // class ConstMatrixView
 
+/// \brief Read-write view onto a rectangular sub-block of an existing matrix.
 template <class MatrixImp>
 class MatrixView : public MatrixInterface<internal::MatrixViewTraits<MatrixImp>, typename MatrixImp::ScalarType>
 {

--- a/dune/xt/la/container/pattern.hh
+++ b/dune/xt/la/container/pattern.hh
@@ -10,6 +10,9 @@
 //   Sven Kaulmann   (2014)
 //   Tobias Leibner  (2017 - 2020)
 
+/// \file
+/// \brief Default sparsity pattern container and factory functions for common patterns.
+
 #ifndef DUNE_XT_LA_CONTAINER_PATTERN_HH
 #define DUNE_XT_LA_CONTAINER_PATTERN_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Default sparsity pattern, storing for each row the sorted indices of its non-zero columns.
 class SparsityPatternDefault
 {
 private:
@@ -69,17 +73,23 @@ private:
   BaseType vector_of_vectors_;
 }; // class SparsityPatternDefault
 
+/// \brief Creates a fully populated (dense) sparsity pattern for a rows x cols matrix.
 SparsityPatternDefault dense_pattern(const size_t rows, const size_t cols);
 
+/// \brief Creates a tridiagonal sparsity pattern for a rows x cols matrix.
 SparsityPatternDefault tridiagonal_pattern(const size_t rows, const size_t cols);
 
+/// \brief Creates a triangular (lower or upper) sparsity pattern for a rows x cols matrix.
 SparsityPatternDefault triangular_pattern(const size_t rows,
                                           const size_t cols,
                                           const Common::MatrixPattern& uplo = Common::MatrixPattern::lower_triangular);
 
+/// \brief Creates a diagonal sparsity pattern for a square rows x rows matrix.
 SparsityPatternDefault diagonal_pattern(const size_t rows);
+/// \brief Creates a diagonal sparsity pattern for a rows x cols matrix with the given diagonal offset.
 SparsityPatternDefault diagonal_pattern(const size_t rows, const size_t cols, int offset = 0);
 
+/// \brief Computes the sparsity pattern of the product of two matrices with the given patterns.
 SparsityPatternDefault multiplication_pattern(const SparsityPatternDefault& lhs_pattern,
                                               const SparsityPatternDefault& rhs_pattern,
                                               const size_t rhs_cols);

--- a/dune/xt/la/container/vector-array/list.hh
+++ b/dune/xt/la/container/vector-array/list.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2019 - 2020)
 
+/// \file
+/// \brief A resizable array of vectors, each annotated with a parameter note.
+
 #ifndef DUNE_XT_LA_CONTAINER_VECTOR_ARRAY_LIST_HH
 #define DUNE_XT_LA_CONTAINER_VECTOR_ARRAY_LIST_HH
 
@@ -22,6 +25,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief A dynamic array of vectors, each annotated with a Common::Parameter note.
 template <class Vector>
 class ListVectorArray
 {

--- a/dune/xt/la/container/vector-interface-internal.hh
+++ b/dune/xt/la/container/vector-interface-internal.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2014 - 2016, 2018 - 2020)
 //   Tobias Leibner  (2014, 2017, 2019 - 2020)
 
+/// \file
+/// \brief Internal iterator helpers for the vector interface.
+
 #ifndef DUNE_XT_LA_CONTAINER_VECTOR_INTERFACE_INTERNAL_HH
 #define DUNE_XT_LA_CONTAINER_VECTOR_INTERFACE_INTERNAL_HH
 

--- a/dune/xt/la/container/vector-view.hh
+++ b/dune/xt/la/container/vector-view.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2019 - 2020)
 //   Tobias Leibner (2019 - 2020)
 
+/// \file
+/// \brief Read-only and read-write views onto a contiguous range of a vector.
+
 #ifndef DUNE_XT_LA_CONTAINER_VECTOR_VIEW_HH
 #define DUNE_XT_LA_CONTAINER_VECTOR_VIEW_HH
 
@@ -80,6 +83,7 @@ VectorImp& empty_vector_ref()
 } // namespace internal
 
 
+/// \brief Read-only view onto a contiguous range of entries of an existing vector.
 template <class VectorImp>
 class ConstVectorView
   : public VectorInterface<internal::ConstVectorViewTraits<VectorImp>,
@@ -258,6 +262,7 @@ private:
 }; // class ConstVectorView
 
 
+/// \brief Read-write view onto a contiguous range of entries of an existing vector.
 template <class VectorImp>
 class VectorView
   : public VectorInterface<internal::VectorViewTraits<VectorImp>,

--- a/dune/xt/la/eigen-solver/default.hh
+++ b/dune/xt/la/eigen-solver/default.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2018 - 2020)
 //   Tobias Leibner (2018, 2020)
 
+/// \file
+/// \brief Default eigensolver specialization using LAPACK or a shifted QR algorithm.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_DEFAULT_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_DEFAULT_HH
 
@@ -26,6 +29,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Available types and default options for the default eigensolver (lapack and shifted_qr).
 template <class MatrixType>
 class EigenSolverOptions<MatrixType, true>
 {
@@ -50,6 +54,7 @@ public:
 }; // class EigenSolverOptions<>
 
 
+/// \brief Default eigensolver computing eigenvalues and eigenvectors via LAPACK or a shifted QR algorithm.
 template <class MatrixImp>
 class EigenSolver<MatrixImp, true>
   : public internal::EigenSolverBase<MatrixImp,

--- a/dune/xt/la/eigen-solver/eigen.hh
+++ b/dune/xt/la/eigen-solver/eigen.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2017 - 2020)
 //   Tobias Leibner  (2017 - 2018, 2020)
 
+/// \file
+/// \brief Eigensolver specialization for EigenDenseMatrix using Eigen, LAPACK or a shifted QR algorithm.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_EIGEN_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_EIGEN_HH
 
@@ -30,6 +33,7 @@ namespace Dune::XT::LA {
 #if HAVE_EIGEN
 
 
+/// \brief Available types and default options for the EigenDenseMatrix eigensolver (eigen, lapack, shifted_qr).
 template <class S>
 class EigenSolverOptions<EigenDenseMatrix<S>, true>
 {
@@ -54,6 +58,7 @@ public:
 }; // class EigenSolverOptions<EigenDenseMatrix<S>>
 
 
+/// \brief Eigensolver for EigenDenseMatrix using Eigen's own solver, LAPACK or a shifted QR algorithm.
 template <class S>
 class EigenSolver<EigenDenseMatrix<S>, true>
   : public internal::EigenSolverBase<EigenDenseMatrix<S>,

--- a/dune/xt/la/eigen-solver/fmatrix.hh
+++ b/dune/xt/la/eigen-solver/fmatrix.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2017 - 2020)
 //   Tobias Leibner  (2017 - 2018, 2020)
 
+/// \file
+/// \brief Eigen-solver specializations for Dune::FieldMatrix and Dune::XT::Common::FieldMatrix.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_FMATRIX_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_FMATRIX_HH
 
@@ -37,6 +40,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Eigen-solver options for a square Dune::FieldMatrix.
 template <class K, int SIZE>
 class EigenSolverOptions<Dune::FieldMatrix<K, SIZE, SIZE>, true>
 {
@@ -66,23 +70,27 @@ public:
 }; // class EigenSolverOptions<Dune::FieldMatrix<K, SIZE, SIZE>>
 
 
+/// \brief Eigen-solver options for a square Dune::XT::Common::FieldMatrix.
 template <class K, int SIZE>
 class EigenSolverOptions<Dune::XT::Common::FieldMatrix<K, SIZE, SIZE>, true>
   : public EigenSolverOptions<Dune::FieldMatrix<K, SIZE, SIZE>, true>
 {};
 
 
+/// \brief Eigen-solver options for a scalar Dune::FieldVector of size one.
 template <class K>
 class EigenSolverOptions<Dune::FieldVector<K, 1>, true> : public EigenSolverOptions<Dune::FieldMatrix<K, 1, 1>, true>
 {};
 
 
+/// \brief Eigen-solver options for a scalar Dune::XT::Common::FieldVector of size one.
 template <class K>
 class EigenSolverOptions<Dune::XT::Common::FieldVector<K, 1>, true>
   : public EigenSolverOptions<Dune::FieldMatrix<K, 1, 1>, true>
 {};
 
 
+/// \brief Eigen-solver for a square Dune::FieldMatrix.
 template <class K, int SIZE>
 class EigenSolver<Dune::FieldMatrix<K, SIZE, SIZE>, true>
   : public internal::EigenSolverBase<Dune::FieldMatrix<K, SIZE, SIZE>,
@@ -186,6 +194,7 @@ protected:
 }; // class EigenSolver<FieldMatrix<...>>
 
 
+/// \brief Eigen-solver for a square Dune::XT::Common::FieldMatrix.
 template <class K, int SIZE>
 class EigenSolver<Dune::XT::Common::FieldMatrix<K, SIZE, SIZE>, true>
   : public EigenSolver<Dune::FieldMatrix<K, SIZE, SIZE>>
@@ -199,6 +208,7 @@ public:
 };
 
 
+/// \brief Eigen-solver for a scalar Dune::XT::Common::FieldVector of size one.
 template <class K>
 class EigenSolver<Dune::XT::Common::FieldVector<K, 1>, true>
   : Common::ConstStorageProvider<Dune::FieldMatrix<K, 1, 1>>
@@ -217,6 +227,7 @@ public:
 };
 
 
+/// \brief Eigen-solver for a scalar Dune::FieldVector of size one.
 template <class K>
 class EigenSolver<Dune::FieldVector<K, 1>, true>
   : Common::ConstStorageProvider<Dune::FieldMatrix<K, 1, 1>>

--- a/dune/xt/la/eigen-solver/internal/base.hh
+++ b/dune/xt/la/eigen-solver/internal/base.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2017 - 2020)
 
+/// \file
+/// \brief Internal base class and helpers shared by the eigen-solver implementations.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_BASE_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_BASE_HH
 

--- a/dune/xt/la/eigen-solver/internal/eigen.hh
+++ b/dune/xt/la/eigen-solver/internal/eigen.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017 - 2018, 2020)
 
+/// \file
+/// \brief Internal eigen-solver implementation backed by the Eigen library.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_EIGEN_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_EIGEN_HH
 

--- a/dune/xt/la/eigen-solver/internal/lapacke.hh
+++ b/dune/xt/la/eigen-solver/internal/lapacke.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2017 - 2018, 2020)
 
+/// \file
+/// \brief Internal eigen-solver implementation backed by LAPACK/LAPACKE.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_LAPACKE_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_LAPACKE_HH
 

--- a/dune/xt/la/eigen-solver/internal/numpy.hh
+++ b/dune/xt/la/eigen-solver/internal/numpy.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Internal eigen-solver implementation backed by NumPy.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_NUMPY_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_NUMPY_HH
 

--- a/dune/xt/la/eigen-solver/internal/shifted-qr.hh
+++ b/dune/xt/la/eigen-solver/internal/shifted-qr.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2018 - 2020)
 //   Tobias Leibner (2017 - 2018, 2020)
 
+/// \file
+/// \brief Internal eigen-solver implementation using a shifted QR algorithm.
+
 #ifndef DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_SHIFTEDQR_HH
 #define DUNE_XT_LA_EIGEN_SOLVER_INTERNAL_SHIFTEDQR_HH
 

--- a/dune/xt/la/exceptions.hh
+++ b/dune/xt/la/exceptions.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017, 2020)
 
+/// \file
+/// \brief Exception types thrown by dune-xt-la (solver, eigensolver and inversion failures).
+
 #ifndef DUNE_XT_LA_EXCEPTIONS_HH
 #define DUNE_XT_LA_EXCEPTIONS_HH
 
@@ -17,76 +20,99 @@
 namespace Dune::XT::LA::Exceptions {
 
 
+/// \brief Thrown when a requested feature or backend is not available.
 class not_available : public Dune::Exception
 {};
 
+/// \brief Base exception thrown when solving a linear system fails.
 class linear_solver_failed : public Dune::Exception
 {};
 
+/// \brief Linear solver failure because the input data did not fulfill the solver's requirements.
 class linear_solver_failed_bc_data_did_not_fulfill_requirements : public linear_solver_failed
 {};
 
+/// \brief Linear solver failure because the iterative method did not converge.
 class linear_solver_failed_bc_it_did_not_converge : public linear_solver_failed
 {};
 
+/// \brief Linear solver failure because the solver was not set up correctly.
 class linear_solver_failed_bc_it_was_not_set_up_correctly : public linear_solver_failed
 {};
 
+/// \brief Linear solver failure because the computed solution does not solve the system.
 class linear_solver_failed_bc_the_solution_does_not_solve_the_system : public linear_solver_failed
 {};
 
 
+/// \brief Base exception thrown when computing an eigendecomposition fails.
 class eigen_solver_failed : public Dune::Exception
 {};
 
+/// \brief Eigensolver failure because the input data did not fulfill the solver's requirements.
 class eigen_solver_failed_bc_data_did_not_fulfill_requirements : public eigen_solver_failed
 {};
 
+/// \brief Eigensolver failure because the solver was not set up correctly.
 class eigen_solver_failed_bc_it_was_not_set_up_correctly : public eigen_solver_failed
 {};
 
+/// \brief Eigensolver failure because the result contained inf or nan values.
 class eigen_solver_failed_bc_result_contained_inf_or_nan : public eigen_solver_failed
 {};
 
+/// \brief Eigensolver failure because the eigenvalues are not real as requested.
 class eigen_solver_failed_bc_eigenvalues_are_not_real_as_requested : public eigen_solver_failed
 {};
 
+/// \brief Eigensolver failure because the eigenvalues are not positive as requested.
 class eigen_solver_failed_bc_eigenvalues_are_not_positive_as_requested : public eigen_solver_failed
 {};
 
+/// \brief Eigensolver failure because the eigenvalues are not negative as requested.
 class eigen_solver_failed_bc_eigenvalues_are_not_negative_as_requested : public eigen_solver_failed
 {};
 
+/// \brief Eigensolver failure because the eigenvectors are not real as requested.
 class eigen_solver_failed_bc_eigenvectors_are_not_real_as_requested : public eigen_solver_failed
 {};
 
+/// \brief Eigensolver failure because the result is not a valid eigendecomposition.
 class eigen_solver_failed_bc_result_is_not_an_eigendecomposition : public eigen_solver_failed
 {};
 
 
+/// \brief Base exception thrown when computing a generalized eigendecomposition fails.
 class generalized_eigen_solver_failed : public Dune::Exception
 {};
 
+/// \brief Generalized eigensolver failure because the input data did not fulfill the solver's requirements.
 class generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements : public generalized_eigen_solver_failed
 {};
 
+/// \brief Generalized eigensolver failure because the solver was not set up correctly.
 class generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly : public generalized_eigen_solver_failed
 {};
 
+/// \brief Generalized eigensolver failure because the result contained inf or nan values.
 class generalized_eigen_solver_failed_bc_result_contained_inf_or_nan : public generalized_eigen_solver_failed
 {};
 
+/// \brief Generalized eigensolver failure because the eigenvalues are not real as requested.
 class generalized_eigen_solver_failed_bc_eigenvalues_are_not_real_as_requested : public generalized_eigen_solver_failed
 {};
 
+/// \brief Generalized eigensolver failure because the eigenvalues are not positive as requested.
 class generalized_eigen_solver_failed_bc_eigenvalues_are_not_positive_as_requested
   : public generalized_eigen_solver_failed
 {};
 
+/// \brief Generalized eigensolver failure because the eigenvalues are not negative as requested.
 class generalized_eigen_solver_failed_bc_eigenvalues_are_not_negative_as_requested
   : public generalized_eigen_solver_failed
 {};
 
+/// \brief Generalized eigensolver failure because the eigenvectors are not real as requested.
 class generalized_eigen_solver_failed_bc_eigenvectors_are_not_real_as_requested : public generalized_eigen_solver_failed
 {};
 
@@ -94,21 +120,27 @@ class generalized_eigen_solver_failed_bc_eigenvectors_are_not_real_as_requested 
 //{};
 
 
+/// \brief Base exception thrown when inverting a matrix fails.
 class matrix_invert_failed : public Dune::Exception
 {};
 
+/// \brief Matrix inversion failure because the input data did not fulfill the requirements.
 class matrix_invert_failed_bc_data_did_not_fulfill_requirements : public matrix_invert_failed
 {};
 
+/// \brief Matrix inversion failure because the inverter was not set up correctly.
 class matrix_invert_failed_bc_it_was_not_set_up_correctly : public matrix_invert_failed
 {};
 
+/// \brief Matrix inversion failure because the result contained inf or nan values.
 class matrix_invert_failed_bc_result_contained_inf_or_nan : public matrix_invert_failed
 {};
 
+/// \brief Matrix inversion failure because the result is not a left inverse.
 class matrix_invert_failed_bc_result_is_not_a_left_inverse : public matrix_invert_failed
 {};
 
+/// \brief Matrix inversion failure because the result is not a right inverse.
 class matrix_invert_failed_bc_result_is_not_a_right_inverse : public matrix_invert_failed
 {};
 

--- a/dune/xt/la/generalized-eigen-solver/default.hh
+++ b/dune/xt/la/generalized-eigen-solver/default.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2019 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Default generalized eigen-solver specializations for arbitrary matrix types.
+
 #ifndef DUNE_XT_LA_GENERALIZED_EIGEN_SOLVER_DEFAULT_HH
 #define DUNE_XT_LA_GENERALIZED_EIGEN_SOLVER_DEFAULT_HH
 
@@ -25,6 +28,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Default generalized eigen-solver options for a generic matrix type.
 template <class MatrixType>
 class GeneralizedEigenSolverOptions<MatrixType, true>
 {
@@ -51,6 +55,7 @@ public:
 }; // class GeneralizedEigenSolverOptions<>
 
 
+/// \brief Default generalized eigen-solver for a generic matrix type.
 template <class MatrixImp>
 class GeneralizedEigenSolver<MatrixImp, true>
   : public internal::GeneralizedEigenSolverBase<

--- a/dune/xt/la/generalized-eigen-solver/internal/base.hh
+++ b/dune/xt/la/generalized-eigen-solver/internal/base.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2017 - 2020)
 
+/// \file
+/// \brief Internal base class and helpers shared by the generalized eigen-solver implementations.
+
 #ifndef DUNE_XT_LA_GENERALIZED_EIGEN_SOLVER_INTERNAL_BASE_HH
 #define DUNE_XT_LA_GENERALIZED_EIGEN_SOLVER_INTERNAL_BASE_HH
 

--- a/dune/xt/la/generalized-eigen-solver/internal/lapacke.hh
+++ b/dune/xt/la/generalized-eigen-solver/internal/lapacke.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2019 - 2020)
 //   Tobias Leibner  (2020)
 
+/// \file
+/// \brief Internal generalized eigen-solver implementation backed by LAPACK/LAPACKE.
+
 #ifndef DUNE_XT_LA_GENERALIZED_EIGEN_SOLVER_INTERNAL_LAPACKE_HH
 #define DUNE_XT_LA_GENERALIZED_EIGEN_SOLVER_INTERNAL_LAPACKE_HH
 

--- a/dune/xt/la/matrix-inverter/default.hh
+++ b/dune/xt/la/matrix-inverter/default.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2017 - 2020)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Default matrix-inverter specializations for arbitrary matrix types.
+
 #ifndef DUNE_XT_LA_MATRIX_INVERTER_DEFAULT_HH
 #define DUNE_XT_LA_MATRIX_INVERTER_DEFAULT_HH
 
@@ -21,6 +24,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Default matrix-inverter options for a generic matrix type.
 template <class MatrixType>
 class MatrixInverterOptions<MatrixType, true>
 {
@@ -41,6 +45,7 @@ public:
 }; // class MatrixInverterOptions<MatrixType, true>
 
 
+/// \brief Default matrix-inverter for a generic matrix type.
 template <class MatrixImp>
 class MatrixInverter<MatrixImp, true> : public internal::MatrixInverterBase<MatrixImp>
 {

--- a/dune/xt/la/matrix-inverter/eigen.hh
+++ b/dune/xt/la/matrix-inverter/eigen.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2020)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Matrix-inverter specializations for EigenDenseMatrix.
+
 #ifndef DUNE_XT_LA_MATRIX_INVERTER_EIGEN_HH
 #define DUNE_XT_LA_MATRIX_INVERTER_EIGEN_HH
 
@@ -26,6 +29,7 @@ namespace Dune::XT::LA {
 #if HAVE_EIGEN
 
 
+/// \brief Matrix-inverter options for an EigenDenseMatrix.
 template <class S>
 class MatrixInverterOptions<EigenDenseMatrix<S>, true>
 {
@@ -48,6 +52,7 @@ public:
 }; // class MatrixInverterOptions<EigenDenseMatrix<S>>
 
 
+/// \brief Matrix-inverter for an EigenDenseMatrix.
 template <class S>
 class MatrixInverter<EigenDenseMatrix<S>, true> : public internal::MatrixInverterBase<EigenDenseMatrix<S>>
 {
@@ -98,6 +103,7 @@ protected:
 #else // HAVE_EIGEN
 
 
+/// \brief Matrix-inverter options for an EigenDenseMatrix (unavailable without Eigen).
 template <class S>
 class MatrixInverterOptions<EigenDenseMatrix<S>, true>
 {
@@ -105,6 +111,7 @@ class MatrixInverterOptions<EigenDenseMatrix<S>, true>
 };
 
 
+/// \brief Matrix-inverter for an EigenDenseMatrix (unavailable without Eigen).
 template <class S>
 class MatrixInverter<EigenDenseMatrix<S>, true>
 {

--- a/dune/xt/la/matrix-inverter/fmatrix.hh
+++ b/dune/xt/la/matrix-inverter/fmatrix.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2017 - 2020)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Matrix-inverter specializations for Dune::FieldMatrix and Dune::XT::Common::FieldMatrix.
+
 #ifndef DUNE_XT_LA_MATRIX_INVERTER_FMATRIX_HH
 #define DUNE_XT_LA_MATRIX_INVERTER_FMATRIX_HH
 
@@ -27,6 +30,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Matrix-inverter options for a Dune::FieldMatrix.
 template <class K, int ROWS, int COLS>
 class MatrixInverterOptions<FieldMatrix<K, ROWS, COLS>, true>
 {
@@ -51,11 +55,13 @@ public:
   }
 }; // class MatrixInverterOptions<FieldMatrix<K, ROWS, COLS>>
 
+/// \brief Matrix-inverter options for a Dune::XT::Common::FieldMatrix.
 template <class K, int ROWS, int COLS>
 class MatrixInverterOptions<Common::FieldMatrix<K, ROWS, COLS>, true>
   : public MatrixInverterOptions<FieldMatrix<K, ROWS, COLS>>
 {};
 
+/// \brief Matrix-inverter for a Dune::FieldMatrix.
 template <class K, int ROWS, int COLS>
 class MatrixInverter<FieldMatrix<K, ROWS, COLS>, true> : public internal::MatrixInverterBase<FieldMatrix<K, ROWS, COLS>>
 {
@@ -115,6 +121,7 @@ protected:
 }; // class MatrixInverter<FieldMatrix<...>>
 
 
+/// \brief Matrix-inverter for a Dune::XT::Common::FieldMatrix.
 template <class K, int ROWS, int COLS>
 class MatrixInverter<Common::FieldMatrix<K, ROWS, COLS>, true> : public MatrixInverter<FieldMatrix<K, ROWS, COLS>>
 {

--- a/dune/xt/la/matrix-inverter/internal/base.hh
+++ b/dune/xt/la/matrix-inverter/internal/base.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2017 - 2020)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Internal base class and helpers shared by the matrix-inverter implementations.
+
 #ifndef DUNE_XT_LA_MATRIX_INVERTER_BASE_HH
 #define DUNE_XT_LA_MATRIX_INVERTER_BASE_HH
 

--- a/dune/xt/la/matrix-inverter/internal/eigen.hh
+++ b/dune/xt/la/matrix-inverter/internal/eigen.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2018, 2020)
 
+/// \file
+/// \brief Internal matrix-inverter helpers backed by the Eigen library.
+
 #ifndef DUNE_XT_LA_MATRIX_INVERTER_INTERNAL_EIGEN_HH
 #define DUNE_XT_LA_MATRIX_INVERTER_INTERNAL_EIGEN_HH
 

--- a/dune/xt/la/print.hh
+++ b/dune/xt/la/print.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017, 2020)
 
+/// \file
+/// \brief Imports the common print/repr helpers into the LA namespace.
+
 #ifndef DUNE_XT_LA_PRINT_HH
 #define DUNE_XT_LA_PRINT_HH
 

--- a/dune/xt/la/solver/common.hh
+++ b/dune/xt/la/solver/common.hh
@@ -10,6 +10,9 @@
 //   René Fritze      (2015 - 2020)
 //   Tobias Leibner   (2014, 2018, 2020)
 
+/// \file
+/// \brief Linear solver specializations for CommonDenseMatrix.
+
 #ifndef DUNE_XT_LA_SOLVER_COMMON_HH
 #define DUNE_XT_LA_SOLVER_COMMON_HH
 
@@ -30,6 +33,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Linear solver options for a CommonDenseMatrix.
 template <class S, class CommunicatorType>
 class SolverOptions<CommonDenseMatrix<S>, CommunicatorType> : protected internal::SolverUtils
 {
@@ -50,6 +54,7 @@ public:
 }; // class SolverOptions<CommonDenseMatrix<...>>
 
 
+/// \brief Linear solver for a CommonDenseMatrix using QR decomposition.
 template <class S, class CommunicatorType>
 class Solver<CommonDenseMatrix<S>, CommunicatorType> : protected internal::SolverUtils
 {

--- a/dune/xt/la/solver/dense.hh
+++ b/dune/xt/la/solver/dense.hh
@@ -10,6 +10,9 @@
 //   René Fritze      (2015 - 2020)
 //   Tobias Leibner   (2014, 2018, 2020)
 
+/// \file
+/// \brief Linear solver specializations for generic dense (non-LA-container) matrix types.
+
 #ifndef DUNE_XT_LA_SOLVER_DENSE_HH
 #define DUNE_XT_LA_SOLVER_DENSE_HH
 
@@ -25,6 +28,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Linear solver options for a generic dense matrix type.
 template <class Matrix>
 class SolverOptions<
     Matrix,
@@ -49,6 +53,7 @@ public:
 }; // class SolverOptions<...>
 
 
+/// \brief Linear solver for a generic dense matrix type using QR decomposition.
 template <class Matrix>
 class Solver<
     Matrix,

--- a/dune/xt/la/solver/fasp.hh
+++ b/dune/xt/la/solver/fasp.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2013, 2015 - 2016, 2018 - 2019)
 //   Tobias Leibner  (2017, 2020)
 
+/// \file
+/// \brief Algebraic multigrid solver specialization backed by the FASP library.
+
 #ifndef DUNE_XT_LA_SOLVER_FASP_HH
 #define DUNE_XT_LA_SOLVER_FASP_HH
 
@@ -28,6 +31,7 @@ namespace Dune {
 namespace XT {
 namespace LA {
 
+/// \brief Algebraic multigrid solver for an EigenRowMajorSparseMatrix using the FASP library.
 template <class ElementImp>
 class AmgSolver<Dune::XT::LA::EigenRowMajorSparseMatrix<ElementImp>, Dune::XT::LA::EigenDenseVector<ElementImp>>
   : public SolverInterface<Dune::XT::LA::EigenRowMajorSparseMatrix<ElementImp>,

--- a/dune/xt/la/solver/istl.hh
+++ b/dune/xt/la/solver/istl.hh
@@ -10,6 +10,9 @@
 //   René Fritze      (2014 - 2020)
 //   Tobias Leibner   (2014 - 2015, 2018 - 2020)
 
+/// \file
+/// \brief Linear solver specializations for IstlRowMajorSparseMatrix (dune-istl backends).
+
 #ifndef DUNE_XT_LA_SOLVER_ISTL_HH
 #define DUNE_XT_LA_SOLVER_ISTL_HH
 
@@ -102,6 +105,7 @@ struct IstlSolverTraits<S, SequentialCommunication>
 } // namespace internal
 
 
+/// \brief Linear solver options for an IstlRowMajorSparseMatrix.
 template <class S, class CommunicatorType>
 class SolverOptions<IstlRowMajorSparseMatrix<S>, CommunicatorType> : protected internal::SolverUtils
 {
@@ -164,6 +168,7 @@ public:
 }; // class SolverOptions
 
 
+/// \brief Linear solver for an IstlRowMajorSparseMatrix using dune-istl backends.
 template <class S, class CommunicatorType>
 class Solver<IstlRowMajorSparseMatrix<S>, CommunicatorType> : protected internal::SolverUtils
 {

--- a/dune/xt/la/solver/istl/amg.hh
+++ b/dune/xt/la/solver/istl/amg.hh
@@ -10,6 +10,9 @@
 //   René Fritze      (2014 - 2016, 2018 - 2019)
 //   Tobias Leibner   (2014, 2017 - 2020)
 
+/// \file
+/// \brief Algebraic multigrid preconditioned BiCGStab applicator for IstlRowMajorSparseMatrix.
+
 #ifndef DUNE_XT_LA_SOLVER_ISTL_AMG_HH
 #define DUNE_XT_LA_SOLVER_ISTL_AMG_HH
 
@@ -32,6 +35,7 @@ namespace Dune::XT::LA {
 
 
 //! the general, parallel case
+/// \brief Applies an AMG-preconditioned BiCGStab solver to an IstlRowMajorSparseMatrix (general, parallel case).
 template <class S, class CommunicatorType>
 class AmgApplicator
 {
@@ -145,6 +149,7 @@ protected:
 };
 
 //! specialization for our faux type \ref SequentialCommunication
+/// \brief Applies an AMG-preconditioned BiCGStab solver to an IstlRowMajorSparseMatrix (sequential case).
 template <class S>
 class AmgApplicator<S, SequentialCommunication>
 {

--- a/dune/xt/la/solver/saddlepoint.hh
+++ b/dune/xt/la/solver/saddlepoint.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2019 - 2020)
 //   Tobias Leibner  (2019 - 2020)
 
+/// \file
+/// \brief Solver for saddle point systems via the Schur complement.
+
 #ifndef DUNE_XT_LA_SOLVER_ISTL_SADDLEPOINT_HH
 #define DUNE_XT_LA_SOLVER_ISTL_SADDLEPOINT_HH
 
@@ -34,6 +37,7 @@ namespace Dune::XT::LA {
 
 // Solver for saddle point system (A B1; B2^T C) (u; p) = (f; g) using the Schur complement, i.e., solve (B2^T A^{-1} B1
 // - C) p = B2^T A^{-1} f - g first and then u = A^{-1} (F - B1 p)
+/// \brief Solves a saddle point system (A B1; B2^T C) (u; p) = (f; g) using the Schur complement.
 template <class VectorType, class MatrixType, class CommunicatorType = SequentialCommunication>
 class SaddlePointSolver
 {

--- a/dune/xt/la/solver/view.hh
+++ b/dune/xt/la/solver/view.hh
@@ -8,6 +8,9 @@
 //   René Fritze    (2019 - 2020)
 //   Tobias Leibner (2019 - 2020)
 
+/// \file
+/// \brief Linear solver specializations for MatrixView.
+
 #ifndef DUNE_XT_LA_SOLVER_VIEW_HH
 #define DUNE_XT_LA_SOLVER_VIEW_HH
 
@@ -28,6 +31,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Linear solver options for a MatrixView (forwarded to the underlying matrix type).
 template <class MatrixImp, class CommunicatorType>
 class SolverOptions<MatrixView<MatrixImp>, CommunicatorType> : protected internal::SolverUtils
 {
@@ -46,6 +50,7 @@ public:
 }; // class SolverOptions<MatrixView<...>>
 
 
+/// \brief Linear solver for a MatrixView, copying the view into a full matrix before solving.
 template <class MatrixImp, class CommunicatorType>
 class Solver<MatrixView<MatrixImp>, CommunicatorType> : protected internal::SolverUtils
 {

--- a/dune/xt/la/type_traits.hh
+++ b/dune/xt/la/type_traits.hh
@@ -9,6 +9,9 @@
 //   René Fritze     (2018 - 2019)
 //   Tobias Leibner  (2017 - 2020)
 
+/// \file
+/// \brief Linear algebra backend enum and type traits to detect and relate container types.
+
 #ifndef DUNE_XT_LA_TYPE_TRAITS_HH
 #define DUNE_XT_LA_TYPE_TRAITS_HH
 
@@ -17,6 +20,7 @@
 namespace Dune::XT::LA {
 
 
+/// \brief Enumeration of the available linear algebra backends (common, ISTL, Eigen; dense and sparse).
 enum class Backends
 {
   common_dense,
@@ -134,6 +138,7 @@ struct is_istl_dense_vector_helper
 } // namespace internal
 
 
+/// \brief Trait that is true if C is a dune-xt-la container (derives from ContainerInterface).
 template <class C, bool candidate = internal::is_container_helper<C>::is_candidate>
 struct is_container : public std::is_base_of<ContainerInterface<typename C::Traits, typename C::ScalarType>, C>
 {};
@@ -143,6 +148,7 @@ struct is_container<C, false> : public std::false_type
 {};
 
 
+/// \brief Trait that is true if M is a dune-xt-la matrix (derives from MatrixInterface).
 template <class M, bool candidate = internal::is_matrix_helper<M>::is_candidate>
 struct is_matrix : public std::is_base_of<MatrixInterface<typename M::Traits, typename M::ScalarType>, M>
 {};
@@ -152,6 +158,7 @@ struct is_matrix<M, false> : public std::false_type
 {};
 
 
+/// \brief Trait that is true if V is a dune-xt-la vector (derives from VectorInterface).
 template <class V, bool candidate = internal::is_vector_helper<V>::is_candidate>
 struct is_vector : public std::is_base_of<VectorInterface<typename V::Traits, typename V::ScalarType>, V>
 {};
@@ -161,6 +168,7 @@ struct is_vector<V, false> : public std::false_type
 {};
 
 
+/// \brief Trait that is true if V is an Eigen-based vector (derives from EigenBaseVector).
 template <class V, bool candidate = internal::is_eigen_vector_helper<V>::is_candidate>
 struct is_eigen_vector : public std::is_base_of<EigenBaseVector<typename V::Traits, typename V::ScalarType>, V>
 {};
@@ -170,6 +178,7 @@ struct is_eigen_vector<V, false> : public std::false_type
 {};
 
 
+/// \brief Trait that is true if V is an ISTL dense vector (derives from IstlDenseVector).
 template <class V, bool candidate = internal::is_istl_dense_vector_helper<V>::is_candidate>
 struct is_istl_dense_vector : public std::is_base_of<IstlDenseVector<typename V::ScalarType>, V>
 {};
@@ -179,6 +188,7 @@ struct is_istl_dense_vector<V, false> : public std::false_type
 {};
 
 
+/// \brief Trait that is true if C exposes a native backend (derives from ProvidesBackend).
 template <class C, bool candidate = internal::provides_backend_helper<C>::is_candidate>
 struct provides_backend : public std::is_base_of<ProvidesBackend<typename C::Traits>, C>
 {};
@@ -188,6 +198,7 @@ struct provides_backend<C, false> : public std::false_type
 {};
 
 
+/// \brief Trait that is true if C provides raw data access (derives from ProvidesDataAccess).
 template <class C, bool candidate = internal::provides_data_access_helper<C>::is_candidate>
 struct provides_data_access : public std::is_base_of<ProvidesDataAccess<typename C::Traits>, C>
 {};
@@ -197,6 +208,7 @@ struct provides_data_access<C, false> : public std::false_type
 {};
 
 
+/// \brief Determines the matching sparse matrix container type for a given vector type V (member typedef 'type').
 template <class V, bool = is_vector<V>::value>
 struct extract_matrix;
 
@@ -216,6 +228,7 @@ template <class V>
 using matrix_t = typename extract_matrix<V>::type;
 
 
+/// \brief Determines the matching vector container type for a given matrix type M (member typedef 'type').
 template <class M, bool = is_matrix<M>::value>
 struct extract_vector;
 


### PR DESCRIPTION
## Summary

Works through the **first bucket** of the `dune/xt` Doxygen audit in #165 — the **"Missing everything"** category (105 files across `dune/xt/{common,functions,grid,la}`).

For every file in that bucket this PR:
- adds a Doxygen `\file` header (none of these files had one), and
- adds a `\brief` description to every public class/struct/free function that previously lacked any Doxygen.

Files that expose no documentable public symbols — include-only aggregators, version-dispatch shims, pragma-only / macro-only headers, and `internal`-only implementation headers — receive a `\file` header only.

Consistent with the audit standard, the following are intentionally **not** documented: `namespace internal`/`detail` helpers, private members, forward declarations, and pure `using`/typedef aliases.

## Scope

| Subtree | Files documented |
|---|---|
| `dune/xt/common` | 14 |
| `dune/xt/functions` | 17 |
| `dune/xt/grid` | 32 |
| `dune/xt/la` | 42 |
| **Total** | **105** |

(The audit table rounds this bucket to 106; the bulleted list it expands to contains 105 entries, all of which are covered here.)

## Verification

- Every one of the 105 files now contains a `\file` header (checked by grep).
- No added comment line exceeds the project's 120-column limit.
- `clang-format` (v18) reports no formatting changes attributable to the added comments. (Three files show pre-existing stream-wrapping/template-parameter differences from an older clang-format version; these are left untouched to avoid unrelated churn.)

## Notes

This is the first of four buckets in #165; the remaining buckets ("Partially documented", "Only missing `\file`", "Already complete") are out of scope for this PR.

https://claude.ai/code/session_01FtzByTGFXTgpYXB5Q5AG1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtzByTGFXTgpYXB5Q5AG1M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation with comprehensive Doxygen comments across the library, including brief descriptions for headers, classes, and functions in common utilities, grid/domain decomposition, finite element functions, and linear algebra modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->