### PR TITLE
ci: speed up test_binaries build with ccache and memory-capped parallelism

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -19,6 +19,12 @@ jobs:
     name: Build on Linux
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    env:
+      # Compiler-level cache. Unlike the build/ cache (keyed on the vcpkg/preset
+      # hash), the ccache survives manifest changes and partial rebuilds, so the
+      # 400+ test-binary translation units stay warm across runs.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: "2G"
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -57,18 +63,42 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build
+        sudo apt-get install -y ninja-build ccache
+
+    - name: Restore ccache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.workspace }}/.ccache
+        # run_id makes every save a unique (always-miss) key so each run writes a
+        # fresh cache; the prefix restore-key then pulls the most recent ccache
+        # from any previous run.
+        key: ${{ runner.os }}-ccache-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-
 
     - name: Configure CMake
       id: configure_cmake
-      run: cmake --preset=debug
+      # Route every compile through ccache. Passing the launcher as a cache
+      # variable (not just an env var) forces CMake to regenerate the Ninja
+      # rules even when a stale build/ tree is restored from cache.
+      run: >
+        cmake --preset=debug
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: cmake --build --preset=debug --parallel
 
     - name: Build test binaries
       run: |
-        cmake --build --preset=debug --target test_binaries --parallel -- -l 2
+        # test_binaries is ~400 separate executables, several of which are
+        # template-heavy TUs that peak around ~2 GB RAM each. The old "-l 2"
+        # load cap effectively serialised the build (~6 s/file, ~40 min). Cap
+        # concurrency by memory instead: -j 3 keeps peak RAM well under the
+        # 16 GB runner while using 3 of the 4 vCPUs. With a warm ccache most of
+        # these are cache hits and cost almost nothing.
+        cmake --build --preset=debug --target test_binaries --parallel -- -j 3
+        ccache --show-stats
 
     - name: Test with CTest
       run: |
@@ -82,6 +112,16 @@ jobs:
           build
           .vcpkg-root
         key: ${{ runner.os }}-build-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+
+    - name: Save ccache
+      # Always persist the compiler cache (even when the build or tests fail) so
+      # the next run starts warm. Only requires that configure succeeded, since
+      # that is what populates the cache directory.
+      if: always() && steps.configure_cmake.outcome == 'success'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ github.run_id }}
 
     - name: Upload error logs (in case of failure)
       if: always() && (steps.configure_cmake.conclusion == 'failure')

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -82,9 +82,7 @@ jobs:
       # variable (not just an env var) forces CMake to regenerate the Ninja
       # rules even when a stale build/ tree is restored from cache.
       run: >
-        cmake --preset=debug
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake --preset=debug -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: cmake --build --preset=debug --parallel


### PR DESCRIPTION
## Problem

The **"Build test binaries"** step of `Non-docker Build and Test` is the dominant
cost of CI. Measured from the Actions step-timing API and the raw ninja log of
recent runs of the `build-linux` job:

| Step | Duration |
|---|---|
| Configure CMake (build/ cache hit) | ~56 s |
| Configure CMake (build/ cache miss, vcpkg from source) | ~20 m |
| Build (lib + bindings) | ~1 m 9 s |
| **Build test binaries** | **~40 min** (extrapolated; a recent run was cancelled at 32/403) |

The step builds **403 separate executables** and was invoked with
`--parallel -- -l 2`. The ninja log shows the `-l 2` load-average cap effectively
**serialised** the build on the 4-vCPU `ubuntu-24.04` runner — one object every
~6 s with zero overlap (`[4/403]` 15:07:20 → `[32/403]` 15:10:08 = 28 files / 168 s
= 6.0 s/file), defeating the point of `--parallel`. The cap is most likely an OOM
guard: several test TUs (e.g. the `float_cmp` template family) peak around ~2 GB
RAM, so 4× in parallel on the 16 GB runner risks the OOM-killer.

## Changes (only the `build-linux` job)

- **Replace `-l 2` with `-j 3`** — cap concurrency by *memory* rather than load.
  `3 × ~2 GB` stays well under 16 GB while using 3 of the 4 vCPUs.
- **Add ccache** — install it, route compiles through it via
  `CMAKE_<LANG>_COMPILER_LAUNCHER` passed as cache variables (forces ninja-rule
  regeneration even with a restored `build/`), and cache the ccache dir with a
  rotating `run_id` key + prefix restore-key. Unlike the `build/` cache it survives
  vcpkg/preset hash changes and partial/cancelled rebuilds, keeping the test TUs
  warm across runs. The cache is saved with `if: always()` so it persists even when
  the build or tests fail. `ccache --show-stats` is printed for visibility.

## Expected effect

- Cold test-binary build: ~40 min → ~13–14 min (3× parallelism).
- Warm runs (ccache hits): down to a few minutes.
- No change to which tests are built or run.

## Follow-up

The deeper structural costs (403 combinatorial executables, vcpkg from-source on
cache miss, no PCH/unity) are tracked in a separate issue.

https://claude.ai/code/session_01TbGMZoR8ogiqq1UiFv5wpF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbGMZoR8ogiqq1UiFv5wpF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux build pipeline performance through enhanced caching mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->