### PR TITLE
Fix wave speed underestimation in the hyperbolic dt estimate

### DIFF
--- a/dune/gdt/test/burgers/burgers__1d__explicit__dg_p1.mini
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dg_p1.mini
@@ -12,5 +12,5 @@ target.h                        = [6.25e-02 3.12e-02]
 norm.L_infty_L_2                = [5.88e-02 4.21e-02]
 quantity.rel_mass_conserv_error = [0 0]
 quantity.num_timesteps          = [9.90e+01 9.90e+01]
-quantity.CFL                    = [2.35e-01 5.09e-01]
+quantity.CFL                    = [2.98e-01 6.45e-01]
 

--- a/dune/gdt/test/burgers/burgers__1d__explicit__dg_p2.mini
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dg_p2.mini
@@ -12,5 +12,5 @@ target.h                        = [6.25e-02 3.12e-02]
 norm.L_infty_L_2                = [5.56e-02 4.37e-02]
 quantity.rel_mass_conserv_error = [0 0]
 quantity.num_timesteps          = [2.57e+02 2.57e+02]
-quantity.CFL                    = [9.90e-02 1.98e-01]
+quantity.CFL                    = [1.26e-01 2.51e-01]
 

--- a/dune/gdt/test/burgers/burgers__1d__explicit__dg_p3.mini
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dg_p3.mini
@@ -12,5 +12,5 @@ target.h                        = [6.25e-02 3.12e-02]
 norm.L_infty_L_2                = [5.14e-02 4.13e-02]
 quantity.rel_mass_conserv_error = [0 0]
 quantity.num_timesteps          = [6.07e+02 6.07e+02]
-quantity.CFL                    = [4.17e-02 8.32e-02]
+quantity.CFL                    = [5.29e-02 1.05e-01]
 

--- a/dune/gdt/test/burgers/burgers__1d__explicit__fv.mini
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__fv.mini
@@ -12,7 +12,7 @@ target.h                        = [6.25e-02 3.12e-02]
 norm.L_infty_L_2                = [1.31e-01 8.92e-02]
 quantity.rel_mass_conserv_error = [0 0]
 quantity.num_timesteps          = [1.07e+02 1.07e+02]
-quantity.CFL                    = [2.31e-01 4.80e-01]
+quantity.CFL                    = [2.93e-01 6.09e-01]
 
 
 [Burgers1dExplicitFvTest.periodic_boundaries__numerical_lax_friedrichs_flux.setup]
@@ -27,7 +27,7 @@ target.h                        = [6.25e-02 3.12e-02]
 norm.L_infty_L_2                = [1.31e-01 8.77e-02]
 quantity.rel_mass_conserv_error = [0 0]
 quantity.num_timesteps          = [1.12e+02 1.12e+02]
-quantity.CFL                    = [2.20e-01 4.56e-01]
+quantity.CFL                    = [2.78e-01 5.78e-01]
 
 
 [Burgers1dExplicitFvTest.periodic_boundaries__numerical_engquist_osher_flux.setup]
@@ -42,5 +42,5 @@ target.h                        = [6.25e-02 3.12e-02]
 norm.L_infty_L_2                = [1.31e-01 8.92e-02]
 quantity.rel_mass_conserv_error = [0 0]
 quantity.num_timesteps          = [1.07e+02 1.07e+02]
-quantity.CFL                    = [2.31e-01 4.80e-01]
+quantity.CFL                    = [2.93e-01 6.09e-01]
 

--- a/dune/gdt/test/misc/estimate_dt_wave_speed_sampling.cc
+++ b/dune/gdt/test/misc/estimate_dt_wave_speed_sampling.cc
@@ -1,0 +1,72 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <limits>
+
+#include <dune/xt/functions/base/function-as-grid-function.hh>
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/gdt/tools/hyperbolic.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using E = XT::Grid::extract_entity_t<GV>;
+
+using StateWrapperType = XT::Functions::FunctionAsGridFunctionWrapper<E, 1, 1, double>;
+
+
+/// For a convex flux the maximal wave speed over the state range [u_min, u_max] is attained at the boundary of the
+/// range, but the estimate used to sample the flux derivative only at (interior) Gauss quadrature points, so max|f'|
+/// was systematically underestimated and the resulting dt was no upper bound for the CFL-stable time step length.
+GTEST_TEST(EstimateDtForHyperbolicSystem, samples_wave_speed_at_data_range_boundary)
+{
+  auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 4u);
+  auto grid_view = grid_provider.leaf_view();
+  // piecewise constant state attaining the values 0 and 1 at element quadrature points, i.e. the estimated state
+  // range is exactly [0, 1] (a continuous state like u(x) = x would only be sampled at interior quadrature points
+  // of the elements, shrinking the estimated range - a separate approximation that is not under test here)
+  const XT::Functions::GenericFunction<1, 1, 1> step_state(
+      0, [](const auto& x, const auto& /*param*/) { return x[0] < 0.5 ? 0. : 1.; }, "step_state");
+  const StateWrapperType state(step_state);
+  // Burgers flux: f(u) = u^2/2, f'(u) = u, so max|f'| = 1 on [0, 1] and the expected dt is
+  // 1 / (perimeter/volume * max|f'|) = 1 / (2/h * 1) = h/2 = 0.125
+  // (the two-point Gauss rule on [0, 1] samples u = 0.211 and u = 0.789 only, leading to dt = 0.158 before the fix)
+  const XT::Functions::GenericFunction<1, 1, 1> burgers_flux(
+      2,
+      [](const auto& u, const auto& /*param*/) { return 0.5 * u * u; },
+      "burgers",
+      {},
+      [](const auto& u, const auto& /*param*/) { return u; });
+  const auto dt = estimate_dt_for_hyperbolic_system(grid_view, state, burgers_flux);
+  EXPECT_NEAR(dt, 0.125, 1e-10);
+}
+
+GTEST_TEST(EstimateDtForHyperbolicSystem, returns_max_for_constant_flux)
+{
+  auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 4u);
+  auto grid_view = grid_provider.leaf_view();
+  const XT::Functions::GenericFunction<1, 1, 1> some_state(
+      1, [](const auto& x, const auto& /*param*/) { return x; }, "linear_state");
+  const StateWrapperType state(some_state);
+  // a constant flux does not transport anything, so there is no CFL restriction at all
+  const XT::Functions::GenericFunction<1, 1, 1> constant_flux(
+      0,
+      [](const auto& /*u*/, const auto& /*param*/) { return 1.; },
+      "constant",
+      {},
+      [](const auto& u, const auto& /*param*/) { return decltype(u)(0.); });
+  const auto dt = estimate_dt_for_hyperbolic_system(grid_view, state, constant_flux);
+  EXPECT_EQ(dt, std::numeric_limits<double>::max());
+}

--- a/dune/gdt/tools/hyperbolic.hh
+++ b/dune/gdt/tools/hyperbolic.hh
@@ -69,15 +69,25 @@ double estimate_dt_for_hyperbolic_system(
     if (!(data_minimum[ii] < data_maximum[ii]))
       data_maximum[ii] = data_minimum[ii] + 1e-6 * data_minimum[ii];
   // estimate flux derivative range
-  R max_flux_derivative = std::numeric_limits<R>::min();
+  R max_flux_derivative = 0.;
   const auto flux_range_grid = XT::Grid::make_cube_grid<YaspGrid<m, EquidistantOffsetCoordinates<double, m>>>(
       data_minimum, data_maximum, XT::Common::FieldVector<unsigned int, m>(1));
   const auto flux_range = *flux_range_grid.leaf_view().template begin<0>();
-  for (auto&& quadrature_point : QuadratureRules<R, m>::rule(flux_range.type(), flux.order())) {
-    const auto df = flux.jacobian(flux_range.geometry().global(quadrature_point.position()));
+  auto update_max_flux_derivative = [&](const auto& state) {
+    const auto df = flux.jacobian(state);
     for (size_t ss = 0; ss < d; ++ss)
       max_flux_derivative = std::max(max_flux_derivative, df[ss].infinity_norm());
-  }
+  };
+  for (auto&& quadrature_point : QuadratureRules<R, m>::rule(flux_range.type(), flux.order()))
+    update_max_flux_derivative(flux_range.geometry().global(quadrature_point.position()));
+  // Gauss points lie in the interior of the state range, but for the common case of a flux whose derivative is
+  // monotone in each component (e.g. any convex or concave flux) the maximum is attained on the boundary of the
+  // range, so additionally sample the corners (otherwise max|f'| is systematically underestimated and the returned
+  // dt is no upper bound, e.g. 27% too large for Burgers' flux on the data range [0, 1])
+  for (int ii = 0; ii < flux_range.geometry().corners(); ++ii)
+    update_max_flux_derivative(flux_range.geometry().corner(ii));
+  if (max_flux_derivative == 0.) // constant flux, no transport at all
+    return std::numeric_limits<double>::max();
   D perimeter_over_volume = std::numeric_limits<D>::min();
   for (auto&& element : elements(grid_view)) {
     D perimeter = 0;


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

`estimate_dt_for_hyperbolic_system` (`dune/gdt/tools/hyperbolic.hh`) estimates `max|f'|` over the bounding box of the state range by sampling the flux jacobian at **Gauss quadrature points** of that box. Gauss points are interior points, but for the common case of a flux whose derivative is monotone in each component (any convex or concave flux) the maximum of |f'| is attained on the **boundary** of the range. The wave speed was therefore systematically underestimated and the returned dt is not an upper bound for the CFL-stable step:

- Burgers (`f = u²/2`, `f' = u`) with data range `[0, 1]`: the flux order is 2, so the 2-point Gauss rule samples `u = 0.211` and `u = 0.789` only → `max|f'| = 0.789` instead of `1` → **dt 27% too large**.

In practice this was masked by the factor-2 cushion of the 1d Cockburn–Coquel–LeFloch bound, but the estimate is mathematically not the bound it claims to implement.

Additionally, the accumulator was initialized with `std::numeric_limits<R>::min()` — the smallest *positive* double, not the lowest value — which silently masked the constant-flux case behind an absurd `dt ≈ 4e307` instead of handling it.

## The fix

- The corners of the state-range box are sampled in addition to the quadrature points (for componentwise-monotone derivatives this makes the estimate sharp; for general fluxes it strictly improves the interior-only sampling).
- The accumulator starts at `0`, and a constant flux (no transport, no CFL restriction) now explicitly returns `std::numeric_limits<double>::max()`.

## The test

`dune/gdt/test/misc/estimate_dt_wave_speed_sampling.cc`:
- a piecewise-constant state attaining 0 and 1 (estimated range exactly `[0, 1]`) with the Burgers flux must give exactly `dt = 1/(2/h · 1) = h/2 = 0.125` (the old code returns 0.158);
- a constant flux returns `numeric_limits<double>::max()`.

## Re-baselined diagnostics

The Burgers EOC studies record the estimated dt as the diagnostic quantity `CFL` in their `.mini` baselines. The sharper wave-speed estimate shifts exactly that column (all error/EOC/mass-conservation values are unchanged, since the tests step with `dt = h`, not with the estimate), so the `quantity.CFL` entries of `burgers__1d__explicit__{fv,dg_p1,dg_p2,dg_p3}.mini` are updated to the values produced by the fixed estimate (e.g. FV: `2.31e-01 → 2.93e-01`, the expected ≈27% shift).

Note: this PR touches lines adjacent to (but disjoint from) #188, which fixes an independent problem in the same function; both apply cleanly onto `main`.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new unit tests verifying the CFL time-step estimator against analytically known scenarios.
  * Updated recorded/expected CFL values in several Burgers test result files to reflect revised estimates.

* **Bug Fixes**
  * Improved CFL time-step estimation by expanding sampling of flux behavior and handling constant-flux cases to avoid underestimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->