### PR TITLE
Fix hyperbolic dt estimate for constant (zero/negative) state components

### DIFF
--- a/dune/gdt/test/misc/estimate_dt_degenerate_data_range.cc
+++ b/dune/gdt/test/misc/estimate_dt_degenerate_data_range.cc
@@ -1,0 +1,69 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/xt/functions/base/function-as-grid-function.hh>
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/gdt/tools/hyperbolic.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using E = XT::Grid::extract_entity_t<GV>;
+
+
+/// The dt estimate has to cope with state components of constant value (e.g. the initial momentum of an Euler problem
+/// at rest is constant 0): the bounding box of the state range is degenerate then and used to be "fixed" by an additive
+/// perturbation of 1e-6 * minimum, which stays degenerate for a constant-zero and becomes inverted (maximum < minimum)
+/// for a constant-negative component, so that the estimate crashed instead of returning a dt.
+struct EstimateDtForDegenerateDataRangeTest : public ::testing::Test
+{
+  using StateFunctionType = XT::Functions::GenericFunction<1, 1, 1>;
+  using StateWrapperType = XT::Functions::FunctionAsGridFunctionWrapper<E, 1, 1, double>;
+
+  double estimate_dt_for_constant_state(const double value)
+  {
+    auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 4u);
+    auto grid_view = grid_provider.leaf_view();
+    const StateFunctionType constant_state(
+        0, [=](const auto& /*x*/, const auto& /*param*/) { return value; }, "constant_state");
+    const StateWrapperType state(constant_state);
+    // linear flux f(u) = u, i.e. |f'| = 1, so the expected dt is 1 / (perimeter/volume * max|f'|) = h/2
+    const XT::Functions::GenericFunction<1, 1, 1> flux(
+        1,
+        [](const auto& u, const auto& /*param*/) { return u; },
+        "linear",
+        {},
+        [](const auto& u, const auto& /*param*/) { return decltype(u)(1.); });
+    return estimate_dt_for_hyperbolic_system(grid_view, state, flux);
+  }
+}; // struct EstimateDtForDegenerateDataRangeTest
+
+
+TEST_F(EstimateDtForDegenerateDataRangeTest, constant_positive_state)
+{
+  EXPECT_NEAR(estimate_dt_for_constant_state(1.), 0.125, 1e-10);
+}
+
+TEST_F(EstimateDtForDegenerateDataRangeTest, constant_zero_state)
+{
+  // used to construct a YaspGrid with an empty bounding box [0, 0]
+  EXPECT_NEAR(estimate_dt_for_constant_state(0.), 0.125, 1e-10);
+}
+
+TEST_F(EstimateDtForDegenerateDataRangeTest, constant_negative_state)
+{
+  // used to construct a YaspGrid with an inverted bounding box [-1, -1.000001]
+  EXPECT_NEAR(estimate_dt_for_constant_state(-1.), 0.125, 1e-10);
+}

--- a/dune/gdt/tools/hyperbolic.hh
+++ b/dune/gdt/tools/hyperbolic.hh
@@ -15,6 +15,9 @@
 #ifndef DUNE_GDT_TOOLS_HYPERBOLIC_HH
 #define DUNE_GDT_TOOLS_HYPERBOLIC_HH
 
+#include <algorithm>
+#include <cmath>
+
 #include <dune/geometry/quadraturerules.hh>
 
 #include <dune/grid/common/gridview.hh>
@@ -64,10 +67,12 @@ double estimate_dt_for_hyperbolic_system(
       }
     }
   }
-  // ensure distinct minima/maxima (otherwise the grid creation below will fail)
+  // ensure distinct minima/maxima (otherwise the grid creation below will fail), in particular for components with
+  // constant zero or negative values (an additive perturbation of 1e-6 * data_minimum would stay zero for
+  // data_minimum == 0 and would yield an inverted interval for data_minimum < 0)
   for (size_t ii = 0; ii < m; ++ii)
     if (!(data_minimum[ii] < data_maximum[ii]))
-      data_maximum[ii] = data_minimum[ii] + 1e-6 * data_minimum[ii];
+      data_maximum[ii] = data_minimum[ii] + std::max(1e-6 * std::abs(data_minimum[ii]), 1e-6);
   // estimate flux derivative range
   R max_flux_derivative = std::numeric_limits<R>::min();
   const auto flux_range_grid = XT::Grid::make_cube_grid<YaspGrid<m, EquidistantOffsetCoordinates<double, m>>>(


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

`estimate_dt_for_hyperbolic_system` (`dune/gdt/tools/hyperbolic.hh`, [Cockburn–Coquel–LeFloch]-type bound) samples the flux derivative over the bounding box of the state range, realized as a `YaspGrid` — which needs strictly increasing bounds per component. Degenerate components were "fixed" with

```cpp
data_maximum[ii] = data_minimum[ii] + 1e-6 * data_minimum[ii];
```

which is broken in exactly the cases it was written for:

- **constant zero component**: the perturbation is `0`, the interval stays empty — the grid construction the comment warns about still fails. This is an entirely common case, e.g. the initial momentum ρv ≡ 0 of an Euler problem at rest (cf. the inviscid-compressible-flow test data).
- **constant negative component** (e.g. min = max = −1): the new maximum is −1.000001 < minimum — an *inverted* interval.

## The fix

The perturbation is now `std::max(1e-6 · |minimum|, 1e-6)`, positive in all cases.

## The test

`dune/gdt/test/misc/estimate_dt_degenerate_data_range.cc` runs the estimate for constant positive (sanity baseline), constant zero and constant negative states with a linear flux and checks the resulting dt against the analytic value `1/(perimeter/volume · max|f'|) = h/2`. The zero and negative cases fail (crash) with the previous code.

Note: this PR touches lines adjacent to (but disjoint from) #189, which fixes an independent problem in the same function; both apply cleanly onto `main`.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestep calculation for hyperbolic systems with constant state values, preventing crashes when encountering zero or negative constant values. Improved numerical stability through refined perturbation logic.

* **Tests**
  * Added regression test to validate timestep calculation with constant state components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->