### PR TITLE
docs: cover all in-tree headers in clangquill C++ API (include undocumented symbols)

### DIFF
--- a/tutorials/source/conf.py
+++ b/tutorials/source/conf.py
@@ -150,9 +150,10 @@ clangquill_std = "c++17"
 clangquill_clang_resource_dir = _clang_resource_dir()
 clangquill_output_dir = "cpp_api"
 clangquill_group_by = "file"
-# Emit only symbols that carry a documentation comment; flip to True to also
-# list the (largely templated) undocumented internals.
-clangquill_include_undocumented = False
+# Emit every symbol clangquill extracts, including the (largely templated)
+# undocumented internals, so the C++ API pages cover all in-tree headers rather
+# than only those carrying a documentation comment.
+clangquill_include_undocumented = True
 # Persist the SQLite IR + page hashes so local rebuilds are incremental.
 clangquill_cache_dir = "_clangquill_cache"
 


### PR DESCRIPTION
## What

Verified header coverage of the ClangQuill-generated C++ API docs (the `cpp_api/` pages produced by the `clangquill.sphinx_ext` extension during the tutorials Sphinx build) and flipped `clangquill_include_undocumented` to `True` in `tutorials/source/conf.py`.

## Why

The tutorials build feeds `dune/**/*.hh` to ClangQuill with `group_by = "file"`, so each header gets an API page only when it declares at least one **visible** symbol. With `include_undocumented = False`, "visible" meant "carries a documentation comment", which silently dropped headers whose symbols are real but undocumented (largely templated internals).

## Verification

Reproduced the exact `clangquill_*` config from `conf.py` and parsed all headers with libclang (clang 18, c++17), then compared the input glob against the files that actually produce a page:

| | headers with a page | missing |
|---|---|---|
| `include_undocumented = False` (before) | 304 / 368 | 64 |
| `include_undocumented = True` (after) | **366 / 368** | 2 |

- The glob `dune/**/*.hh` matches **368** headers (the lone `.h`, `dune/xt/test/gtest/gtest.h`, is intentionally not matched). All 368 are opened by libclang; none fail to parse.
- The 64 previously-missing headers all had symbols but no documentation comment; 62 of them are recovered by this change.
- The **2** that remain pageless — `dune/xt/common/disable_warnings.hh` and `dune/xt/common/reenable_warnings.hh` — are pure `#pragma GCC diagnostic` headers that declare **no C++ symbols at all**. ClangQuill is symbol-driven, so it cannot emit a page for a header that contributes no symbol (their `/// \file` brief has nothing to attach to). This is expected and not fixable via config.

## Note

Enabling undocumented symbols substantially increases the size of the C++ API section (the previously-suppressed templated internals are now listed), which is the intended effect.

https://claude.ai/code/session_01USGmTeJfAELAo9BnpwMz8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGmTeJfAELAo9BnpwMz8d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation generation to include previously undocumented C++ symbols and templated internals for more comprehensive API coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->