### PR TITLE
Fix undefined behavior in TimeStepperInterface::solution_closest_to_time

### DIFF
--- a/dune/gdt/test/misc/timestepper_solution_closest_to_time.cc
+++ b/dune/gdt/test/misc/timestepper_solution_closest_to_time.cc
@@ -1,0 +1,71 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/la/container/common.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+#include <dune/gdt/tools/timestepper/interface.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using V = XT::LA::CommonDenseVector<double>;
+using DF = DiscreteFunction<V, GV>;
+
+
+struct DummyTimeStepper : public TimeStepperInterface<DF>
+{
+  DummyTimeStepper(DF& initial_values)
+    : TimeStepperInterface<DF>(0., initial_values)
+  {
+  }
+
+  double step(const double dt, const double /*max_dt*/) override final
+  {
+    current_time() += dt;
+    return dt;
+  }
+};
+
+
+/// solution_closest_to_time used to dereference the map's end() iterator for any query time at or beyond the last
+/// stored time point (e.g. the natural query t = t_end) and could never return the closest *earlier* time point
+/// (it compared lower_bound and upper_bound, which coincide for any t between two stored time points).
+GTEST_TEST(TimeStepperInterface, solution_closest_to_time_returns_the_closest_time_point)
+{
+  auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 4u);
+  auto grid_view = grid_provider.leaf_view();
+  const FiniteVolumeSpace<GV> space(grid_view);
+  DF initial_values(space);
+  DummyTimeStepper stepper(initial_values);
+
+  EXPECT_THROW(stepper.solution_closest_to_time(0.), Dune::InvalidStateException);
+
+  for (const double t : {0., 1., 2.}) {
+    DF u(space);
+    u.dofs().vector()[0] = t;
+    stepper.solution().emplace_hint(stepper.solution().end(), t, u.copy_as_discrete_function());
+  }
+
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(-1.).first, 0.);
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(0.).first, 0.);
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(0.4).first, 0.); // used to wrongly return 1.
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(0.6).first, 1.);
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(1.).first, 1.);
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(1.9).first, 2.);
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(2.).first, 2.); // used to dereference end()
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(5.).first, 2.); // used to dereference end()
+  // the returned discrete function belongs to the returned time point
+  EXPECT_DOUBLE_EQ(stepper.solution_closest_to_time(1.9).second->dofs().vector()[0], 2.);
+}

--- a/dune/gdt/tools/timestepper/interface.hh
+++ b/dune/gdt/tools/timestepper/interface.hh
@@ -17,6 +17,7 @@
 #define DUNE_GDT_TIMESTEPPER_INTERFACE_HH
 
 #include <cstdio>
+#include <iterator>
 #include <utility>
 
 #include <dune/xt/common/memory.hh>
@@ -354,10 +355,16 @@ public:
    */
   virtual const typename DiscreteSolutionType::value_type& solution_closest_to_time(const RangeFieldType t) const
   {
-    if (solution().empty())
+    const auto& sol = solution();
+    if (sol.empty())
       DUNE_THROW(Dune::InvalidStateException, "Solution is empty!");
-    return solution().upper_bound(t)->first - t > t - solution().lower_bound(t)->first ? *solution().lower_bound(t)
-                                                                                       : *solution().upper_bound(t);
+    const auto upper = sol.lower_bound(t); // first stored time point >= t
+    if (upper == sol.end()) // t is larger than all stored time points
+      return *std::prev(upper);
+    if (upper == sol.begin()) // t is smaller than (or equal to) the first stored time point
+      return *upper;
+    const auto lower = std::prev(upper); // last stored time point < t
+    return (upper->first - t < t - lower->first) ? *upper : *lower;
   }
 
   virtual const DiscreteFunctionType& solution_at_time(const RangeFieldType t) const


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

`TimeStepperInterface::solution_closest_to_time` (`dune/gdt/tools/timestepper/interface.hh`) compared `map::lower_bound(t)` and `map::upper_bound(t)`:

```cpp
return solution().upper_bound(t)->first - t > t - solution().lower_bound(t)->first
       ? *solution().lower_bound(t) : *solution().upper_bound(t);
```

Two defects:

1. For any `t` strictly between two stored time points, `lower_bound(t)` and `upper_bound(t)` return the **same** (later) iterator — `lower_bound` is "first element ≥ t", not "last element ≤ t" — so the closest *earlier* time point can never be returned (query `t = 0.4` with stored times `{0, 1, 2}` returns the snapshot at `1`).
2. For any `t` at or beyond the **last** stored time point, `upper_bound(t)` is `end()`, which was dereferenced unconditionally — undefined behavior for the most natural query of all, `solution_closest_to_time(t_end)`.

## The fix

Use `lower_bound` and its predecessor, with explicit handling of queries before the first and at/after the last stored time point.

## The test

`dune/gdt/test/misc/timestepper_solution_closest_to_time.cc` builds a minimal time stepper over an FV space, stores snapshots at `t = 0, 1, 2` (tagged through their DoF values) and checks the returned time point for queries before, between, exactly at and beyond the stored times — including `t = 2` and `t = 5`, which used to dereference `end()`, and `t = 0.4`, which used to return the wrong neighbor.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for solution lookup functionality, covering edge cases including boundary conditions and out-of-range queries.

* **Bug Fixes**
  * Enhanced the solution-finding algorithm to accurately return the nearest time point for any query time across the stored solution range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->