### PR TITLE
[grid] Fix make_dgf_grid to call static create() factory method

### DIFF
--- a/dune/xt/grid/gridprovider/dgf.hh
+++ b/dune/xt/grid/gridprovider/dgf.hh
@@ -82,7 +82,7 @@ template <class GridType>
 auto make_dgf_grid(const std::string& filename, MPIHelper::MPICommunicator mpi_comm = MPIHelper::getCommunicator())
 {
   static_assert(is_grid<GridType>::value);
-  return DgfGridProviderFactory<GridType>(filename, mpi_comm);
+  return DgfGridProviderFactory<GridType>::create(filename, mpi_comm);
 }
 
 


### PR DESCRIPTION
## Summary

Fixes a latent bug in the single-filename `make_dgf_grid` overload in `dune/xt/grid/gridprovider/dgf.hh`.

The overload used constructor syntax:

```cpp
return DgfGridProviderFactory<GridType>(filename, mpi_comm);
```

but `DgfGridProviderFactory` declares **no constructor** — it exposes only static `create(...)` factory methods. As written, this overload would fail to compile if it were ever instantiated. It went unnoticed because nothing currently instantiates this particular overload.

The fix calls the static factory method, consistent with:
- the sibling `make_dgf_grid(const Common::Configuration&, ...)` overload in the same file, and
- `make_cube_grid` and `make_gmsh_grid`, which all use `Factory<GridType>::create(...)`.

```diff
-  return DgfGridProviderFactory<GridType>(filename, mpi_comm);
+  return DgfGridProviderFactory<GridType>::create(filename, mpi_comm);
```

## Context

Spotted by CodeRabbit during review of the documentation-only PR #167. Since it's a logic fix unrelated to that PR's documentation scope, it's split out here as a separate, focused change.

https://claude.ai/code/session_01FtzByTGFXTgpYXB5Q5AG1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtzByTGFXTgpYXB5Q5AG1M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal implementation of grid creation by utilizing a factory pattern for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->