### PR TITLE
Add meshio to the docs extra (fix example__gmsh_grid on main)

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -48,9 +48,14 @@ jobs:
         # Key on the inputs that determine the toolchain/manifest so the cache is
         # rebuilt when they change. The trailing-dash restore-key only matches
         # caches written by this (consistent) scheme, never the legacy build-only one.
-        key: ${{ runner.os }}-build-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+        # The -v2- generation token deliberately invalidates older caches: a cancelled
+        # run left a corrupted dune-env (a half-installed "~une-common" distribution and
+        # conflicting dune-common versions) in the cached build/, which broke configure
+        # ("Dune python package could not be found"). Bump this token to force a clean
+        # rebuild if the cached dune-env is ever poisoned again.
+        key: ${{ runner.os }}-build-v2-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          ${{ runner.os }}-build-v2-
 
     - name: Drop stale build cache if vcpkg toolchain is missing
       run: |
@@ -109,7 +114,7 @@ jobs:
         path: |
           build
           .vcpkg-root
-        key: ${{ runner.os }}-build-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+        key: ${{ runner.os }}-build-v2-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
 
     - name: Save ccache
       # Always persist the compiler cache (even when the build or tests fail) so

--- a/python/xt/setup.py.in
+++ b/python/xt/setup.py.in
@@ -35,7 +35,7 @@ docs_packages = ['python-slugify', 'sphinxcontrib-bibtex', 'furo', 'myst-nb>=0.1
                  # meshio is required by pymor's discretize_gmsh (used in the gmsh tutorial)
                  # to read Gmsh meshes, and the tutorial uses it to re-write a dune-grid
                  # readable version 2.2 mesh
-                 'meshio>=4']
+                 'meshio>=4.4']
 examples_packages = ['pymor==2022.2.0; python_version < "3.11"',
                      'pymor; python_version >= "3.11"']
 

--- a/python/xt/setup.py.in
+++ b/python/xt/setup.py.in
@@ -31,7 +31,11 @@ visualization_packages = [ 'k3d>=2.15.2', 'vtk', 'ipywidgets', 'lxml', 'xmljson'
 # clangquill parses the in-tree dune-gdt/dune-xt C++ headers with libclang and
 # renders the MyST C++ API pages consumed by the Sphinx build (see
 # tutorials/source/conf.py); it replaces the previous Doxygen-based API setup.
-docs_packages = ['python-slugify', 'sphinxcontrib-bibtex', 'furo', 'myst-nb>=0.16', 'pymor', 'clangquill>=0.1.1', 'plotly']
+docs_packages = ['python-slugify', 'sphinxcontrib-bibtex', 'furo', 'myst-nb>=0.16', 'pymor', 'clangquill>=0.1.1', 'plotly',
+                 # meshio is required by pymor's discretize_gmsh (used in the gmsh tutorial)
+                 # to read Gmsh meshes, and the tutorial uses it to re-write a dune-grid
+                 # readable version 2.2 mesh
+                 'meshio>=4']
 examples_packages = ['pymor==2022.2.0; python_version < "3.11"',
                      'pymor; python_version >= "3.11"']
 


### PR DESCRIPTION
Follow-up to #168 (closes the last gap from #127).

`example__gmsh_grid` currently fails on `main` with `MeshioMissingError`: pymor's `discretize_gmsh` requires `meshio>=4` to read Gmsh meshes (and the notebook itself uses `meshio` to re-write a dune-grid-readable v2.2 mesh).

`meshio` was only pip-installed ad-hoc in the `build_tutorials` CI job in #168, and that install line was dropped when the job was refactored to a `uv` venv during the `main` merge — so the dependency is no longer present.

This declares `meshio>=4` in the **`docs` extra** (`python/xt/setup.py.in`, the single source of truth for tutorial dependencies, right next to `pymor`). `dune-gdt[docs]` then pulls it in automatically, so the `build_tutorials` job (which installs `dune-gdt[docs,visualisation]`) gets it with no separate CI line — and anyone running the tutorials locally does too.

All other deferred notebooks from #127 already pass on `main`; this should turn `example__gmsh_grid` green as well.

https://claude.ai/code/session_01UpjKLqgeNAjRiwLRnkNrp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpjKLqgeNAjRiwLRnkNrp4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation build tooling so tutorials (including the Gmsh-based tutorial) can read/rewrite meshes and render related plots reliably.
  * Rotated CI build cache keys on Linux to force refresh of the build/toolchain cache, improving reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->