### PR TITLE
Fix Oswald interpolation clearing the wrong range DoFs

### DIFF
--- a/dune/gdt/operators/oswald-interpolation.hh
+++ b/dune/gdt/operators/oswald-interpolation.hh
@@ -177,9 +177,10 @@ public:
     auto local_source = source_function.local_function();
     DynamicVector<size_t> global_DoF_indices(range_space_.mapper().max_local_size());
     // clear range on those DoFs associated with assembly_grid_view_ individually
-    // (might only be a subset, range *= 0 would clear too much)
-    for (const auto& DoF_id : global_DoF_id_to_global_LP_id_map_)
-      if (DoF_id != std::numeric_limits<size_t>::max())
+    // (might only be a subset, range *= 0 would clear too much); the map is indexed by global DoF id and its values
+    // are global Lagrange point ids, so we have to iterate over the indices here, not over the values
+    for (size_t DoF_id = 0; DoF_id < global_DoF_id_to_global_LP_id_map_.size(); ++DoF_id)
+      if (global_DoF_id_to_global_LP_id_map_[DoF_id] != std::numeric_limits<size_t>::max())
         range_vector[DoF_id] = 0;
     // walk the grid to average on all inner Lagrange points
     auto range_basis = range_space_.basis().localize();

--- a/dune/gdt/test/operators/oswald_interpolation_prefilled_range.cc
+++ b/dune/gdt/test/operators/oswald_interpolation_prefilled_range.cc
@@ -1,0 +1,56 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/xt/grid/boundaryinfo/allneumann.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/interpolations/default.hh>
+#include <dune/gdt/operators/oswald-interpolation.hh>
+#include <dune/gdt/spaces/l2/discontinuous-lagrange.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using I = XT::Grid::extract_intersection_t<GV>;
+using V = XT::LA::IstlDenseVector<double>;
+
+
+/// The operator documents that it clears exactly those range DoFs associated with its assembly grid view (so that a
+/// range vector may be reused/prefilled). The clearing loop used to iterate over the *values* of the DoF-to-Lagrange-
+/// point map (i.e. Lagrange point ids) instead of its indices (DoF ids), so it zeroed the wrong entries and stale
+/// values survived in the result.
+GTEST_TEST(OswaldInterpolationOperator, clears_prefilled_range_vectors)
+{
+  auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 8u);
+  auto grid_view = grid_provider.leaf_view();
+  const auto space = make_discontinuous_lagrange_space(grid_view, /*order=*/1);
+  const XT::Grid::AllNeumannBoundaryInfo<I> boundary_info;
+  OswaldInterpolationOperator<GV> oswald_interpolation(grid_view, space, boundary_info);
+  oswald_interpolation.assemble();
+
+  // a discontinuous source
+  const auto source =
+      default_interpolation<V>(0, [](const auto& xx, const auto& /*mu*/) { return xx[0] < 0.5 ? 0. : 1.; }, space);
+
+  // reference: apply into a fresh (zero-initialized) vector
+  V fresh_range(space.mapper().size(), 0.);
+  oswald_interpolation.apply(source, fresh_range);
+
+  // the same apply into a prefilled vector has to yield the same result
+  V prefilled_range(space.mapper().size(), 777.);
+  oswald_interpolation.apply(source, prefilled_range);
+
+  for (size_t ii = 0; ii < space.mapper().size(); ++ii)
+    EXPECT_DOUBLE_EQ(prefilled_range[ii], fresh_range[ii]) << "ii = " << ii;
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

`OswaldInterpolationOperator::apply` (`dune/gdt/operators/oswald-interpolation.hh`) deliberately clears only those range DoFs associated with its assembly grid view — the comment explains that `range *= 0` "would clear too much" when the range vector covers a larger space. But the clearing loop

```cpp
for (const auto& DoF_id : global_DoF_id_to_global_LP_id_map_)
  if (DoF_id != std::numeric_limits<size_t>::max())
    range_vector[DoF_id] = 0;
```

iterates over the **values** of the map (global Lagrange-point ids, despite the variable name) instead of its **indices** (global DoF ids). It therefore zeroes the first `cg_size` entries of the vector instead of the DG DoFs of the assembly grid view: stale values survive in any reused/prefilled range vector (`stale + average` after the subsequent `+=`), and for subset grid views the wrong subset is cleared — defeating exactly the use case the careful clearing was written for. (No out-of-bounds access, since cg_size ≤ dg_size.)

Every in-repo caller passes a freshly zero-initialized vector, which is why this stayed invisible to the existing `operators_oswald_interpolation__*` tests and the ESV2007 study.

## The fix

Iterate over the indices:

```cpp
for (size_t DoF_id = 0; DoF_id < global_DoF_id_to_global_LP_id_map_.size(); ++DoF_id)
  if (global_DoF_id_to_global_LP_id_map_[DoF_id] != std::numeric_limits<size_t>::max())
    range_vector[DoF_id] = 0;
```

## The test

`dune/gdt/test/operators/oswald_interpolation_prefilled_range.cc` applies the assembled operator to a discontinuous source once into a fresh vector and once into a vector prefilled with `777.` and requires identical results.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_