### PR TITLE
benchmarks: fix Benchmarks workflow timing out on main

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -42,10 +42,11 @@ add_custom_target(
 # Each benchmark is wrapped in a per-benchmark wall-clock timeout (coreutils `timeout`, if available) so a single
 # runaway benchmark fails fast with a clear error instead of consuming the whole CI job timeout. `timeout` exits 124 on
 # expiry, which fails the custom command (and thus the `run_benchmarks` target). If `timeout` is not found (e.g. on some
-# macOS dev setups), the benchmark is run directly without the safety net.
-# Overridable on the CMake command line, e.g. -DDUNE_GDT_BENCHMARK_TIMEOUT_SECONDS=120 for local runs.
-set(DUNE_GDT_BENCHMARK_TIMEOUT_SECONDS 600 CACHE STRING
-    "Per-benchmark wall-clock timeout in seconds for the run_benchmarks target")
+# macOS dev setups), the benchmark is run directly without the safety net. Overridable on the CMake command line, e.g.
+# -DDUNE_GDT_BENCHMARK_TIMEOUT_SECONDS=120 for local runs.
+set(DUNE_GDT_BENCHMARK_TIMEOUT_SECONDS
+    600
+    CACHE STRING "Per-benchmark wall-clock timeout in seconds for the run_benchmarks target")
 find_program(DUNE_GDT_TIMEOUT_EXECUTABLE NAMES timeout)
 
 # The prefix is the same for every benchmark, so build it once.

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -43,16 +43,20 @@ add_custom_target(
 # runaway benchmark fails fast with a clear error instead of consuming the whole CI job timeout. `timeout` exits 124 on
 # expiry, which fails the custom command (and thus the `run_benchmarks` target). If `timeout` is not found (e.g. on some
 # macOS dev setups), the benchmark is run directly without the safety net.
-set(_benchmark_timeout_seconds 600)
+# Overridable on the CMake command line, e.g. -DDUNE_GDT_BENCHMARK_TIMEOUT_SECONDS=120 for local runs.
+set(DUNE_GDT_BENCHMARK_TIMEOUT_SECONDS 600 CACHE STRING
+    "Per-benchmark wall-clock timeout in seconds for the run_benchmarks target")
 find_program(DUNE_GDT_TIMEOUT_EXECUTABLE NAMES timeout)
+
+# The prefix is the same for every benchmark, so build it once.
+if(DUNE_GDT_TIMEOUT_EXECUTABLE)
+  set(_timeout_prefix ${DUNE_GDT_TIMEOUT_EXECUTABLE} ${DUNE_GDT_BENCHMARK_TIMEOUT_SECONDS})
+else()
+  set(_timeout_prefix)
+endif()
 
 set(_run_commands COMMAND ${CMAKE_COMMAND} -E make_directory ${_benchmark_report_dir})
 foreach(target ${_benchmark_targets})
-  if(DUNE_GDT_TIMEOUT_EXECUTABLE)
-    set(_timeout_prefix ${DUNE_GDT_TIMEOUT_EXECUTABLE} ${_benchmark_timeout_seconds})
-  else()
-    set(_timeout_prefix)
-  endif()
   list(
     APPEND
     _run_commands

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -38,8 +38,21 @@ add_custom_target(
 
 # `run_benchmarks`: build, then run every benchmark, writing one <name>.json nanobench report per benchmark into
 # ${_benchmark_report_dir}.
+#
+# Each benchmark is wrapped in a per-benchmark wall-clock timeout (coreutils `timeout`, if available) so a single
+# runaway benchmark fails fast with a clear error instead of consuming the whole CI job timeout. `timeout` exits 124 on
+# expiry, which fails the custom command (and thus the `run_benchmarks` target). If `timeout` is not found (e.g. on some
+# macOS dev setups), the benchmark is run directly without the safety net.
+set(_benchmark_timeout_seconds 600)
+find_program(DUNE_GDT_TIMEOUT_EXECUTABLE NAMES timeout)
+
 set(_run_commands COMMAND ${CMAKE_COMMAND} -E make_directory ${_benchmark_report_dir})
 foreach(target ${_benchmark_targets})
+  if(DUNE_GDT_TIMEOUT_EXECUTABLE)
+    set(_timeout_prefix ${DUNE_GDT_TIMEOUT_EXECUTABLE} ${_benchmark_timeout_seconds})
+  else()
+    set(_timeout_prefix)
+  endif()
   list(
     APPEND
     _run_commands
@@ -48,6 +61,7 @@ foreach(target ${_benchmark_targets})
     -E
     env
     "DUNE_GDT_BENCHMARK_OUTPUT_DIR=${_benchmark_report_dir}"
+    ${_timeout_prefix}
     $<TARGET_FILE:${target}>)
 endforeach()
 add_custom_target(

--- a/benchmarks/assembly_kernels__continuous_lagrange.cpp
+++ b/benchmarks/assembly_kernels__continuous_lagrange.cpp
@@ -100,10 +100,13 @@ int main(int argc, char** argv)
   // higher epoch counts than the heavy e2e benchmarks: a single element-assembly sweep is cheap
   bench.warmup(1).epochs(5).minEpochIterations(1);
 
-  // 2D: 128x128 cells; 3D: 24x24x24 cells -- comparable element counts, kept modest so a sweep
-  // over orders finishes quickly while still amortizing per-walk overhead.
-  run_for_grid<YASP_2D_EQUIDISTANT_OFFSET>(bench, "2d", 128u, {1, 2, 3});
-  run_for_grid<YASP_3D_EQUIDISTANT_OFFSET>(bench, "3d", 24u, {1, 2, 3});
+  // Workloads are deliberately small so the full sweep finishes in a few seconds in CI while still
+  // amortizing per-walk overhead. The 3D sweep is kept coarse and capped at order 2: a 3D
+  // high-order continuous-Lagrange assembly builds a very large sparse matrix (e.g. order 3 on a
+  // 24^3 grid is ~390k DOFs with >100M nonzeros, rebuilt every iteration) and dominates the runtime
+  // by orders of magnitude -- enough to blow past the workflow's job timeout.
+  run_for_grid<YASP_2D_EQUIDISTANT_OFFSET>(bench, "2d", 64u, {1, 2, 3});
+  run_for_grid<YASP_3D_EQUIDISTANT_OFFSET>(bench, "3d", 12u, {1, 2});
 
   Benchmark::write_report(bench, "assembly_kernels__continuous_lagrange");
   return 0;


### PR DESCRIPTION
## Problem

Every run of the **Benchmarks** workflow on `main` since PR #152 (`assembly-kernel-density`) has ended with conclusion `cancelled` — 6 consecutive runs. They are not hard "failures": the job hits its `timeout-minutes: 120` inside the **Run benchmarks** step, and GitHub records a timed-out job as `cancelled`.

### Root cause

| Run | Commit | "Run benchmarks" step | Result |
|-----|--------|-----------------------|--------|
| last good | `f0ee604` (PR #144) | **13 s** | success |
| first bad | `ff99721` (PR #152) | **~98 min → killed by 120-min timeout** | cancelled |

`run_benchmarks` runs each executable sequentially in alphabetical glob order, so `assembly_kernels__continuous_lagrange` runs **first**, and its nanobench report is only written after its *entire* order/dimension sweep completes. Zero JSON reports were produced (the artifact upload failed with *no files found*), which means that first benchmark never finished within 120 minutes.

The culprit is its oversized workload: a **3D 24×24×24 grid swept over FE orders {1,2,3}**. The 3D order-3 case alone is ≈ 389k DOFs with a >100M-nonzero sparse matrix, rebuilt on every nanobench iteration, which dominates everything. (The sibling `assembly_kernels__sipdg` reuses the same small grid as the pre-existing e2e ESV2007 benchmark, so it is cheap and not the problem.)

## Fix

1. **Right-size `assembly_kernels__continuous_lagrange`** so the full sweep finishes in seconds while staying a meaningful before/after yardstick:
   - 2D: `128² → 64²`, orders `{1,2,3}` (2D is cheap even at P3).
   - 3D: `24³ → 12³` and cap orders to `{1,2}` (drop the dominant 3D high-order assembly).

2. **Per-benchmark timeout safety net** in `run_benchmarks`: wrap each benchmark invocation with coreutils `timeout` (when available; falls back to running directly otherwise) so any single runaway benchmark fails fast with a clear error instead of consuming the whole 2-hour job. The 120-minute job timeout stays as the outer backstop.

## Verification

A full local build to run the resized benchmark was not possible in the dev sandbox (an unrelated third-party dependency, `openblas`, fails to compile there with an AVX512 "target specific option mismatch"; CI runners build it fine). The fix is verified end-to-end on CI via `workflow_dispatch` on this branch — the **Run benchmarks** step now completes quickly and all five JSON reports are produced.

https://claude.ai/code/session_014nBiSyXW5Tw6BHwEVoFoPk

---
_Generated by [Claude Code](https://claude.ai/code/session_014nBiSyXW5Tw6BHwEVoFoPk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an optional, configurable per-benchmark wall-clock timeout (default 600s) used when a system timeout tool is available.
  * Reduced benchmark workload sizes to speed CI and local runs: lowered 2D resolution and reduced 3D resolution and high-order sweeps to keep runtimes reasonable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->