### PR TITLE
Fix Engquist-Osher flux dropping the state integral for negative states

### DIFF
--- a/dune/gdt/local/numerical-fluxes/engquist-osher.hh
+++ b/dune/gdt/local/numerical-fluxes/engquist-osher.hh
@@ -82,14 +82,16 @@ public:
                   const XT::Common::Parameter& param = {}) const override final
   {
     this->compute_entity_coords(x_in_intersection_coords);
+    // computes the oriented integral \int_0^{s} min_max(f'(u) n, 0) du, which carries a negative
+    // sign for s < 0 (the quadrature then runs over [s, 0], traversed in reverse direction)
     auto integrate_f = [&](const LocalFluxType& local_flux,
                            const auto& x,
                            const auto& s,
                            const std::function<double(const R&, const R&)>& min_max) {
-      if (!(s[0] > 0.))
+      if (s[0] == 0.)
         return 0.;
       double ret = 0.;
-      const OneDGrid state_grid(1, 0., s[0]);
+      const OneDGrid state_grid(1, std::min(s[0], 0.), std::max(s[0], 0.));
       const auto state_interval = *state_grid.leafGridView().template begin<0>();
       for (const auto& quadrature_point : QuadratureRules<R, 1>::rule(state_interval.type(), local_flux.order(param))) {
         const auto local_uu = quadrature_point.position();
@@ -98,7 +100,7 @@ public:
         ret +=
             state_interval.geometry().integrationElement(local_uu) * quadrature_point.weight() * min_max(n * df[0], 0.);
       }
-      return ret;
+      return (s[0] > 0.) ? ret : -ret;
     };
     return (local_flux_inside_->evaluate(x_in_inside_coords_, 0., param) * n)
            + integrate_f(*local_flux_inside_,

--- a/dune/gdt/test/misc/numerical_fluxes.cc
+++ b/dune/gdt/test/misc/numerical_fluxes.cc
@@ -1,0 +1,91 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/gdt/local/numerical-fluxes/engquist-osher.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using I = XT::Grid::extract_intersection_t<GV>;
+
+/// Checks the Engquist-Osher flux g(u, v) = f(0) n + \int_0^u max(f'(s) n, 0) ds + \int_0^v min(f'(s) n, 0) ds
+/// against analytically computed values, in particular for negative states (which used to be silently dropped).
+struct EngquistOsherFluxTest : public ::testing::Test
+{
+  using FluxType = XT::Functions::GenericFunction<1, 1, 1>;
+  using NumericalFluxType = NumericalEngquistOsherFlux<I, 1, 1, double>;
+  using StateType = typename NumericalFluxType::StateType;
+  using LocalCoordType = typename NumericalFluxType::LocalIntersectionCoords;
+
+  void SetUp() override
+  {
+    grid_provider_ = std::make_unique<XT::Grid::GridProvider<G>>(XT::Grid::make_cube_grid<G>(0., 1., 2u));
+    auto grid_view = grid_provider_->leaf_view();
+    for (auto&& element : elements(grid_view))
+      for (auto&& intersection : intersections(grid_view, element))
+        if (intersection.neighbor() && !inner_intersection_) {
+          inner_intersection_ = std::make_unique<I>(intersection);
+          normal_ = intersection.centerUnitOuterNormal();
+        }
+    ASSERT_NE(inner_intersection_, nullptr);
+    ASSERT_DOUBLE_EQ(normal_[0], 1.); // intersections of the first element are visited first
+  }
+
+  double apply(const FluxType& flux, const double u, const double v, const double n) const
+  {
+    NumericalFluxType numerical_flux(flux);
+    numerical_flux.bind(*inner_intersection_);
+    return numerical_flux.apply(LocalCoordType(), StateType(u), StateType(v), {n})[0];
+  }
+
+  std::unique_ptr<XT::Grid::GridProvider<G>> grid_provider_;
+  std::unique_ptr<I> inner_intersection_;
+  FieldVector<double, 1> normal_;
+}; // struct EngquistOsherFluxTest
+
+
+TEST_F(EngquistOsherFluxTest, linear_flux)
+{
+  // f(u) = u, f'(u) = 1: the flux has to reduce to the upwind value f(u) n for n = 1 (and f(v) n for n = -1),
+  // for positive as well as negative states
+  const FluxType linear_flux(
+      1,
+      [](const auto& u, const auto& /*param*/) { return u; },
+      "linear",
+      {},
+      [](const auto& u, const auto& /*param*/) { return decltype(u)(1.); });
+  EXPECT_NEAR(apply(linear_flux, 2., 3., 1.), 2., 1e-14);
+  EXPECT_NEAR(apply(linear_flux, -2., -1., 1.), -2., 1e-14); // <- used to yield 0.
+  EXPECT_NEAR(apply(linear_flux, -2., 3., 1.), -2., 1e-14); // <- used to yield 0.
+  EXPECT_NEAR(apply(linear_flux, 3., 2., -1.), -2., 1e-14);
+  EXPECT_NEAR(apply(linear_flux, -1., -2., -1.), 2., 1e-14); // <- used to yield 0.
+}
+
+TEST_F(EngquistOsherFluxTest, burgers_flux)
+{
+  // f(u) = u^2/2, f'(u) = u: for n = 1 the Engquist-Osher flux is g(u, v) = max(u, 0)^2/2 + min(v, 0)^2/2
+  const FluxType burgers_flux(
+      2,
+      [](const auto& u, const auto& /*param*/) { return 0.5 * u * u; },
+      "burgers",
+      {},
+      [](const auto& u, const auto& /*param*/) { return u; });
+  EXPECT_NEAR(apply(burgers_flux, 1., 2., 1.), 0.5, 1e-14);
+  EXPECT_NEAR(apply(burgers_flux, -1., 1., 1.), 0., 1e-14); // transonic rarefaction
+  EXPECT_NEAR(apply(burgers_flux, -2., -1., 1.), 0.5, 1e-14); // <- used to yield 0.
+  EXPECT_NEAR(apply(burgers_flux, 1., -2., 1.), 2.5, 1e-14); // transonic shock, used to yield 0.5
+  EXPECT_NEAR(apply(burgers_flux, 2., -2., 1.), 4., 1e-14); // <- used to yield 2.
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

The Engquist–Osher numerical flux is

```
g(u, v) = f(0)·n + ∫₀ᵘ max(f'(s)·n, 0) ds + ∫₀ᵛ min(f'(s)·n, 0) ds
```

The state-integration helper in `dune/gdt/local/numerical-fluxes/engquist-osher.hh` bailed out with `0.` whenever the integration endpoint was **not positive**:

```cpp
if (!(s[0] > 0.))
  return 0.;
const OneDGrid state_grid(1, 0., s[0]);   // <- also invalid for s[0] < 0
```

so both integrals were silently dropped for negative states. Concrete consequences (1d, n = +1):

| flux | states | correct EO flux | returned |
|---|---|---|---|
| f(u) = u | u = v = −1 | −1 (upwind) | 0 |
| f(u) = u²/2 | u = −2, v = −1 | 0.5 | 0 |
| f(u) = u²/2 | u = 1, v = −2 (transonic shock) | 2.5 | 0.5 |

Any FV/DG solution with negative states was advanced with an inconsistent flux — a plain accuracy/consistency bug, not just an instability.

**Why no test caught it:** the linear-transport and Burgers EOC studies use nonnegative initial data (indicator / Gaussian bump), so the broken branch was never taken.

## The fix

The integral is computed as an oriented integral: for a negative endpoint the quadrature runs over `[s, 0]` and the result is negated (`∫₀ˢ = −∫ₛ⁰`). The `s = 0` guard stays (a degenerate `OneDGrid` is not constructible).

## The test

`dune/gdt/test/misc/numerical_fluxes.cc` binds the flux to a real 1d grid intersection and checks it against analytically computed values for the linear and Burgers fluxes — positive states (pinning existing behavior), negative states, a transonic rarefaction and a transonic shock. The negative-state and transonic-shock cases fail with the previous implementation.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Engquist-Osher numerical flux to correctly handle negative flow directions. Previously, negative cases returned incorrect or zero results.

* **Tests**
  * Added comprehensive unit tests for the Engquist-Osher flux, including linear flux and Burgers' flux test cases with both positive and negative flow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->