### PR TITLE
docs: show repo-root-relative paths in clangquill C++ API file headings

### DIFF
--- a/tutorials/source/_clangquill_templates/file.md.jinja
+++ b/tutorials/source/_clangquill_templates/file.md.jinja
@@ -1,0 +1,5 @@
+{{ "#" * level }} File `{{ file.path | repo_relpath }}`
+{% for symbol in symbols %}
+
+{{ gen.render_symbol(symbol, level=level + 1) }}
+{% endfor %}

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -171,6 +171,54 @@ clangquill_group_by = "file"
 clangquill_include_undocumented = False
 # Persist the SQLite IR + page hashes so local rebuilds are incremental.
 clangquill_cache_dir = "_clangquill_cache"
+# Render the C++ API file headings with repository-root-relative paths (see the
+# _clangquill_templates/file.md.jinja override and _patch_clangquill_relpath
+# below). Resolved relative to this srcdir, like every other clangquill path.
+clangquill_template_dirs = ["_clangquill_templates"]
+
+
+def _patch_clangquill_relpath():
+    """Make the C++ API "File" headings show repo-root-relative paths.
+
+    clangquill resolves every parsed input to an absolute path and stores that
+    in its IR, so the bundled ``file.md.jinja`` prints build-machine paths like
+    ``/home/runner/work/dune-gdt/dune-gdt/dune/gdt/foo.hh``. There is no config
+    knob to re-root them, and clangquill builds its Jinja environment internally
+    without exposing a hook for custom filters, so we register a ``repo_relpath``
+    filter by wrapping ``Generator._install_context`` (run for every Generator).
+    Our ``_clangquill_templates/file.md.jinja`` override then renders
+    ``{{ file.path | repo_relpath }}`` to emit stable ``dune/...`` paths
+    independent of where the docs happen to be built.
+
+    Degrades to a no-op if clangquill cannot be imported (e.g. a wheel built
+    without it); the extension itself would already have failed in that case.
+    """
+    try:
+        from clangquill.generator import Generator  # noqa: PLC0415
+    except ImportError:
+        return
+
+    repo_root = str((this_dir / ".." / "..").resolve())
+
+    def repo_relpath(path):
+        try:
+            rel = os.path.relpath(path, repo_root)
+        except ValueError:
+            return path
+        # Leave paths outside the repository untouched (should not happen for the
+        # dune/**/*.hh inputs, but never print a surprising ``../..`` escape).
+        return path if rel.startswith("..") else rel
+
+    original_install_context = Generator._install_context
+
+    def install_context(self):
+        original_install_context(self)
+        self.env.filters["repo_relpath"] = repo_relpath
+
+    Generator._install_context = install_context
+
+
+_patch_clangquill_relpath()
 
 bibtex_bibfiles = ["bibliography.bib"]
 # Add any paths that contain templates here, relative to this directory.

--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -171,10 +171,6 @@ clangquill_group_by = "file"
 clangquill_include_undocumented = False
 # Persist the SQLite IR + page hashes so local rebuilds are incremental.
 clangquill_cache_dir = "_clangquill_cache"
-# Render the C++ API file headings with repository-root-relative paths (see the
-# _clangquill_templates/file.md.jinja override and _patch_clangquill_relpath
-# below). Resolved relative to this srcdir, like every other clangquill path.
-clangquill_template_dirs = ["_clangquill_templates"]
 
 
 def _patch_clangquill_relpath():
@@ -190,35 +186,56 @@ def _patch_clangquill_relpath():
     ``{{ file.path | repo_relpath }}`` to emit stable ``dune/...`` paths
     independent of where the docs happen to be built.
 
-    Degrades to a no-op if clangquill cannot be imported (e.g. a wheel built
-    without it); the extension itself would already have failed in that case.
+    Returns ``True`` when the filter was wired onto clangquill's Generator and
+    ``False`` otherwise — clangquill is missing (e.g. a wheel built without it)
+    or a future version dropped the internal ``_install_context`` hook. The
+    caller must only activate the template override when this returns ``True``,
+    since the override relies on the ``repo_relpath`` filter being present.
     """
     try:
         from clangquill.generator import Generator  # noqa: PLC0415
     except ImportError:
-        return
+        return False
+
+    # Guard the private hook we wrap: if a future clangquill renames or drops it,
+    # bail out cleanly instead of raising at import time (and let the caller skip
+    # the template override) so the docs build degrades to absolute paths rather
+    # than failing outright.
+    original_install_context = getattr(Generator, "_install_context", None)
+    if original_install_context is None:
+        return False
 
     repo_root = str((this_dir / ".." / "..").resolve())
 
     def repo_relpath(path):
+        """Render an absolute parsed-file path relative to the repository root.
+
+        Paths outside the repository are returned unchanged (should not happen
+        for the ``dune/**/*.hh`` inputs, but never emit a surprising ``../..``
+        escape).
+        """
         try:
             rel = os.path.relpath(path, repo_root)
         except ValueError:
             return path
-        # Leave paths outside the repository untouched (should not happen for the
-        # dune/**/*.hh inputs, but never print a surprising ``../..`` escape).
         return path if rel.startswith("..") else rel
 
-    original_install_context = Generator._install_context
-
     def install_context(self):
+        """Register the ``repo_relpath`` filter on each Generator's Jinja env."""
         original_install_context(self)
         self.env.filters["repo_relpath"] = repo_relpath
 
     Generator._install_context = install_context
+    return True
 
 
-_patch_clangquill_relpath()
+# Only activate the file.md.jinja override (which renders
+# {{ file.path | repo_relpath }}) when the filter was actually registered;
+# otherwise clangquill falls back to its bundled template with absolute paths
+# rather than crashing on an unknown Jinja filter. Resolved relative to this
+# srcdir, like every other clangquill path.
+if _patch_clangquill_relpath():
+    clangquill_template_dirs = ["_clangquill_templates"]
 
 bibtex_bibfiles = ["bibliography.bib"]
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Problem

On the staging C++ API build (https://staging.dune-gdt.org/cpp_api/index.html), each generated page's **"File"** heading shows the **absolute** path of the parsed header, e.g.:

> # File `/home/runner/work/dune-gdt/dune-gdt/dune/gdt/operators/interfaces.hh`

These leak the build-machine layout and are unstable across environments. They should be **relative to the repository root** (`dune/gdt/operators/interfaces.hh`).

## Root cause

clangquill's pipeline resolves every input to an absolute path (`Path(...).resolve()` in `_resolve_inputs`) and stores it in its IR. The bundled `file.md.jinja` template then renders `` File `{{ file.path }}` `` verbatim. clangquill exposes **no config knob** to re-root these paths, and it builds its Jinja environment internally with no hook for custom filters.

## Fix

Entirely within the docs config (`tutorials/source`):

- **`conf.py`** — register a `repo_relpath` Jinja filter by wrapping `clangquill.generator.Generator._install_context` (runs for every `Generator` instance). The filter computes `os.path.relpath(path, <repo root>)`, where the repo root is the deterministic `(<srcdir>/../..)` already used by the rest of the clangquill config. Paths outside the repo are left untouched, and the patch degrades to a no-op if clangquill can't be imported.
- **`_clangquill_templates/file.md.jinja`** — a template override (wired via the new `clangquill_template_dirs`) identical to the bundled one except it renders `{{ file.path | repo_relpath }}`.

Result:

> # File `dune/gdt/operators/interfaces.hh`

…regardless of where the docs are built.

## Verification

Against the real `clangquill==0.1.1` package (extracted from the sdist):
- `conf.py` byte-compiles.
- The wrapped `Generator._install_context` registers the `repo_relpath` filter on the real `Generator`'s Jinja env.
- Rendering the override template through clangquill's exact Jinja environment turns `/home/runner/work/dune-gdt/dune-gdt/dune/gdt/operators/interfaces.hh` into `dune/gdt/operators/interfaces.hh`.
- The filter leaves out-of-repo paths (e.g. system headers) absolute.

https://claude.ai/code/session_01QEj8jNEb6o96QGw5keo5iM

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEj8jNEb6o96QGw5keo5iM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved C++ API documentation layout: file sections now render with clearer headings and organized symbol listings for easier navigation.
  * Generated file paths in documentation are now repository-relative, making source references more consistent and user-friendly.
  * Support for custom template overrides to allow tailored documentation styling without breaking rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->