### PR TITLE
Fix sparse Cholesky silently producing wrong factors on exact zeros

### DIFF
--- a/dune/xt/la/algorithms/cholesky.hh
+++ b/dune/xt/la/algorithms/cholesky.hh
@@ -98,7 +98,10 @@ void cholesky_rowwise(MatrixType& A)
       for (size_t kk = 0; kk < jj; ++kk)
         L_ij -= M::get_entry(L, ii, kk) * M::get_entry(L, jj, kk);
       L_ij /= M::get_entry(L, jj, jj);
-      if (!only_set_nonzero || !XT::Common::is_zero(L_ij))
+      // for sparse matrices, only write entries that are part of the sparsity pattern; an entry certainly is if its
+      // currently stored value is nonzero, and it has to be overwritten then even if L_ij is exactly zero (otherwise
+      // the stale value of A would poison the remaining factorization)
+      if (!only_set_nonzero || !XT::Common::is_zero(L_ij) || !XT::Common::is_zero(M::get_entry(L, ii, jj)))
         M::set_entry(L, ii, jj, L_ij);
     } // jj
     auto L_ii = M::get_entry(A, ii, ii);
@@ -130,7 +133,8 @@ void cholesky_colwise(MatrixType& A)
       for (size_t kk = 0; kk < jj; ++kk)
         L_ij -= M::get_entry(L, ii, kk) * M::get_entry(L, jj, kk);
       L_ij *= L_jj_inv;
-      if (!only_set_nonzero || !XT::Common::is_zero(L_ij))
+      // see the comment in cholesky_rowwise: a stored nonzero entry has to be overwritten even if L_ij is zero
+      if (!only_set_nonzero || !XT::Common::is_zero(L_ij) || !XT::Common::is_zero(M::get_entry(L, ii, jj)))
         M::set_entry(L, ii, jj, L_ij);
     } // ii
   } // jj
@@ -160,7 +164,8 @@ cholesky_csr(MatrixType& A)
           L_ij -= entries[ll++] * entries[kk++];
       }
       L_ij /= M::get_entry(L, jj, jj);
-      if (!XT::Common::is_zero(L_ij))
+      // see the comment in cholesky_rowwise: a stored nonzero entry has to be overwritten even if L_ij is zero
+      if (!XT::Common::is_zero(L_ij) || !XT::Common::is_zero(M::get_entry(L, ii, jj)))
         M::set_entry(L, ii, jj, L_ij);
     } // jj
     auto L_ii = M::get_entry(A, ii, ii);

--- a/dune/xt/test/la/algorithms_cholesky_exact_zero_in_factor.cc
+++ b/dune/xt/test/la/algorithms_cholesky_exact_zero_in_factor.cc
@@ -1,0 +1,68 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+// This one has to come first (includes the config.h)!
+#include <dune/xt/test/main.hxx>
+
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/common/matrix.hh>
+
+#include <dune/xt/la/algorithms/cholesky.hh>
+#include <dune/xt/la/container.hh>
+#include <dune/xt/test/la/container.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+
+// The sparse code paths used to skip writing factor entries that are exactly zero ("only_set_nonzero"). If the
+// corresponding entry of A is part of the sparsity pattern and nonzero, the stale value of A survived in the factor
+// and silently poisoned the remaining factorization (or made it throw on a perfectly SPD matrix).
+template <class MatrixType>
+void check_cholesky_factor_with_exact_zero()
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  // A = [[1,1,1],[1,2,1],[1,1,5]] is SPD with L = [[1,0,0],[1,1,0],[1,0,2]]; note the exact zero L_21 at a position
+  // where A holds a nonzero value
+  auto A = create<MatrixType>({{1, 1, 1}, {1, 2, 1}, {1, 1, 5}}, dense_pattern(3, 3));
+  cholesky(A);
+  EXPECT_NEAR(M::get_entry(A, 0, 0), 1., 1e-14);
+  EXPECT_NEAR(M::get_entry(A, 1, 0), 1., 1e-14);
+  EXPECT_NEAR(M::get_entry(A, 1, 1), 1., 1e-14);
+  EXPECT_NEAR(M::get_entry(A, 2, 0), 1., 1e-14);
+  EXPECT_NEAR(M::get_entry(A, 2, 1), 0., 1e-14); // <- used to keep the stale value 1 on the sparse paths
+  EXPECT_NEAR(M::get_entry(A, 2, 2), 2., 1e-14); // <- used to be sqrt(3) on the sparse paths
+
+  // A2 = [[1,1,1],[1,2,1],[1,1,2]] is SPD with L = [[1,0,0],[1,1,0],[1,0,1]]; with the stale L_21 = 1 the pivot
+  // L_22^2 = 2 - 1 - 1 = 0 made the factorization throw on this SPD matrix
+  auto A2 = create<MatrixType>({{1, 1, 1}, {1, 2, 1}, {1, 1, 2}}, dense_pattern(3, 3));
+  EXPECT_NO_THROW(cholesky(A2));
+  EXPECT_NEAR(M::get_entry(A2, 2, 1), 0., 1e-14);
+  EXPECT_NEAR(M::get_entry(A2, 2, 2), 1., 1e-14);
+} // ... check_cholesky_factor_with_exact_zero(...)
+
+
+GTEST_TEST(CholeskyWithExactZeroInFactor, dense_field_matrix)
+{
+  check_cholesky_factor_with_exact_zero<FieldMatrix<double, 3, 3>>();
+}
+
+GTEST_TEST(CholeskyWithExactZeroInFactor, common_sparse_matrix_csr)
+{
+  check_cholesky_factor_with_exact_zero<CommonSparseMatrixCsr<double>>();
+}
+
+GTEST_TEST(CholeskyWithExactZeroInFactor, common_sparse_matrix_csc)
+{
+  check_cholesky_factor_with_exact_zero<CommonSparseMatrixCsc<double>>();
+}
+
+GTEST_TEST(CholeskyWithExactZeroInFactor, istl_row_major_sparse_matrix)
+{
+  check_cholesky_factor_with_exact_zero<IstlRowMajorSparseMatrix<double>>();
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

The sparse code paths of the Cholesky factorization in `dune/xt/la/algorithms/cholesky.hh` (CSR `cholesky_csr`, CSC `cholesky_colwise<true>`, Istl `cholesky_rowwise<true>`) skip writing factor entries that are exactly zero, to avoid `set_entry` calls for positions outside the sparsity pattern:

```cpp
if (!only_set_nonzero || !XT::Common::is_zero(L_ij))
  M::set_entry(L, ii, jj, L_ij);
```

When the computed `L_ij` is **exactly zero** at a position where A stores a **nonzero** value — exact cancellation, routine with integer-valued data — the skip leaves the stale entry of A in the factor, which poisons all later rows/columns:

- `A = [[1,1,1],[1,2,1],[1,1,5]]` (SPD, true `L = [[1,0,0],[1,1,0],[1,0,2]]`, note `L_21 = (1−1·1)/1 = 0`): the stale `1` survives and `L_22 = √(5−1−1) = √3` instead of `2` — **silently wrong results**;
- `A = [[1,1,1],[1,2,1],[1,1,2]]` (SPD, `L_22 = 1`): the stale entry makes the pivot `2−1−1 = 0` and the factorization **throws MathError on an SPD matrix**.

The dense path is unaffected, i.e. dense and sparse storage disagreed on the same matrix. The existing 5×5 test matrix has no exact cancellation in its factor, which is why this went unnoticed.

## The fix

An entry whose stored value is nonzero is necessarily part of the pattern, so it can — and must — be overwritten even when the computed `L_ij` is zero. The skip now only applies when both the computed and the currently stored value are zero:

```cpp
if (!only_set_nonzero || !XT::Common::is_zero(L_ij) || !XT::Common::is_zero(M::get_entry(L, ii, jj)))
```

(applied to all three sites). The documented limitation that the factor must not need fill-in *outside* A's pattern is unchanged.

## The test

`dune/xt/test/la/algorithms_cholesky_exact_zero_in_factor.cc` factorizes both matrices above with dense `FieldMatrix` (baseline), `CommonSparseMatrixCsr`, `CommonSparseMatrixCsc` and `IstlRowMajorSparseMatrix`, checking every entry of L and that the second matrix does not throw.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Cholesky factorization in sparse matrix operations to properly handle exact-zero entries. The fix ensures stale stored values are overwritten, preventing corruption of subsequent factorization steps across multiple sparse matrix formats.

* **Tests**
  * Added unit tests for Cholesky factorization with exact-zero entries in sparse matrices to verify correct behavior and prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->