### PR TITLE
Fix tridiagonal LDL^T edge cases (unchecked last pivot, cached factor size)

### DIFF
--- a/dune/xt/la/algorithms/cholesky.hh
+++ b/dune/xt/la/algorithms/cholesky.hh
@@ -35,7 +35,8 @@ void tridiagonal_ldlt(FirstVectorType& diag, SecondVectorType& subdiag)
 {
   using V1 = Common::VectorAbstraction<FirstVectorType>;
   using V2 = Common::VectorAbstraction<SecondVectorType>;
-  V1::set_entry(diag, 0, V1::get_entry(diag, 0));
+  if (diag.size() == 0)
+    return;
   for (size_t ii = 0; ii < diag.size() - 1; ++ii) {
     if (!(V1::get_entry(diag, ii) > 0)) // use !(.. > 0) instead of (.. <= 0) to also throw on NaNs
       DUNE_THROW(MathError, "LDL^T factorization failed!");
@@ -43,6 +44,9 @@ void tridiagonal_ldlt(FirstVectorType& diag, SecondVectorType& subdiag)
     V1::set_entry(
         diag, ii + 1, V1::get_entry(diag, ii + 1) - V1::get_entry(diag, ii) * std::pow(V2::get_entry(subdiag, ii), 2));
   }
+  // also check the last pivot (as LAPACK's dpttrf does), the loop above only validates d_0, ..., d_{n-2}
+  if (!(V1::get_entry(diag, diag.size() - 1) > 0))
+    DUNE_THROW(MathError, "LDL^T factorization failed!");
 }
 
 template <class FirstVectorType, class SecondVectorType, class VectorType>
@@ -54,8 +58,15 @@ solve_tridiag_ldlt(const FirstVectorType& diag, const SecondVectorType& subdiag,
   using V = Common::VectorAbstraction<VectorType>;
   using ScalarType = typename V::ScalarType;
   size_t size = vec.size();
+  if (size == 0)
+    return;
+  // the thread_local matrix is only initialized on the first call (per thread), so it has to be rebuilt whenever a
+  // system of a different size is solved on this thread (otherwise the solves below read/write out of bounds)
   thread_local auto L =
       eye_matrix<CommonSparseMatrix<ScalarType>>(size, diagonal_pattern(size, size) + diagonal_pattern(size, size, -1));
+  if (L.rows() != size)
+    L = eye_matrix<CommonSparseMatrix<ScalarType>>(size,
+                                                   diagonal_pattern(size, size) + diagonal_pattern(size, size, -1));
   for (size_t ii = 0; ii < size - 1; ++ii)
     L.set_entry(ii + 1, ii, V2::get_entry(subdiag, ii));
   // solve LDL^T x = rhs;

--- a/dune/xt/test/la/algorithms_tridiagonal_ldlt_edge_cases.cc
+++ b/dune/xt/test/la/algorithms_tridiagonal_ldlt_edge_cases.cc
@@ -1,0 +1,64 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+// This one has to come first (includes the config.h)!
+#include <dune/xt/test/main.hxx>
+
+#include <dune/common/dynvector.hh>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/la/algorithms/cholesky.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+using VectorType = Dune::DynamicVector<double>;
+
+
+// solves the tridiagonal system with constant diagonal 2 and constant subdiagonal 1 of the given size and checks the
+// solution against a manufactured right-hand side
+void factorize_and_solve_tridiag_2_1(const size_t size)
+{
+  VectorType diag(size, 2.);
+  VectorType subdiag(size - 1, 1.);
+  internal::tridiagonal_ldlt(diag, subdiag);
+  // manufactured solution x_i = i + 1, rhs = A x
+  VectorType expected(size, 0.);
+  VectorType rhs(size, 0.);
+  for (size_t ii = 0; ii < size; ++ii) {
+    expected[ii] = double(ii) + 1.;
+    rhs[ii] = 2. * (double(ii) + 1.) + (ii > 0 ? double(ii) : 0.) + (ii < size - 1 ? double(ii) + 2. : 0.);
+  }
+  internal::solve_tridiag_ldlt(diag, subdiag, rhs);
+  for (size_t ii = 0; ii < size; ++ii)
+    EXPECT_NEAR(rhs[ii], expected[ii], 1e-13) << "size = " << size << ", ii = " << ii;
+} // ... factorize_and_solve_tridiag_2_1(...)
+
+
+GTEST_TEST(TridiagonalLdlt, throws_for_singular_matrix_with_singular_last_pivot)
+{
+  // [[1, 1], [1, 1]] is singular positive semidefinite: the LDL^T pivots are d = (1, 0), and only the last one
+  // vanishes. The fallback factorization used to validate all pivots but the last, so the subsequent solve silently
+  // divided by zero instead of throwing (LAPACK's dpttrf reports this case as an error).
+  VectorType diag{1., 1.};
+  VectorType subdiag{1.};
+  EXPECT_THROW(internal::tridiagonal_ldlt(diag, subdiag), Dune::MathError);
+  // same through the public interface (which dispatches to LAPACK if available)
+  VectorType diag2{1., 1.};
+  VectorType subdiag2{1.};
+  EXPECT_THROW(tridiagonal_ldlt(diag2, subdiag2), Dune::MathError);
+}
+
+GTEST_TEST(TridiagonalLdlt, solve_works_for_consecutive_systems_of_different_sizes)
+{
+  // the solver used to cache its unit-lower-bidiagonal factor matrix in a thread_local that was sized on the first
+  // call only, so a subsequent solve with a different size on the same thread accessed it out of bounds
+  factorize_and_solve_tridiag_2_1(3);
+  factorize_and_solve_tridiag_2_1(5); // <- used to access entries outside of the cached 3x3 sparsity pattern
+  factorize_and_solve_tridiag_2_1(2); // <- used to iterate 5 rows over vectors of length 2
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem). Both fixes concern the tridiagonal LDL^T machinery in `dune/xt/la/algorithms/cholesky.hh`.

## Problem 1 — last pivot never validated

`internal::tridiagonal_ldlt` checked `d_ii > 0` only for `ii = 0, …, n−2`; the last pivot `d_{n−1}` is computed but never validated. For a singular positive-semidefinite matrix whose only vanishing pivot is the last — e.g. `[[1,1],[1,1]]` with `d = (1, 0)` — the factorization "succeeded" and the subsequent solve silently divided by zero (Inf/NaN results), while LAPACK's `dpttrf` reports exactly this case as an error: the fallback and the LAPACK path disagreed on the same input. The last pivot is now checked too, matching `dpttrf` (and an empty system no longer underflows `diag.size() - 1`).

## Problem 2 — thread_local factor cached with the wrong size

`internal::solve_tridiag_ldlt` cached its unit-lower-bidiagonal factor in

```cpp
thread_local auto L = eye_matrix<CommonSparseMatrix<...>>(size, ...);
```

which is initialized **once per thread** with the size of the *first* call. Any later solve with a different size on the same thread accessed the cached matrix out of bounds: smaller→larger hits `set_entry` outside the cached pattern/row pointers; larger→smaller makes the triangular solves iterate more rows than the vectors have (raw-pointer reads/writes past the end). Note that even LAPACK-enabled builds reach this code through the matrix-valued right-hand-side overload for non-contiguous storage. The cache is now rebuilt whenever the size changes (keeping the fast path for repeated equal-size solves).

## The test

`dune/xt/test/la/algorithms_tridiagonal_ldlt_edge_cases.cc` checks that both the internal fallback and the public interface (which dispatches to LAPACK where available) throw `MathError` on the singular example, and factorizes + solves systems of sizes 3, 5 and 2 in sequence on the same thread against manufactured solutions (sizes 5-after-3 and 2-after-5 used to access out of bounds).

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_