### PR TITLE
Fix Householder QR for non-square matrices

### DIFF
--- a/dune/xt/la/algorithms/qr.hh
+++ b/dune/xt/la/algorithms/qr.hh
@@ -97,11 +97,11 @@ void multiply_householder_from_right(MatrixType& A,
   using M = Common::MatrixAbstraction<MatrixType>;
   using V = Common::VectorAbstraction<VectorType>;
   using W = Common::VectorAbstraction<DynamicVector<typename V::ScalarType>>;
-  // calculate A w first
+  // calculate A w first, (Aw)_r = \sum_c A_{rc} w_c
   auto Aw = W::create(M::rows(A), 0.);
   for (size_t rr = row_begin; rr < row_end; ++rr)
     for (size_t cc = col_begin; cc < col_end; ++cc)
-      W::add_to_entry(Aw, cc, V::get_entry(v, cc) * M::get_entry(A, rr, cc));
+      W::add_to_entry(Aw, rr, M::get_entry(A, rr, cc) * V::get_entry(v, cc));
   for (size_t rr = row_begin; rr < row_end; ++rr)
     for (size_t cc = col_begin; cc < col_end; ++cc)
       M::add_to_entry(A, rr, cc, -tau * W::get_entry(Aw, rr) * Common::conj(V::get_entry(v, cc)));
@@ -158,7 +158,11 @@ void qr_decomposition(MatrixType& A, VectorType& tau, IndexVectorType& permutati
 
   auto w = W::create(num_rows, ScalarType(0.));
 
-  for (size_t jj = 0; jj < num_cols - 1; ++jj) {
+  // As in LAPACK's geqp3, one Householder reflection is needed per column for matrices with num_rows > num_cols
+  // (stopping after num_cols - 1 reflections leaves the subdiagonal entries of the last column un-eliminated).
+  // For num_rows <= num_cols the last reflection would act on a single row and can be skipped.
+  const size_t num_reflections = std::min(num_rows > 0 ? num_rows - 1 : 0, num_cols);
+  for (size_t jj = 0; jj < num_reflections; ++jj) {
 
     // Pivoting
     // swap column jj and column with greatest norm
@@ -340,9 +344,9 @@ struct QrHelper
                                 transpose == XT::Common::Transpose::yes ? 'T' : 'N',
                                 num_rhs_rows,
                                 num_rhs_cols,
-                                static_cast<int>(num_rows),
+                                /*number of reflectors=*/static_cast<int>(std::min(num_rows, num_cols)),
                                 M::data(QR),
-                                num_rhs_rows,
+                                /*leading dimension of QR=*/static_cast<int>(is_row_major ? num_cols : num_rows),
                                 V::data(tau),
                                 V3::data(y),
                                 is_row_major ? num_rhs_cols : num_rhs_rows);
@@ -352,15 +356,19 @@ struct QrHelper
     } else {
       assert(num_cols < size_t(std::numeric_limits<int>::max()));
       auto w = W::create(num_rows, ScalarType(0.));
+      // at most min(num_rows, num_cols) reflectors are stored (as for dormqr above); iterating up to num_cols would
+      // access w (of length num_rows) out of bounds for matrices with num_cols > num_rows
+      const int num_reflectors = static_cast<int>(std::min(num_rows, num_cols));
       if (transpose == XT::Common::Transpose::no)
-        for (int jj = static_cast<int>(num_cols) - 1; jj >= 0; --jj) {
+        for (int jj = num_reflectors - 1; jj >= 0; --jj) {
           set_w_vector(QR, jj, w);
           multiply_householder_from_left(y, tau[jj], w, jj, num_rows);
         }
       else
-        for (int jj = 0; jj < static_cast<int>(num_cols); ++jj) {
+        for (int jj = 0; jj < num_reflectors; ++jj) {
           set_w_vector(QR, jj, w);
-          multiply_householder_from_left(y, tau[jj], w, jj, num_rows);
+          // Q^H = H_{k-1}^H ... H_0^H with H_j^H = I - conj(tau_j) w w^H
+          multiply_householder_from_left(y, Common::conj(tau[jj]), w, jj, num_rows);
         }
     }
   } // static void apply_q_from_qr(...)

--- a/dune/xt/test/la/algorithms_qr_full_rank_tall.cc
+++ b/dune/xt/test/la/algorithms_qr_full_rank_tall.cc
@@ -1,0 +1,158 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+// This one has to come first (includes the config.h)!
+#include <dune/xt/test/main.hxx>
+
+#include <algorithm>
+#include <cmath>
+#include <type_traits>
+#include <vector>
+
+#include <dune/common/dynmatrix.hh>
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/common/matrix.hh>
+#include <dune/xt/la/algorithms/qr.hh>
+#include <dune/xt/la/container/eye-matrix.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+
+// Checks AP = QR and the orthogonality of Q for a matrix of full column rank.
+//
+// The pre-existing 5x3 test passes a rank-2 matrix (its third column is a linear combination of the first two), so
+// it never noticed that the Householder QR used to apply only num_cols - 1 reflections: for full-rank matrices with
+// num_rows > num_cols the subdiagonal entries of the last (pivoted) column were left un-eliminated, producing
+// Q and R with Q R != A P.
+template <class MatrixType>
+void check_qr_decomposition(const MatrixType& matrix, const size_t num_rows, const size_t num_cols)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  auto QR = matrix;
+  Dune::DynamicVector<double> tau(num_cols, 0.);
+  std::vector<int> permutations(num_cols);
+  qr(QR, tau, permutations);
+  // extract R (upper triangular part)
+  auto R = QR;
+  for (size_t ii = 0; ii < num_rows; ++ii)
+    for (size_t jj = 0; jj < std::min(ii, num_cols); ++jj)
+      M::set_entry(R, ii, jj, 0.);
+  const auto Q = calculate_q_from_qr(QR, tau);
+  using QM = Common::MatrixAbstraction<std::decay_t<decltype(Q)>>;
+  // Q has to be orthogonal
+  for (size_t ii = 0; ii < num_rows; ++ii)
+    for (size_t jj = 0; jj < num_rows; ++jj) {
+      double entry_QtQ = 0.;
+      for (size_t kk = 0; kk < num_rows; ++kk)
+        entry_QtQ += QM::get_entry(Q, kk, ii) * QM::get_entry(Q, kk, jj);
+      EXPECT_NEAR(entry_QtQ, ii == jj ? 1. : 0., 1e-13) << "ii = " << ii << ", jj = " << jj;
+    }
+  // Q R has to equal A P (P permutes the columns of A)
+  for (size_t ii = 0; ii < num_rows; ++ii)
+    for (size_t jj = 0; jj < num_cols; ++jj) {
+      double entry_QR = 0.;
+      for (size_t kk = 0; kk < num_rows; ++kk)
+        entry_QR += QM::get_entry(Q, ii, kk) * (kk < num_rows ? M::get_entry(R, kk, jj) : 0.);
+      const double entry_AP = M::get_entry(matrix, ii, static_cast<size_t>(permutations[jj]));
+      EXPECT_NEAR(entry_QR, entry_AP, 1e-13) << "ii = " << ii << ", jj = " << jj;
+    }
+} // ... check_qr_decomposition(...)
+
+
+GTEST_TEST(QrTallFullRank, decomposes_5x3_full_rank_matrix)
+{
+  const FieldMatrix<double, 5, 3> matrix{{2., 1., 0.}, {1., 3., 1.}, {0., 1., 4.}, {1., 0., 1.}, {3., 1., 2.}};
+  check_qr_decomposition(matrix, 5, 3);
+}
+
+GTEST_TEST(QrTallFullRank, decomposes_3x2_full_rank_matrix)
+{
+  // for this matrix the missing last reflection left A(2,1) un-eliminated before the fix
+  const FieldMatrix<double, 3, 2> matrix{{1., 0.}, {0., 1.}, {0., 1.}};
+  check_qr_decomposition(matrix, 3, 2);
+}
+
+GTEST_TEST(QrTallFullRank, decomposes_4x1_matrix)
+{
+  // a single-column matrix received no reflection at all before the fix
+  const FieldMatrix<double, 4, 1> matrix{{1.}, {2.}, {2.}, {4.}};
+  check_qr_decomposition(matrix, 4, 1);
+  // additionally check R(0,0) = +-||A||_2 = +-5
+  auto QR = matrix;
+  Dune::DynamicVector<double> tau(1, 0.);
+  std::vector<int> permutations(1);
+  qr(QR, tau, permutations);
+  EXPECT_NEAR(std::abs(QR[0][0]), 5., 1e-13);
+}
+
+GTEST_TEST(QrTallFullRank, decomposes_dynamic_matrix)
+{
+  Dune::DynamicMatrix<double> matrix(5, 3, 0.);
+  const FieldMatrix<double, 5, 3> values{{2., 1., 0.}, {1., 3., 1.}, {0., 1., 4.}, {1., 0., 1.}, {3., 1., 2.}};
+  for (size_t ii = 0; ii < 5; ++ii)
+    for (size_t jj = 0; jj < 3; ++jj)
+      matrix[ii][jj] = values[ii][jj];
+  check_qr_decomposition(matrix, 5, 3);
+}
+
+GTEST_TEST(QrTallFullRank, apply_q_from_qr_roundtrip)
+{
+  const FieldMatrix<double, 5, 3> matrix{{2., 1., 0.}, {1., 3., 1.}, {0., 1., 4.}, {1., 0., 1.}, {3., 1., 2.}};
+  auto QR = matrix;
+  Dune::DynamicVector<double> tau(3, 0.);
+  std::vector<int> permutations(3);
+  qr(QR, tau, permutations);
+  const FieldVector<double, 5> x{1., -2., 3., 0.5, -1.};
+  FieldVector<double, 5> Qx(0.), QtQx(0.);
+  apply_q_from_qr<Common::Transpose::no>(QR, tau, x, Qx);
+  apply_q_from_qr<Common::Transpose::yes>(QR, tau, Qx, QtQx);
+  for (size_t ii = 0; ii < 5; ++ii)
+    EXPECT_NEAR(QtQx[ii], x[ii], 1e-13) << "ii = " << ii;
+}
+
+GTEST_TEST(QrTallFullRank, decomposes_12x2_matrix_and_applies_q)
+{
+  // 12 rows > min_lapack_factor_size = 10, so this exercises the LAPACK code paths (geqp3/dormqr) where available;
+  // the dormqr call used to pass the number of rows as the number of elementary reflectors (reading past the end of
+  // tau for tall matrices) and the wrong leading dimension of QR
+  FieldMatrix<double, 12, 2> matrix;
+  for (size_t ii = 0; ii < 12; ++ii) {
+    matrix[ii][0] = 1. + 0.5 * ii;
+    matrix[ii][1] = std::pow(-1., int(ii)) + 0.1 * ii * ii;
+  }
+  check_qr_decomposition(matrix, 12, 2);
+  auto QR = matrix;
+  Dune::DynamicVector<double> tau(2, 0.);
+  std::vector<int> permutations(2);
+  qr(QR, tau, permutations);
+  FieldVector<double, 12> x(0.), Qx(0.), QtQx(0.);
+  for (size_t ii = 0; ii < 12; ++ii)
+    x[ii] = std::sin(double(ii));
+  apply_q_from_qr<Common::Transpose::no>(QR, tau, x, Qx);
+  apply_q_from_qr<Common::Transpose::yes>(QR, tau, Qx, QtQx);
+  for (size_t ii = 0; ii < 12; ++ii)
+    EXPECT_NEAR(QtQx[ii], x[ii], 1e-12) << "ii = " << ii;
+}
+
+GTEST_TEST(MultiplyHouseholderFromRight, matches_hand_computed_example)
+{
+  // A (I - tau v v^T) for A = [[1, 2], [3, 4]], tau = 1, v = (1, 1):
+  // A v = (3, 7), so the result is A - (A v) v^T = [[-2, -1], [-4, -3]].
+  // The implementation used to accumulate A v with the wrong index, yielding [[-3, -2], [-3, -2]].
+  FieldMatrix<double, 2, 2> A{{1., 2.}, {3., 4.}};
+  const FieldVector<double, 2> v{1., 1.};
+  internal::multiply_householder_from_right(A, 1., v, 0, 2, 0, 2);
+  EXPECT_NEAR(A[0][0], -2., 1e-15);
+  EXPECT_NEAR(A[0][1], -1., 1e-15);
+  EXPECT_NEAR(A[1][0], -4., 1e-15);
+  EXPECT_NEAR(A[1][1], -3., 1e-15);
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem). The four fixes below all concern the application of Householder reflections in `dune/xt/la/algorithms/qr.hh`, so they are bundled.

## Problem 1 — missing last reflection for tall matrices (high)

`qr_decomposition` ran `for (jj = 0; jj < num_cols - 1; ++jj)`. For square matrices skipping the last reflection is harmless (it would only normalize the sign of `R(n−1,n−1)`), but for **tall** matrices (rows > cols) the reflection of the last column is required to eliminate its subdiagonal entries (LAPACK applies `min(m,n)` reflectors). The leftovers were then misread as Householder-vector components by `calculate_q_from_qr`/`apply_q_from_qr`, producing `Q·R ≠ A·P`. An m×1 matrix received **no** reflection at all. Also, `num_cols == 0` underflowed `size_t`.

**Why the existing 5×3 test passes:** its matrix `[[1,2,3],[4,5,6],...,[13,14,15]]` has rank 2 (col₃ = 2col₂ − col₁), so after two reflections the entries the missing third reflection should eliminate are already ~1e−15, below the test tolerance. Any full-rank tall matrix fails the `Q·R = A·P` check.

The loop now runs `min(num_rows − 1, num_cols)` times (unchanged for square, `n` reflections for tall, `m−1` for wide).

## Problem 2 — `multiply_householder_from_right` accumulates A·w into the wrong index

```cpp
W::add_to_entry(Aw, cc, V::get_entry(v, cc) * M::get_entry(A, rr, cc));  // (Aw)_c += v_c A_rc
```
computes column sums scaled by `v_c` instead of `(Aw)_r = Σ_c A_rc v_c`; the subsequent rank-1 update then uses `Aw[rr]`. For `A = [[1,2],[3,4]]`, `τ = 1`, `v = (1,1)` it returns `[[−3,−2],[−3,−2]]` instead of `[[−2,−1],[−4,−3]]`. Currently dead code (the shifted-QR eigensolver carries its own correct copy), but exported and a trap for future use.

## Problem 3 — dormqr called with square-matrix assumptions

The LAPACK path of `apply_q_from_qr` passed the right-hand side's row count both as the number of elementary reflectors `k` (reading past the end of `tau`, which has `num_cols` entries, for tall QR) and as the leading dimension of `QR` (wrong for row-major non-square storage). Now `k = min(rows, cols)` and `lda = is_row_major ? cols : rows`.

## Problem 4 — complex transposed apply misses the conjugation

`Qᴴ = H_{k−1}ᴴ···H₀ᴴ` with `H_jᴴ = I − conj(τ_j) w wᴴ`; the fallback used `τ_j` unconjugated (no effect for real scalars).

## The tests

`dune/xt/test/la/algorithms_qr_full_rank_tall.cc`: full-rank 5×3 (static + dynamic storage), 3×2 and 4×1 decompositions checking `Q·R = A·P` and orthogonality of `Q`; a 12×2 matrix that crosses `min_lapack_factor_size = 10` and exercises the LAPACK geqp3/dormqr branch where available; `Q`/`Qᵀ` application roundtrips; and the hand-computed 2×2 example for `multiply_householder_from_right`.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected QR decomposition behavior: fixed reflector application and accumulation, adjusted iteration limits for rectangular/non-square matrices, and fixed conjugation handling when applying Q.

* **Tests**
  * Added regression tests validating QR on tall/full-rank matrices across sizes and edge cases, including orthogonality, factorization accuracy, and reflector application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->