### PR TITLE
Fix theta wrongly scaling the consistency flux in the IPDG flux reconstruction

### DIFF
--- a/dune/gdt/operators/laplace-ipdg-flux-reconstruction.hh
+++ b/dune/gdt/operators/laplace-ipdg-flux-reconstruction.hh
@@ -226,13 +226,16 @@ public:
                                          * (rt_basis_values[local_key_index] * normal)
                                          * intersection_Pk_basis_values[jj]);
                 }
+                // The numerical flux of the theta-IPDG family is theta-independent (the symmetry prefactor only
+                // weights the symmetry term {K grad(v)}[u], which contributes to the potential, not to the flux),
+                // see e.g. [Arnold, Brezzi, Cockburn, Marini, 2002] or [Ern, Stephansen, Vohralik, 2010]:
+                // t_h . n = -{K grad(u_h)}_omega . n + penalty [u_h]
                 for (size_t jj = 0; jj < intersection_Pk_basis.size(); ++jj)
                   rhs[jj] += quadrature_weight * integration_factor
                              * (penalty * (source_value_element - source_value_neighbor)
-                                - symmetry_prefactor_
-                                      * (normal
-                                         * (weight_minus * (diffusion_element * source_grad_element)
-                                            + weight_plus * (diffusion_neighbor * source_grad_neighbor))))
+                                - (normal
+                                   * (weight_minus * (diffusion_element * source_grad_element)
+                                      + weight_plus * (diffusion_neighbor * source_grad_neighbor))))
                              * intersection_Pk_basis_values[jj];
               }
             } else {
@@ -279,10 +282,10 @@ public:
                                    quadrature_weight * integration_factor * (rt_basis_values[local_key_index] * normal)
                                        * intersection_Pk_basis_values[jj]);
               }
+              // as on inner intersections: the numerical flux is theta-independent
               for (size_t jj = 0; jj < intersection_Pk_basis.size(); ++jj)
                 rhs[jj] += quadrature_weight * integration_factor
-                           * (penalty * source_value_element
-                              - symmetry_prefactor_ * (normal * (diffusion_element * source_grad_element)))
+                           * (penalty * source_value_element - (normal * (diffusion_element * source_grad_element)))
                            * intersection_Pk_basis_values[jj];
             }
           }

--- a/dune/gdt/test/operators/laplace_ipdg_flux_reconstruction_theta.cc
+++ b/dune/gdt/test/operators/laplace_ipdg_flux_reconstruction_theta.cc
@@ -1,0 +1,95 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/xt/common/float_cmp.hh>
+#include <dune/xt/functions/grid-function.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/gdt/interpolations/default.hh>
+#include <dune/gdt/operators/laplace-ipdg-flux-reconstruction.hh>
+#include <dune/gdt/spaces/hdiv/raviart-thomas.hh>
+#include <dune/gdt/spaces/l2/discontinuous-lagrange.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using E = XT::Grid::extract_entity_t<GV>;
+using V = XT::LA::IstlDenseVector<double>;
+
+
+/// For u_h(x) = x_0 (globally continuous, all jumps vanish) and K = I the reconstructed diffusive flux on inner
+/// faces has to be t_h . n = -{K grad(u_h)} . n = -n_0, independently of the symmetry prefactor theta of the IPDG
+/// variant: in the unified flux framework [Arnold, Brezzi, Cockburn, Marini, 2002] the numerical flux is
+/// sigma_hat = {K grad(u_h)}_omega - penalty/h [u_h] n for SIPDG (theta=1), IIPDG (theta=0) and NIPDG (theta=-1)
+/// alike; theta only enters the symmetry term {K grad(v)}[u]. The reconstruction used to multiply the consistency
+/// part by theta, yielding a zero flux for theta=0 and a sign-flipped flux for theta=-1.
+struct LaplaceIpdgFluxReconstructionThetaTest : public ::testing::Test
+{
+  void check_reconstructed_face_fluxes(const double symmetry_prefactor)
+  {
+    auto grid_provider = XT::Grid::make_cube_grid<G>(0., 1., 2u);
+    auto grid_view = grid_provider.leaf_view();
+    const auto dg_space = make_discontinuous_lagrange_space(grid_view, /*order=*/1);
+    const auto rt_space = make_raviart_thomas_space(grid_view, /*order=*/0);
+    const auto u_h = default_interpolation<V>(1, [](const auto& xx, const auto& /*mu*/) { return xx[0]; }, dg_space);
+    LaplaceIpdgFluxReconstructionOperator<GV> reconstruction(grid_view,
+                                                             rt_space,
+                                                             symmetry_prefactor,
+                                                             /*inner_penalty=*/8.,
+                                                             /*dirichlet_penalty=*/14.,
+                                                             /*diffusion=*/{1.});
+    const auto t_h = reconstruction.apply(u_h);
+    auto local_t_h = t_h.local_function();
+    size_t num_checked_inner_faces = 0;
+    size_t num_checked_boundary_faces = 0;
+    for (auto&& element : elements(grid_view)) {
+      local_t_h->bind(element);
+      for (auto&& intersection : intersections(grid_view, element)) {
+        // for RT_0 on axis-aligned cubes, t_h . n at the face center equals the face DoF
+        const auto face_center = intersection.geometry().center();
+        const auto value = local_t_h->evaluate(element.geometry().local(face_center));
+        const auto normal = intersection.centerUnitOuterNormal();
+        if (intersection.neighbor()) {
+          // inner faces: their DoFs are determined by the inner-face equations only (no boundary penalty here)
+          EXPECT_NEAR(value * normal, -normal[0], 1e-12)
+              << "face center = " << face_center << ", symmetry_prefactor = " << symmetry_prefactor;
+          ++num_checked_inner_faces;
+        } else if (XT::Common::FloatCmp::eq(face_center[0], 0.)) {
+          // Dirichlet faces on x_0 = 0, where u_h vanishes: the boundary penalty term penalty/h * u_h drops out and
+          // the (theta-independent) consistency term alone determines the face DoF, t_h . n = -grad(u_h) . n = -n_0
+          EXPECT_NEAR(value * normal, -normal[0], 1e-12)
+              << "face center = " << face_center << ", symmetry_prefactor = " << symmetry_prefactor;
+          ++num_checked_boundary_faces;
+        }
+      }
+    }
+    EXPECT_EQ(num_checked_inner_faces, 8); // 4 inner faces on the 2x2 grid, each visited from both sides
+    EXPECT_EQ(num_checked_boundary_faces, 2); // 2 boundary faces on x_0 = 0
+  } // ... check_reconstructed_face_fluxes(...)
+}; // struct LaplaceIpdgFluxReconstructionThetaTest
+
+
+TEST_F(LaplaceIpdgFluxReconstructionThetaTest, sipdg)
+{
+  check_reconstructed_face_fluxes(1.);
+}
+
+TEST_F(LaplaceIpdgFluxReconstructionThetaTest, iipdg)
+{
+  check_reconstructed_face_fluxes(0.); // <- the reconstructed flux used to vanish entirely
+}
+
+TEST_F(LaplaceIpdgFluxReconstructionThetaTest, nipdg)
+{
+  check_reconstructed_face_fluxes(-1.); // <- the reconstructed flux used to point in the wrong direction
+}


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

The diffusive numerical flux of the θ-IPDG family is **θ-independent**: in the unified framework of [Arnold, Brezzi, Cockburn, Marini, 2002] (and in [Ern, Stephansen, Vohralík, 2010], whose weighted averages this operator implements) the flux is

```
σ̂ = {K∇u_h}_ω − (penalty/h)·[u_h]·n
```

for SIPDG (θ = 1), IIPDG (θ = 0) and NIPDG (θ = −1) alike; θ only weights the symmetry term `{K∇v}[u]`, which contributes to the *potential* trace û, not to the flux. Local conservation says the same: testing the IPDG bilinear form with the indicator of an element kills the θ-term (∇v ≡ 0), leaving the θ-free flux balance.

`LaplaceIpdgFluxReconstructionOperator` (`dune/gdt/operators/laplace-ipdg-flux-reconstruction.hh`) multiplied the consistency part `−{K∇u_h}_ω·n` of its right-hand side by `symmetry_prefactor_` on inner **and** boundary faces. Concretely, for u_h(x) = x₀ (continuous, [u] = 0) and K = I the reconstructed flux is `0` instead of `−n₀` for IIPDG and `+n₀` (sign-flipped!) for NIPDG — the a posteriori quantities η_DF/η_R built from t_h are meaningless for any θ ≠ 1, and ∇·t_h no longer balances f.

**Why no test caught it:** the ESV2007 regression test (`stationary_heat_equation__ESV2007__table_1`) only runs θ = 1, where the wrong factor is a no-op.

## The fix

Drop the `symmetry_prefactor_` factor from the consistency part of the face right-hand sides (inner and Dirichlet); the member and constructor parameter stay (θ remains meaningful for the discretization the reconstruction belongs to).

## The test

`dune/gdt/test/operators/laplace_ipdg_flux_reconstruction_theta.cc` reconstructs the flux of u_h(x) = x₀ on a 2×2 grid for θ ∈ {1, 0, −1} and checks `t_h·n = −n₀` at all inner face centers (for RT₀ on axis-aligned cubes the face-center normal trace equals the face DoF, which is determined by the inner-face equations alone, so the g = 0 boundary-penalty convention does not enter). θ = 0 and θ = −1 fail before the fix; θ = 1 pins the previously correct behavior.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved flux reconstruction calculations on interior and boundary intersections by removing redundant symmetry adjustments, ensuring consistent and accurate results across different discretization variants.

* **Tests**
  * Introduced new test suite validating flux reconstruction behavior across multiple numerical schemes, verifying correct flux computation at interior face intersections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->