### PR TITLE
Fix DummyEigenVectorWrapper failing to compile when instantiated

### DIFF
--- a/dune/gdt/operators/reconstruction/internal.hh
+++ b/dune/gdt/operators/reconstruction/internal.hh
@@ -152,14 +152,14 @@ public:
   void compute_eigenvectors(const E& /*entity*/,
                             const DomainType& /*x_local*/,
                             const VectorType& /*u*/,
-                            const XT::Common::Parameter& /*param*/) const override final
+                            const XT::Common::Parameter& /*param*/) override final
   {
   }
 
   void compute_eigenvectors_impl(const E& /*entity*/,
                                  const DomainType& /*x_local*/,
                                  const VectorType& /*u*/,
-                                 const XT::Common::Parameter& /*param*/) const override final
+                                 const XT::Common::Parameter& /*param*/) override final
   {
   }
 
@@ -170,7 +170,7 @@ public:
   }
 
 private:
-  static const MatrixType zero_ = 0.;
+  static constexpr MatrixType zero_ = 0;
 };
 
 

--- a/dune/gdt/test/misc/reconstruction_dummy_eigenvector_wrapper.cc
+++ b/dune/gdt/test/misc/reconstruction_dummy_eigenvector_wrapper.cc
@@ -1,0 +1,50 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/xt/functions/base/function-as-flux-function.hh>
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/gdt/operators/reconstruction/internal.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using E = XT::Grid::extract_entity_t<GV>;
+
+// The wrapper used to fail to compile when instantiated: its compute_eigenvectors(_impl) overloads were
+// const-qualified (the base class methods are not), so the marked overrides did not override anything.
+GTEST_TEST(DummyEigenVectorWrapper, can_be_instantiated_and_applied)
+{
+  using FluxType = XT::Functions::StateFunctionAsFluxFunctionWrapper<E, 1, 1, 1, double>;
+  using VectorType = FieldVector<double, 1>;
+  const XT::Functions::GenericFunction<1, 1, 1> burgers_flux(
+      2,
+      [](const auto& u, const auto& /*param*/) { return 0.5 * u * u; },
+      "burgers",
+      {},
+      [](const auto& u, const auto& /*param*/) { return u; });
+  const FluxType flux(burgers_flux);
+
+  auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 2u);
+  const auto element = *grid_provider.leaf_view().template begin<0>();
+
+  internal::DummyEigenVectorWrapper<FluxType, VectorType> wrapper(flux, /*flux_is_affine=*/false);
+  wrapper.compute_eigenvectors(element, {0.5}, {1.}, {});
+  VectorType ret(0.);
+  wrapper.apply_eigenvectors(0, {2.}, ret);
+  EXPECT_DOUBLE_EQ(ret[0], 2.);
+  wrapper.apply_inverse_eigenvectors(0, {3.}, ret);
+  EXPECT_DOUBLE_EQ(ret[0], 3.);
+  EXPECT_THROW(wrapper.eigenvectors(0), Dune::NotImplemented);
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

`internal::DummyEigenVectorWrapper` (`dune/gdt/operators/reconstruction/internal.hh`) is the documented way to run the linear reconstruction in **ordinary** instead of characteristic coordinates. It cannot be instantiated:

- `compute_eigenvectors` and `compute_eigenvectors_impl` are **const-qualified** while the base class (`EigenvectorWrapperBase`) declares them non-const — the `override final` specifiers therefore do not override anything and instantiation is ill-formed (and without `override` the class would stay abstract, since the pure virtual `compute_eigenvectors_impl` would remain unimplemented);
- `static const MatrixType zero_ = 0.;` (with `MatrixType = int` here) is an invalid in-class initializer (floating literal, no out-of-class definition) while being ODR-used by `eigenvectors()` returning a reference to it.

Since nothing in the repository instantiates the class, the breakage was invisible — the feature was simply unusable.

## The fix

Drop the const qualifiers (matching the base signatures, keeping the empty `compute_eigenvectors` override that skips the work entirely) and make `zero_` a `constexpr` member (implicitly inline since C++17).

## The test

`dune/gdt/test/misc/reconstruction_dummy_eigenvector_wrapper.cc` instantiates the wrapper with a real flux function (which is the actual regression test — it does not compile before the fix) and exercises all methods: `compute_eigenvectors` (no-op), `apply_eigenvectors`/`apply_inverse_eigenvectors` (identity) and `eigenvectors()` (throws `NotImplemented`).

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method signature overrides in eigenvector wrapper to ensure proper virtual method resolution.

* **Tests**
  * Added unit test verifying eigenvector wrapper instantiation and core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->