### PR TITLE
test(stokes): make is_symmetric O(nnz) instead of O(n^2)

### DIFF
--- a/dune/gdt/test/stokes/stokes-taylorhood.hh
+++ b/dune/gdt/test/stokes/stokes-taylorhood.hh
@@ -78,8 +78,13 @@ public:
   {
     if (mat.rows() != mat.cols())
       return false;
+    // Only stored entries can break symmetry: any asymmetric pair has its non-zero side stored, so iterating the
+    // sparsity pattern (O(nnz)) visits it and compares against the (possibly structurally-zero) transpose. Pairs where
+    // both sides are structural zeros are trivially symmetric. This is equivalent to the dense O(n^2) double loop but
+    // avoids scanning the (mostly empty) sparse matrix entry by entry.
+    const auto pattern = mat.pattern();
     for (size_t ii = 0; ii < mat.rows(); ++ii)
-      for (size_t jj = ii; jj < mat.cols(); ++jj)
+      for (const size_t jj : pattern.inner(ii))
         if (XT::Common::FloatCmp::ne(mat.get_entry(ii, jj), mat.get_entry(jj, ii))) {
           std::cerr << "mat.rows() = " << mat.rows() << ", mat.cols() = " << mat.cols() << std::endl;
           std::cerr << "not symmetric for indices " << ii << ", " << jj << " with values " << mat.get_entry(ii, jj)


### PR DESCRIPTION
## Why

Review of the `Non-docker Build and Test` CI run times. The `Build on Linux` job is ~1h52m; the **serial** `Test with CTest` step is ~22 min (1340 s, 283 tests, 0 failures). The per-test breakdown is extremely top-heavy:

| Test | time | % of test step |
|------|------|----------------|
| `test_stokes` | 581.82 s | 43% |
| `test_spaces_h1_continuous_lagrange__cubic_grids` | 206.41 s | 15% |
| `test_linear_transport__1d__implicit__fv` | 192.15 s | 14% |
| `test_stationary_heat_equation__ESV2007` | 92.41 s | 7% |

The dominant cost in these is **genuine numerical work** (direct/iterative solves, implicit time-stepping, EOC refinement sweeps, high-dim/high-order space loops) in a Debug build — not something that can be cut without trade-offs. Those trade-offs are filed separately as #175 and #176.

This PR contains the **one strictly behavior-preserving** improvement found in the test sources.

## What

`StokesDirichletTest::is_symmetric` (`dune/gdt/test/stokes/stokes-taylorhood.hh`) scanned the assembled velocity matrix with a dense `ii/jj` double loop calling `get_entry()` for every index pair — **O(n²) lookups over a sparse matrix** — and it is called **twice** per `run()` (n up to ~7400 for the order-3 cube cases). `test_stokes` is the single slowest test in the suite.

The rewrite iterates the **sparsity pattern** (`mat.pattern()`) and compares each stored `(i, j)` against its transpose — **O(nnz)**.

### Equivalence
Any asymmetric pair has its non-zero side stored in the pattern, so it is still visited and compared against the (possibly structurally-zero) transpose; pairs where both sides are structural zeros are trivially symmetric. The `EXPECT_TRUE(is_symmetric(...))` assertions and the `std::cerr` diagnostic on failure are unchanged.

## Verification
The change uses only public APIs already used by the surrounding test (`pattern()` → `SparsityPatternDefault::inner()`, `get_entry`, `XT::Common::FloatCmp::ne`). It could not be built locally (the sandbox ships CMake 3.28 < the required 3.29), so functional verification is delegated to CI — expect `test_stokes` to still report **PASSED** with a lower wall time than 581.82 s.

## Follow-ups (out of scope here, maintainer decision)
- #175 — reduce redundant per-element checks in the space tests (targets the 206 s `spaces_h1_continuous_lagrange__cubic_grids`).
- #176 — tune EOC / grid workload of the slowest PDE tests (targets the 192 s / 92 s / 582 s solves).

https://claude.ai/code/session_0147bMNKqwm3KNij9aJLJuht

---
_Generated by [Claude Code](https://claude.ai/code/session_0147bMNKqwm3KNij9aJLJuht)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced performance of test validation for matrix properties through optimized iteration strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->