### PR TITLE
Remove orphaned doxygen group-closer in DiscreteFunction

### DIFF
--- a/dune/gdt/discretefunction/default.hh
+++ b/dune/gdt/discretefunction/default.hh
@@ -277,10 +277,6 @@ public:
     return std::make_unique<ThisType>(space_, dofs_.vector().copy());
   }
 
-  /**
-   * \}
-   */
-
   ThisType& operator+=(const BaseType& other)
   {
     dofs().vector() += other.dofs().vector();


### PR DESCRIPTION
## What

Removes a rogue/orphaned doxygen group-closing comment in `dune/gdt/discretefunction/default.hh`.

The `DiscreteFunction` class (just above `operator+=`) contained a stray doxygen group closer:

```cpp
  /**
   * \}
   */
```

with **no** matching `\{` group opener anywhere in that class. The sibling `ConstDiscreteFunction` class has a properly balanced `\name ... \{` / `\}` pair (lines 124–148), so this leftover closer was an orphan.

## Why it looked like a "rogue curly brace"

The actual C++ braces in the file were already balanced (38 `{` / 38 `}`). A naive brace count was thrown off (39 `{` / 40 `}`) purely because of the unbalanced doxygen `\{` / `\}` comment markers — one `\{` (line 126) vs two `\}` (lines 147, 281).

## Fix

Removed the orphaned `\}` doxygen comment block. After the change:

- raw braces: 39 / 39
- doxygen markers: `\{` 1 / `\}` 1
- code-only braces: 38 / 38

No functional/code change — documentation grouping only.

https://claude.ai/code/session_01Dn4B8DVApLpupHniy5RuAG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn4B8DVApLpupHniy5RuAG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed unused documentation formatting comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->