### PR TITLE
Fix infinite recursion in the superbee slope limiter

### DIFF
--- a/dune/gdt/operators/reconstruction/slopes.hh
+++ b/dune/gdt/operators/reconstruction/slopes.hh
@@ -306,8 +306,16 @@ public:
   {
     VectorType ret(0.);
     for (size_t ii = 0; ii < first_slope.size(); ++ii)
-      ret[ii] = superbee(first_slope[ii], second_slope[ii]);
+      ret[ii] = superbee_scalar(first_slope[ii], second_slope[ii]);
     return ret;
+  }
+
+  // superbee(a, b) = maxmod(minmod(2a, b), minmod(a, 2b)), see e.g. LeVeque, "Finite Volume Methods for Hyperbolic
+  // Problems", 2002, Section 6.10
+  template <class FieldType>
+  static FieldType superbee_scalar(const FieldType a, const FieldType b)
+  {
+    return XT::Common::maxmod(XT::Common::minmod(2. * a, b), XT::Common::minmod(a, 2. * b));
   }
 }; // class SuperbeeSlope
 

--- a/dune/gdt/test/misc/reconstruction_slopes.cc
+++ b/dune/gdt/test/misc/reconstruction_slopes.cc
@@ -1,0 +1,103 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+
+#include <dune/gdt/operators/reconstruction/slopes.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+
+/// Identity transformation, allows to test the limiters on plain (non-characteristic) slopes.
+template <size_t r>
+struct IdentityEigenVectorWrapper
+{
+  using VectorType = FieldVector<double, r>;
+  using MatrixType = FieldMatrix<double, r, r>;
+
+  void apply_eigenvectors(const size_t /*dd*/, const VectorType& u, VectorType& ret) const
+  {
+    ret = u;
+  }
+
+  void apply_inverse_eigenvectors(const size_t /*dd*/, const VectorType& u, VectorType& ret) const
+  {
+    ret = u;
+  }
+};
+
+using E = int; // <- only passed through, no entity required for these slopes
+using Wrapper1 = IdentityEigenVectorWrapper<1>;
+using Wrapper3 = IdentityEigenVectorWrapper<3>;
+using V1 = typename Wrapper1::VectorType;
+using V3 = typename Wrapper3::VectorType;
+
+template <class SlopeType, int r>
+FieldVector<double, r> limited_slope(const FieldVector<double, r>& u_left,
+                                     const FieldVector<double, r>& u_entity,
+                                     const FieldVector<double, r>& u_right)
+{
+  const SlopeType slope;
+  const IdentityEigenVectorWrapper<r> eigenvectors;
+  const FieldVector<FieldVector<double, r>, 3> stencil{u_left, u_entity, u_right};
+  return slope.get(E(0), stencil, eigenvectors, 0);
+}
+
+
+GTEST_TEST(MinmodSlopeTest, limits_correctly)
+{
+  using SlopeType = MinmodSlope<E, Wrapper1>;
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(0.), V1(1.), V1(1.5))[0], 0.5);
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(1.5), V1(1.), V1(0.))[0], -0.5);
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(0.), V1(1.), V1(0.))[0], 0.); // extremum
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(1.), V1(1.), V1(5.))[0], 0.);
+}
+
+GTEST_TEST(McSlopeTest, limits_correctly)
+{
+  using SlopeType = McSlope<E, Wrapper1>;
+  // minmod(2 (u - u_l), 2 (u_r - u), (u_r - u_l)/2)
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(0.), V1(1.), V1(4.))[0], 2.);
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(0.), V1(1.), V1(1.25))[0], 0.5);
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(0.), V1(1.), V1(0.))[0], 0.); // extremum
+}
+
+GTEST_TEST(SuperbeeSlopeTest, scalar_superbee_limits_correctly)
+{
+  // superbee(a, b) = maxmod(minmod(2a, b), minmod(a, 2b)); used to die from infinite recursion for r = 1 (and did
+  // not compile for r > 1)
+  using SlopeType = SuperbeeSlope<E, Wrapper1>;
+  EXPECT_DOUBLE_EQ(SlopeType::superbee_scalar(1., 0.5), 1.);
+  EXPECT_DOUBLE_EQ(SlopeType::superbee_scalar(0.5, 1.), 1.);
+  EXPECT_DOUBLE_EQ(SlopeType::superbee_scalar(-1., -0.25), -0.5);
+  EXPECT_DOUBLE_EQ(SlopeType::superbee_scalar(1., -1.), 0.);
+  EXPECT_DOUBLE_EQ(SlopeType::superbee_scalar(0., 1.), 0.);
+  EXPECT_DOUBLE_EQ(SlopeType::superbee_scalar(1., 1.), 1.);
+  EXPECT_DOUBLE_EQ(SlopeType::superbee_scalar(1., 4.), 2.);
+}
+
+GTEST_TEST(SuperbeeSlopeTest, limits_correctly)
+{
+  using SlopeType = SuperbeeSlope<E, Wrapper1>;
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(0.), V1(1.), V1(1.5))[0], 1.);
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(1.5), V1(1.), V1(0.))[0], -1.);
+  EXPECT_DOUBLE_EQ(limited_slope<SlopeType>(V1(0.), V1(1.), V1(0.))[0], 0.); // extremum
+}
+
+GTEST_TEST(SuperbeeSlopeTest, works_for_systems)
+{
+  // r > 1 used to fail to compile (no scalar superbee overload existed)
+  using SlopeType = SuperbeeSlope<E, Wrapper3>;
+  const auto slope = limited_slope<SlopeType, 3>({0., 1.5, 0.}, {1., 1., 1.}, {1.5, 0., 1.});
+  EXPECT_DOUBLE_EQ(slope[0], 1.);
+  EXPECT_DOUBLE_EQ(slope[1], -1.);
+  EXPECT_DOUBLE_EQ(slope[2], 0.);
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

`SuperbeeSlope::superbee(VectorType, VectorType)` in `dune/gdt/operators/reconstruction/slopes.hh` limited each component by calling `superbee` on the scalar entries:

```cpp
for (size_t ii = 0; ii < first_slope.size(); ++ii)
  ret[ii] = superbee(first_slope[ii], second_slope[ii]);
```

but **no scalar overload exists anywhere** (`dune/xt/common/math.hh` only provides `minmod` and `maxmod`, and unqualified lookup of the member name suppresses ADL anyway). Consequences:

- for systems (r > 1): hard compile error when instantiated;
- for scalar problems (r = 1): `FieldVector<double, 1>` converts implicitly to and from `double`, so the vector overload calls **itself** — infinite recursion, stack overflow on first use.

The limiter has been unusable either way; since the entire reconstruction module currently has zero test coverage (nothing in `dune/gdt/test` instantiates any slope class), the breakage was invisible.

## The fix

Add the scalar limiter

```
superbee(a, b) = maxmod(minmod(2a, b), minmod(a, 2b))
```

(LeVeque, *Finite Volume Methods for Hyperbolic Problems*, Sec. 6.10) and call it from the componentwise loop.

## The test

`dune/gdt/test/misc/reconstruction_slopes.cc` is the first test of the slope limiters at all. It checks minmod, MC and superbee against hand-computed stencils through the public `get()` interface (with an identity eigenvector wrapper), including extrema where TVD limiters must return a zero slope, for r = 1 (used to crash) and r = 3 (used to not compile), plus the scalar superbee values themselves (e.g. `superbee(1, 0.5) = 1`, `superbee(1, 4) = 2`, `superbee(1, −1) = 0`).

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved ambiguity in superbee slope limiter computation for accurate slope limiting.

* **Tests**
  * Added comprehensive tests validating slope limiters (Minmod, Mc, Superbee) for both scalar and vector-valued slopes with edge case coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->