### PR TITLE
Fix DG artificial viscosity shock capturing (NaN indicator, broken smoothing, component 0 only)

### DIFF
--- a/dune/gdt/local/operators/advection-dg.hh
+++ b/dune/gdt/local/operators/advection-dg.hh
@@ -22,6 +22,7 @@
 
 #include <dune/xt/common/memory.hh>
 #include <dune/xt/common/parameter.hh>
+#include <dune/xt/grid/entity.hh>
 #include <dune/xt/grid/intersection.hh>
 
 #include <dune/gdt/exceptions.hh>
@@ -784,11 +785,8 @@ public:
       return;
     // compute jump indicator (8.176)
     double element_jump_indicator = 0;
-    double element_boundary_without_domain_boundary = (d == 1) ? 1. : 0.;
     for (auto&& intersection : intersections(assembly_grid_view_, element())) {
       if (intersection.neighbor() && !intersection.boundary()) {
-        if (d > 1)
-          element_boundary_without_domain_boundary += XT::Grid::diameter(intersection);
         const auto neighbor = intersection.outside();
         v_->bind(neighbor);
         const auto integration_order = std::pow(std::max(u_->order(param), v_->order(param)), 2);
@@ -806,8 +804,10 @@ public:
               integration_factor * quadrature_weight * std::pow(value_on_element - value_on_neighbor, 2);
         }
       }
-      element_jump_indicator /= element_boundary_without_domain_boundary * element().geometry().volume();
     }
+    // normalize once by h_K |K|^(3/4) as in (8.176) (this used to happen within the intersection loop above, dividing
+    // earlier faces' contributions repeatedly and yielding 0/0 = NaN on elements touching the domain boundary)
+    element_jump_indicator /= XT::Grid::diameter(element()) * std::pow(element().geometry().volume(), 0.75);
     // compute smoothed discrete jump indicator (8.180)
     double smoothed_discrete_jump_indicator = 0;
     const double xi_min = 0.5;
@@ -818,7 +818,7 @@ public:
       smoothed_discrete_jump_indicator = 1;
     else
       smoothed_discrete_jump_indicator =
-          0.5 * std::sin(M_PI * (element_jump_indicator - (xi_max - xi_min)) / (2 * (xi_max - xi_min))) + 0.5;
+          0.5 * std::sin(M_PI * (element_jump_indicator - 0.5 * (xi_min + xi_max)) / (xi_max - xi_min)) + 0.5;
     // evaluate artificial viscosity form (8.183)
     if (smoothed_discrete_jump_indicator > 0) {
       const auto h = element().geometry().volume();
@@ -829,10 +829,14 @@ public:
         const auto quadrature_weight = quadrature_point.weight();
         const auto source_jacobian = u_->jacobian(point_in_reference_element, param);
         basis.jacobians(point_in_reference_element, basis_jacobians_, param);
-        // compute beta_h
-        for (size_t ii = 0; ii < basis.size(param); ++ii)
+        // compute beta_h, the viscous form acts on all m components (Frobenius product of the jacobians)
+        for (size_t ii = 0; ii < basis.size(param); ++ii) {
+          double grad_u_times_grad_basis = 0.;
+          for (size_t rr = 0; rr < m; ++rr)
+            grad_u_times_grad_basis += source_jacobian[rr] * basis_jacobians_[ii][rr];
           local_dofs_[ii] += integration_factor * quadrature_weight * nu_1_ * std::pow(h, alpha_1_)
-                             * smoothed_discrete_jump_indicator * (source_jacobian[0] * basis_jacobians_[ii][0]);
+                             * smoothed_discrete_jump_indicator * grad_u_times_grad_basis;
+        }
       }
     }
     // apply local mass matrix, if required (not optimal, uses a temporary)

--- a/dune/gdt/test/burgers/burgers__1d__explicit__dg_p1.mini
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dg_p1.mini
@@ -4,13 +4,12 @@ __name = Burgers1dExplicitDgP1Test
 visualization_steps                      = 0
 num_refinements                          = 1
 num_additional_refinements_for_reference = 1
-use_fixed_dt                             = 0.010413909912109373
 
 [Burgers1dExplicitDgP1Test.periodic_boundaries__numerical_engquist_osher_flux.results]
 zero_tolerance                  = 1e-15
 target.h                        = [6.25e-02 3.12e-02]
-norm.L_infty_L_2                = [5.88e-02 4.21e-02]
+norm.L_infty_L_2                = [8.60e-02 5.70e-02]
 quantity.rel_mass_conserv_error = [0 0]
-quantity.num_timesteps          = [9.90e+01 9.90e+01]
-quantity.CFL                    = [2.35e-01 5.09e-01]
+quantity.num_timesteps          = [4.90e+01 9.70e+01]
+quantity.CFL                    = [4.90e-01 5.21e-01]
 

--- a/dune/gdt/test/burgers/burgers__1d__explicit__dg_p2.mini
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dg_p2.mini
@@ -4,13 +4,12 @@ __name = Burgers1dExplicitDgP2Test
 visualization_steps                      = 0
 num_refinements                          = 1
 num_additional_refinements_for_reference = 1
-use_fixed_dt                             = 0.003975344848632812
 
 [Burgers1dExplicitDgP2Test.periodic_boundaries__numerical_engquist_osher_flux.results]
 zero_tolerance                  = 1e-15
 target.h                        = [6.25e-02 3.12e-02]
-norm.L_infty_L_2                = [5.56e-02 4.37e-02]
+norm.L_infty_L_2                = [8.79e-02 6.13e-02]
 quantity.rel_mass_conserv_error = [0 0]
-quantity.num_timesteps          = [2.57e+02 2.57e+02]
-quantity.CFL                    = [9.90e-02 1.98e-01]
+quantity.num_timesteps          = [1.39e+02 2.75e+02]
+quantity.CFL                    = [1.85e-01 1.84e-01]
 

--- a/dune/gdt/test/burgers/burgers__1d__explicit__dg_p3.mini
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dg_p3.mini
@@ -4,13 +4,12 @@ __name = Burgers1dExplicitDgP3Test
 visualization_steps                      = 0
 num_refinements                          = 1
 num_additional_refinements_for_reference = 1
-use_fixed_dt                             = 0.0016714981079101561
 
 [Burgers1dExplicitDgP3Test.periodic_boundaries__numerical_engquist_osher_flux.results]
 zero_tolerance                  = 1e-13
 target.h                        = [6.25e-02 3.12e-02]
-norm.L_infty_L_2                = [5.14e-02 4.13e-02]
+norm.L_infty_L_2                = [7.28e-02 6.00e-02]
 quantity.rel_mass_conserv_error = [0 0]
-quantity.num_timesteps          = [6.07e+02 6.07e+02]
-quantity.CFL                    = [4.17e-02 8.32e-02]
+quantity.num_timesteps          = [3.26e+02 6.61e+02]
+quantity.CFL                    = [7.79e-02 7.63e-02]
 

--- a/dune/gdt/test/misc/advection_dg_artificial_viscosity.cc
+++ b/dune/gdt/test/misc/advection_dg_artificial_viscosity.cc
@@ -1,0 +1,55 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <cmath>
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/la/container/istl.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/interpolations/default.hh>
+#include <dune/gdt/local/operators/advection-dg.hh>
+#include <dune/gdt/spaces/l2/discontinuous-lagrange.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using V = XT::LA::IstlDenseVector<double>;
+
+
+/// The artificial viscosity shock capturing has to vanish for a continuous solution without jumps. The jump
+/// indicator normalization used to be applied within the intersection loop, which on elements touching the domain
+/// boundary in 2d divided by a (partially) zero accumulated boundary measure (0/0 = NaN), switching the viscosity
+/// fully on even for smooth data (and making the indicator dependent on the intersection iteration order).
+GTEST_TEST(AdvectionDgArtificialViscosityShockCapturing, vanishes_for_continuous_solutions)
+{
+  auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 4u);
+  auto grid_view = grid_provider.leaf_view();
+  const auto space = make_discontinuous_lagrange_space(grid_view, /*order=*/1);
+
+  // u(x) = x_0 is contained in the DG space and continuous, so there are no jumps and no viscosity may be added
+  const auto u = default_interpolation<V>(1, [](const auto& xx, const auto& /*mu*/) { return xx[0]; }, space);
+
+  LocalAdvectionDgArtificialViscosityShockCapturingOperator<V, GV> artificial_viscosity_operator(u, grid_view);
+  DiscreteFunction<V, GV> range(space);
+  auto local_range = range.local_discrete_function();
+  for (auto&& element : elements(grid_view)) {
+    artificial_viscosity_operator.bind(element);
+    local_range->bind(element);
+    artificial_viscosity_operator.apply(*local_range);
+  }
+
+  for (size_t ii = 0; ii < space.mapper().size(); ++ii) {
+    EXPECT_TRUE(std::isfinite(range.dofs().vector()[ii])) << "ii = " << ii;
+    EXPECT_NEAR(range.dofs().vector()[ii], 0., 1e-12) << "ii = " << ii;
+  }
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem). This PR fixes three defects of the same feature, `LocalAdvectionDgArtificialViscosityShockCapturingOperator` ([DF2015, Sec. 8.5]) in `dune/gdt/local/operators/advection-dg.hh` — they share the affected operator and the affected test baselines, so they are bundled.

## Problem 1 — broken jump-indicator normalization (high)

The normalization sat **inside** the `for (intersection : ...)` loop, so earlier faces' contributions were divided once per remaining intersection (the indicator depended on the intersection iteration order), and in `d > 1` the accumulated boundary measure is still `0` while the first visited intersections lie on the domain boundary — `0/0 = NaN`, which compares `false` against both thresholds and switches the smoothed indicator to `1`: **full artificial viscosity on every boundary element, even for perfectly smooth data**.

On top of the loop placement, the normalization *quantity* itself (non-domain-boundary measure × element volume, with an ad-hoc `1` in 1d) does not match the reference: **(8.176) in [DF2015] divides the accumulated squared jumps by `h_K |K|^(3/4)`**. The indicator is now computed exactly as in (8.176), once, after the loop. This matters beyond cosmetics: fixing only the loop placement while keeping the boundary-measure normalization makes the 1d indicator scale like `1/h` instead of (8.176)'s `1/h^(7/4)`; with the hard-coded thresholds 0.5/1.5 from (8.180) the Burgers shock then gets no viscosity at all and the DG p2/p3 EOC runs blow up (verified on this branch's CI: level-1 errors of 1e+119). The old in-loop division accidentally landed near the published `h^(-7/4...-2)` scale in 1d, which is why the existing 1d tests appeared healthy.

## Problem 2 — discontinuous "smoothed" indicator (medium)

The ramp was implemented as `0.5·sin(π(ξ − (ξmax−ξmin))/(2(ξmax−ξmin))) + 0.5`, which evaluates to **0.146 at ξ_min and 0.854 at ξ_max** instead of 0 and 1. The correct ramp from (8.180) — `0.5·sin(π(ξ − 1)) + 0.5` for ξ_min = 0.5, ξ_max = 1.5, written here as `0.5·sin(π(ξ − ξ_mid)/(ξmax−ξmin)) + 0.5` — is 0 at ξ_min, 1 at ξ_max, and continuous.

## Problem 3 — viscosity only on solution component 0 (medium, systems only)

The viscous form (8.183) used `source_jacobian[0] * basis_jacobians_[ii][0]`, i.e. only row 0 of the m×d jacobians: for systems (e.g. Euler, m = d+2) only the density equation received viscosity. The form now sums over all m components (Frobenius product). `index_` legitimately selects only the *indicator* component; the viscous form itself must act on all components.

## The test

`dune/gdt/test/misc/advection_dg_artificial_viscosity.cc` interpolates the continuous function u(x) = x₀ into a 2d DG-P1 space (zero inter-element jumps) and applies the artificial-viscosity operator directly on every element: its contributions must vanish and be finite. Before the fix, the NaN indicator on boundary elements switches the viscosity fully on and produces nonzero output.

The test drives the *local* operator directly rather than going through `AdvectionDgOperator`, because the latter's `LocalAdvectionDgVolumeOperator` does not even compile for `d > 1` (its volume term `flux_value * basis_jacobians_[ii]` has no matching `operator*`; the DG operators were only ever instantiated in 1d). That latent issue is out of scope here.

## Note on baselines

The 1d Burgers DG EOC tests (`burgers__1d__explicit__dg_p1/p2/p3`) execute this operator. Their `.mini` files pinned both the expected values **and** a `setup.use_fixed_dt` time step length that had been bisected against the *buggy* (over-viscous) indicator — with the corrected (8.176) scale that frozen dt is no longer stable for p2/p3 (the harness's stability bisection is part of what the baselines encode). This PR therefore

* removes the `use_fixed_dt` pins so the harness re-bisects a stable dt per refinement level (`estimate_fixed_explicit_dt_to_T_end`), and
* re-baselines `norm.L_infty_L_2`, `quantity.num_timesteps` and `quantity.CFL` from this branch's CI run of the corrected operator (all three studies converge again; e.g. p1: 8.60e-02 → 5.70e-02 under refinement).

Trade-off: the re-bisection adds ~5–7 min per DG study to the test job. The bisected dt (`quantity.dt`) is recorded but neither printed nor compared, so it cannot be recovered from CI logs to re-pin; if the runtime matters, a maintainer can run the studies locally once and restore `use_fixed_dt` pins from the recorded value.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi


## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious activation of artificial-viscosity shock-capturing for continuous solutions.
  * Stabilized shock-jump normalization to avoid NaN outcomes and iteration-order sensitivity.

* **Tests**
  * Added a regression test ensuring the shock-capturing term remains numerically zero for continuous fields.

* **Chores**
  * Removed fixed time-step overrides from several benchmark/test configurations and re-baselined the affected 1d Burgers DG EOC studies against the corrected operator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious activation of artificial-viscosity shock-capturing for continuous solutions.
  * Stabilized shock-jump normalization to avoid NaNs and iteration-order sensitivity.
  * Corrected centering of the smoothed jump indicator and generalized viscous weighting to handle all components.

* **Tests**
  * Added a regression test verifying the shock-capturing term vanishes for continuous fields.

* **Chores**
  * Removed fixed time-step overrides from several benchmark/test configurations and updated expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->