### PR TITLE
Fix AdaptiveRungeKuttaTimeStepper (did not compile, unconditional FSAL reuse)

### DIFF
--- a/dune/gdt/test/misc/timestepper_adaptive_rungekutta.cc
+++ b/dune/gdt/test/misc/timestepper_adaptive_rungekutta.cc
@@ -1,0 +1,89 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <cmath>
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/operators/identity.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+#include <dune/gdt/tools/timestepper/adaptive-rungekutta.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using OperatorType = IdentityOperator<GV>;
+using V = typename OperatorType::VectorType;
+using DF = DiscreteFunction<V, GV>;
+
+
+/// Solves u' = -u, u(0) = 1 (via the identity operator L(u) = u and the scalar factor r = -1) up to T = 1 and
+/// compares against the exact solution exp(-1). Aside from the accuracy check, this instantiates
+/// AdaptiveRungeKuttaTimeStepper at all, which used to fail to compile (its solve() override did not match any
+/// virtual base method and it stored DiscreteFunctions by value, whose copy constructor is deleted).
+struct AdaptiveRungeKuttaTimeStepperTest : public ::testing::Test
+{
+  void SetUp() override
+  {
+    grid_provider_ = std::make_unique<XT::Grid::GridProvider<G>>(XT::Grid::make_cube_grid<G>(0., 1., 4u));
+    space_ = std::make_unique<FiniteVolumeSpace<GV>>(grid_provider_->leaf_view());
+    op_ = std::make_unique<OperatorType>(*space_);
+  }
+
+  template <TimeStepperMethods method, class... Args>
+  void check_solves_exponential_decay(Args&&... args)
+  {
+    DF initial_values(*space_);
+    for (size_t ii = 0; ii < space_->mapper().size(); ++ii)
+      initial_values.dofs().vector()[ii] = 1.; // u(0) = 1
+    AdaptiveRungeKuttaTimeStepper<OperatorType, DF, method> stepper(
+        *op_, initial_values, /*r=*/-1., /*t_0=*/0., /*tol=*/1e-8, 0.2, 5, std::forward<Args>(args)...);
+    stepper.solve(/*t_end=*/1., /*initial_dt=*/0.1, /*num_save_steps=*/size_t(-1), /*num_output_steps=*/0);
+    EXPECT_NEAR(stepper.current_time(), 1., 1e-10);
+    for (size_t ii = 0; ii < space_->mapper().size(); ++ii)
+      EXPECT_NEAR(stepper.current_solution().dofs().vector()[ii], std::exp(-1.), 1e-5);
+  }
+
+  std::unique_ptr<XT::Grid::GridProvider<G>> grid_provider_;
+  std::unique_ptr<FiniteVolumeSpace<GV>> space_;
+  std::unique_ptr<OperatorType> op_;
+}; // struct AdaptiveRungeKuttaTimeStepperTest
+
+
+TEST_F(AdaptiveRungeKuttaTimeStepperTest, dormand_prince)
+{
+  check_solves_exponential_decay<TimeStepperMethods::dormand_prince>();
+}
+
+TEST_F(AdaptiveRungeKuttaTimeStepperTest, bogacki_shampine)
+{
+  check_solves_exponential_decay<TimeStepperMethods::bogacki_shampine>();
+}
+
+TEST_F(AdaptiveRungeKuttaTimeStepperTest, non_fsal_user_provided_tableau)
+{
+  // Fehlberg 4(5): c_last = 1/2 != 1 and the last row of A differs from b_1, so the first-same-as-last reuse of the
+  // previous step's last stage is invalid for this method and must not be applied by the time stepper
+  using M = Dune::DynamicMatrix<double>;
+  using X = Dune::DynamicVector<double>;
+  const M A{{0., 0., 0., 0., 0., 0.},
+            {1. / 4., 0., 0., 0., 0., 0.},
+            {3. / 32., 9. / 32., 0., 0., 0., 0.},
+            {1932. / 2197., -7200. / 2197., 7296. / 2197., 0., 0., 0.},
+            {439. / 216., -8., 3680. / 513., -845. / 4104., 0., 0.},
+            {-8. / 27., 2., -3544. / 2565., 1859. / 4104., -11. / 40., 0.}};
+  const X b_1{16. / 135., 0., 6656. / 12825., 28561. / 56430., -9. / 50., 2. / 55.};
+  const X b_2{25. / 216., 0., 1408. / 2565., 2197. / 4104., -1. / 5., 0.};
+  const X c{0., 1. / 4., 3. / 8., 12. / 13., 1., 1. / 2.};
+  check_solves_exponential_decay<TimeStepperMethods::adaptive_rungekutta_other>(A, b_1, b_2, c);
+}

--- a/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
+++ b/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
@@ -217,7 +217,7 @@ public:
     , tol_(tol)
     , scale_factor_min_(scale_factor_min)
     , scale_factor_max_(scale_factor_max)
-    , u_tmp_(BaseType::current_solution())
+    , u_tmp_(BaseType::current_solution().copy_as_discrete_function())
     , A_(A)
     , b_1_(b_1)
     , b_2_(b_2)
@@ -241,8 +241,15 @@ public:
     }
     // store as many discrete functions as needed for intermediate stages
     for (size_t ii = 0; ii < num_stages_; ++ii) {
-      stages_k_.emplace_back(current_solution());
+      stages_k_.emplace_back(current_solution().copy_as_discrete_function());
     }
+    // The first-same-as-last (FSAL) optimization in step() reuses the last stage of the previous (accepted) step as
+    // the first stage of the new step. This is only valid if the last stage is evaluated at (u_{n+1}, t_{n+1}), i.e.
+    // if the last row of A equals b_1, c_0 = 0 and c_{s-1} = 1 (true for Bogacki-Shampine and Dormand-Prince, but
+    // not for arbitrary user-provided embedded methods).
+    fsal_ = Dune::XT::Common::FloatCmp::eq(c_[0], 0.) && Dune::XT::Common::FloatCmp::eq(c_[num_stages_ - 1], 1.);
+    for (size_t jj = 0; jj < num_stages_; ++jj)
+      fsal_ = fsal_ && Dune::XT::Common::FloatCmp::eq(A_[num_stages_ - 1][jj], b_1_[jj]);
   } // constructor AdaptiveRungeKuttaTimeStepper
 
   using BaseType::current_solution;
@@ -257,6 +264,7 @@ public:
                        const bool visualize,
                        const bool write_discrete,
                        const bool write_exact,
+                       const bool reset_begin_time,
                        const std::string prefix,
                        typename BaseType::DiscreteSolutionType& sol,
                        const typename BaseType::VisualizerType& visualizer,
@@ -271,6 +279,7 @@ public:
                                      visualize,
                                      write_discrete,
                                      write_exact,
+                                     reset_begin_time,
                                      prefix,
                                      sol,
                                      visualizer,
@@ -294,18 +303,20 @@ public:
       bool skip_error_computation = false;
       actual_dt *= time_step_scale_factor;
       size_t first_stage_to_compute = 0;
-      if (last_stage_of_previous_step_) {
-        stages_k_[0].dofs().vector() = last_stage_of_previous_step_->dofs().vector();
+      if (fsal_ && last_stage_of_previous_step_) {
+        stages_k_[0]->dofs().vector() = last_stage_of_previous_step_->dofs().vector();
         first_stage_to_compute = 1;
       }
 
       for (size_t ii = first_stage_to_compute; ii < num_stages_; ++ii) {
-        std::fill(stages_k_[ii].dofs().vector().begin(), stages_k_[ii].dofs().vector().end(), RangeFieldType(0.));
-        u_tmp_.dofs().vector() = u_n.dofs().vector();
+        std::fill(stages_k_[ii]->dofs().vector().begin(), stages_k_[ii]->dofs().vector().end(), RangeFieldType(0.));
+        u_tmp_->dofs().vector() = u_n.dofs().vector();
         for (size_t jj = 0; jj < ii; ++jj)
-          u_tmp_.dofs().vector() += stages_k_[jj].dofs().vector() * (actual_dt * r_ * (A_[ii][jj]));
+          u_tmp_->dofs().vector() += stages_k_[jj]->dofs().vector() * (actual_dt * r_ * (A_[ii][jj]));
         try {
-          op_.apply(u_tmp_.dofs().vector(), stages_k_[ii].dofs().vector(), t + actual_dt * c_[ii]);
+          op_.apply(u_tmp_->dofs().vector(),
+                    stages_k_[ii]->dofs().vector(),
+                    XT::Common::Parameter({{"t", {t + actual_dt * c_[ii]}}, {"dt", {actual_dt}}}));
         } catch (const Dune::MathError& e) {
           mixed_error = 1e10;
           skip_error_computation = true;
@@ -323,17 +334,17 @@ public:
 
       if (!skip_error_computation) {
         // compute error vector
-        u_tmp_.dofs().vector() = stages_k_[0].dofs().vector() * b_diff_[0];
+        u_tmp_->dofs().vector() = stages_k_[0]->dofs().vector() * b_diff_[0];
         for (size_t ii = 1; ii < num_stages_; ++ii)
-          u_tmp_.dofs().vector() += stages_k_[ii].dofs().vector() * b_diff_[ii];
-        u_tmp_.dofs().vector() *= actual_dt * r_;
+          u_tmp_->dofs().vector() += stages_k_[ii]->dofs().vector() * b_diff_[ii];
+        u_tmp_->dofs().vector() *= actual_dt * r_;
 
         // calculate u at timestep n+1
         for (size_t ii = 0; ii < num_stages_; ++ii)
-          u_n.dofs().vector() += stages_k_[ii].dofs().vector() * (actual_dt * r_ * b_1_[ii]);
+          u_n.dofs().vector() += stages_k_[ii]->dofs().vector() * (actual_dt * r_ * b_1_[ii]);
 
         // scale error, use absolute error if norm is less than 0.01 and relative error else
-        auto& diff_vector = u_tmp_.dofs().vector();
+        auto& diff_vector = u_tmp_->dofs().vector();
         for (size_t ii = 0; ii < diff_vector.size(); ++ii) {
           if (std::abs(u_n.dofs().vector()[ii]) > 0.01)
             diff_vector[ii] /= std::abs(u_n.dofs().vector()[ii]);
@@ -345,13 +356,15 @@ public:
 
         if (mixed_error > tol_) { // go back from u at timestep n+1 to timestep n
           for (size_t ii = 0; ii < num_stages_; ++ii)
-            u_n.dofs().vector() += stages_k_[ii].dofs().vector() * (-1.0 * r_ * actual_dt * b_1_[ii]);
+            u_n.dofs().vector() += stages_k_[ii]->dofs().vector() * (-1.0 * r_ * actual_dt * b_1_[ii]);
         }
       }
     } // while (mixed_error > tol_)
-    if (!last_stage_of_previous_step_)
-      last_stage_of_previous_step_ = std::make_unique<DiscreteFunctionType>(u_n);
-    last_stage_of_previous_step_->dofs().vector() = stages_k_[num_stages_ - 1].dofs().vector();
+    if (fsal_) {
+      if (!last_stage_of_previous_step_)
+        last_stage_of_previous_step_ = u_n.copy_as_discrete_function();
+      last_stage_of_previous_step_->dofs().vector() = stages_k_[num_stages_ - 1]->dofs().vector();
+    }
 
     t += actual_dt;
 
@@ -364,14 +377,15 @@ private:
   const RangeFieldType tol_;
   const RangeFieldType scale_factor_min_;
   const RangeFieldType scale_factor_max_;
-  DiscreteFunctionType u_tmp_;
+  std::unique_ptr<DiscreteFunctionType> u_tmp_;
   const MatrixType A_;
   const VectorType b_1_;
   const VectorType b_2_;
   const VectorType c_;
   const VectorType b_diff_;
-  std::vector<DiscreteFunctionType> stages_k_;
+  std::vector<std::unique_ptr<DiscreteFunctionType>> stages_k_;
   const size_t num_stages_;
+  bool fsal_;
   std::unique_ptr<DiscreteFunctionType> last_stage_of_previous_step_;
 }; // class AdaptiveRungeKuttaTimeStepper
 


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

`AdaptiveRungeKuttaTimeStepper` (`dune/gdt/tools/timestepper/adaptive-rungekutta.hh`) is dead-but-exported code: nothing in the repository instantiates it, and it **cannot ever have compiled** in its current form:

1. its `solve()` override has no matching virtual in `TimeStepperInterface` — the `reset_begin_time` parameter is missing from the signature — so `override final` is ill-formed on instantiation;
2. it stores `DiscreteFunction`s **by value** (`u_tmp_`, `stages_k_`, `std::make_unique<DiscreteFunctionType>(u_n)`), but `DiscreteFunction`'s copy constructor is deleted;
3. the spatial operator was invoked with a plain `double` as parameter instead of an `XT::Common::Parameter`.

On top of the compile breakage, one genuine numerical bug:

4. the first-same-as-last (**FSAL**) optimization reused the last stage of the previous accepted step as stage 0 of the next step *unconditionally*. That is only valid when the last stage is evaluated at `(u_{n+1}, t_{n+1})`, i.e. when the last row of `A` equals `b_1`, `c_0 = 0` and `c_{s-1} = 1`. This holds for the built-in Bogacki–Shampine and Dormand–Prince tableaus, but **not** for arbitrary user-provided embedded methods (e.g. Fehlberg 4(5), whose `c_{s-1} = 1/2`) — for those the reuse silently substitutes a wrong stage value into every step.

## The fix

- `solve()` gains the missing `reset_begin_time` parameter and passes it through;
- storage uses `copy_as_discrete_function()`/`unique_ptr`s, exactly like `ExplicitRungeKuttaTimeStepper`;
- the operator receives `XT::Common::Parameter({{"t", ...}, {"dt", ...}})`, consistent with the explicit stepper;
- the FSAL property is detected once in the constructor and the stage reuse is only applied when it holds.

Known remaining limitation (out of scope here, noted for completeness): unlike the explicit stepper, the adaptive stepper does not `communicate()` its stages, so it is not MPI-correct.

## The test

`dune/gdt/test/misc/timestepper_adaptive_rungekutta.cc` solves u' = −u up to T = 1 (identity operator, r = −1) with Dormand–Prince, Bogacki–Shampine and a user-provided non-FSAL Fehlberg 4(5) tableau and compares against exp(−1) (tol 1e−8, accepted error 1e−5). It is also the first code to instantiate this class template at all, i.e. it catches problems 1–3 at compile time.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for adaptive Runge-Kutta time stepping methods, including validation against exponential decay problems and support for custom time-stepping tableaus.

* **Bug Fixes**
  * Corrected stage reuse logic for non-FSAL (First-Same-As-Last) time-stepping configurations to prevent incorrect behavior.

* **Refactor**
  * Improved internal memory management and time-step handling in the adaptive time stepper implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->