### PR TITLE
Fix ExplicitRungeKuttaTimeStepper::find_suitable_dt (did not compile)

### DIFF
--- a/dune/gdt/discretefunction/default-datahandle.hh
+++ b/dune/gdt/discretefunction/default-datahandle.hh
@@ -50,7 +50,9 @@ public:
   }
 
   //! returns true if size per entity of given dim and codim is a constant
-  bool fixedsize(int /*dim*/, int /*codim*/) const
+  //! \note has to be spelled fixedSize: CommDataHandleIF dispatches via CRTP and its default implementation calls
+  //!       asImp().fixedSize(...), so a misspelled override recurses infinitely (stack overflow) when communicating
+  bool fixedSize(int /*dim*/, int /*codim*/) const
   {
     return fixed_size_;
   }

--- a/dune/gdt/test/misc/timestepper_explicit_rungekutta.cc
+++ b/dune/gdt/test/misc/timestepper_explicit_rungekutta.cc
@@ -1,0 +1,79 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <cmath>
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/operators/identity.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+#include <dune/gdt/tools/timestepper/explicit-rungekutta.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_1D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using OperatorType = IdentityOperator<GV>;
+using V = typename OperatorType::VectorType;
+using DF = DiscreteFunction<V, GV>;
+
+
+/// Solves u' = -u, u(0) = 1 (via the identity operator L(u) = u and the scalar factor r = -1) up to T = 1 and
+/// compares against the exact solution exp(-1).
+struct ExplicitRungeKuttaTimeStepperTest : public ::testing::Test
+{
+  void SetUp() override
+  {
+    grid_provider_ = std::make_unique<XT::Grid::GridProvider<G>>(XT::Grid::make_cube_grid<G>(0., 1., 4u));
+    space_ = std::make_unique<FiniteVolumeSpace<GV>>(grid_provider_->leaf_view());
+    op_ = std::make_unique<OperatorType>(*space_);
+  }
+
+  template <TimeStepperMethods method>
+  double solve_exponential_decay(const double dt)
+  {
+    DF initial_values(*space_);
+    for (size_t ii = 0; ii < space_->mapper().size(); ++ii)
+      initial_values.dofs().vector()[ii] = 1.; // u(0) = 1
+    ExplicitRungeKuttaTimeStepper<OperatorType, DF, method> stepper(*op_, initial_values, /*r=*/-1.);
+    stepper.solve(/*t_end=*/1., dt, /*num_save_steps=*/size_t(-1), /*num_output_steps=*/0);
+    return stepper.current_solution().dofs().vector()[0];
+  }
+
+  std::unique_ptr<XT::Grid::GridProvider<G>> grid_provider_;
+  std::unique_ptr<FiniteVolumeSpace<GV>> space_;
+  std::unique_ptr<OperatorType> op_;
+}; // struct ExplicitRungeKuttaTimeStepperTest
+
+
+TEST_F(ExplicitRungeKuttaTimeStepperTest, methods_converge_with_their_order)
+{
+  const double exact = std::exp(-1.);
+  EXPECT_NEAR(solve_exponential_decay<TimeStepperMethods::explicit_euler>(1e-3), exact, 2e-4);
+  EXPECT_NEAR(solve_exponential_decay<TimeStepperMethods::explicit_rungekutta_second_order_ssp>(1e-2), exact, 1e-5);
+  EXPECT_NEAR(solve_exponential_decay<TimeStepperMethods::explicit_rungekutta_third_order_ssp>(1e-2), exact, 1e-7);
+  EXPECT_NEAR(solve_exponential_decay<TimeStepperMethods::explicit_rungekutta_classic_fourth_order>(1e-2), exact, 1e-9);
+}
+
+/// find_suitable_dt used to call step() with a single argument (step takes the time step length and the maximal
+/// admissible time step length), so this did not even compile when instantiated.
+TEST_F(ExplicitRungeKuttaTimeStepperTest, find_suitable_dt_compiles_and_accepts_stable_dt)
+{
+  DF initial_values(*space_);
+  for (size_t ii = 0; ii < space_->mapper().size(); ++ii)
+    initial_values.dofs().vector()[ii] = 1.;
+  ExplicitRungeKuttaTimeStepper<OperatorType, DF, TimeStepperMethods::explicit_euler> stepper(
+      *op_, initial_values, /*r=*/-1.);
+  const auto result = stepper.find_suitable_dt(/*initial_dt=*/0.1);
+  EXPECT_TRUE(result.first);
+  EXPECT_DOUBLE_EQ(result.second, 0.1);
+}

--- a/dune/gdt/tools/timestepper/explicit-rungekutta.hh
+++ b/dune/gdt/tools/timestepper/explicit-rungekutta.hh
@@ -231,7 +231,7 @@ public:
    * \brief Constructor ignoring the tol argument for compatibility with AdaptiveRungeKuttaTimeStepper
    */
   ExplicitRungeKuttaTimeStepper(const OperatorType& op,
-                                const DiscreteFunctionType& initial_values,
+                                DiscreteFunctionType& initial_values,
                                 const RangeFieldType r,
                                 const double t_0,
                                 const RangeFieldType /*tol*/)
@@ -282,8 +282,8 @@ public:
     auto& t = current_time();
     auto& u_n = current_solution();
     assert(treshold > 0);
-    // save current state
-    DiscreteFunctionType initial_u_n = u_n;
+    // save current state (DiscreteFunction's copy constructor is deleted)
+    const auto initial_u_n = u_n.copy_as_discrete_function();
     RangeFieldType initial_t = t;
     // start with initial dt
     RangeFieldType current_dt = initial_dt;
@@ -294,7 +294,7 @@ public:
       size_t num_steps = 0;
       // do max_steps_per_dt time steps...
       while (!unlikely_value_occured) {
-        step(current_dt);
+        step(current_dt, current_dt);
         ++num_steps;
         // ... unless there is a value above threshold
         for (size_t kk = 0; kk < u_n.dofs().vector().size(); ++kk) {
@@ -307,13 +307,13 @@ public:
         // if we are able to do max_steps_per_dt time steps with this dt, we accept this dt
         if (num_steps == max_steps_per_dt) {
           std::cout << "looks fine" << std::endl;
-          u_n.dofs().vector() = initial_u_n.dofs().vector();
+          u_n.dofs().vector() = initial_u_n->dofs().vector();
           t = initial_t;
           return std::make_pair(bool(true), current_dt);
         }
       }
       // if there was a value above threshold start over with smaller dt
-      u_n.dofs().vector() = initial_u_n.dofs().vector();
+      u_n.dofs().vector() = initial_u_n->dofs().vector();
       t = initial_t;
       current_dt /= dt_refinement_factor;
       ++num_refinements;


### PR DESCRIPTION
Part of a review of the numerical schemes under `dune/` (one targeted PR per problem).

## The problem

Three latent defects, all in code that nothing in the repository instantiated before the new test:

1. **`find_suitable_dt` did not compile**: it called `step(current_dt)`, but `step()` takes two arguments (the time step length and the maximal admissible step length) and there is no one-argument overload or default. It now passes `current_dt` for both.
2. **More non-compiling state handling in the same method**: it saved the current state via `DiscreteFunctionType initial_u_n = u_n;` — `DiscreteFunction`'s copy constructor is deleted. It now uses `copy_as_discrete_function()`. The compatibility constructor taking a `tol` argument likewise delegated a *const* reference to the main constructor, which requires a mutable one; its parameter is now non-const.
3. **Every `communicate` in `step()` crashed with a stack overflow**: `DiscreteFunctionDataHandle` still spells the `CommDataHandleIF` method `fixedsize`, which dune-grid renamed to `fixedSize`. The interface dispatches via CRTP and its default implementation calls `asImp().fixedSize(...)`, so with the misspelled override the call recursed infinitely — the explicit stepper communicates its stages in every step, so any actual use of the stepper segfaulted immediately (caught by this PR's CI run: `test_timestepper_explicit_rungekutta ***Exception: SegFault`). The same misspelling exists at `dune/gdt/spaces/parallel/datahandles.hh:171` and `:683`; those handles are not exercised by any test and are left for a separate change.

## The test

`dune/gdt/test/misc/timestepper_explicit_rungekutta.cc` is the first test to instantiate and run the explicit Runge-Kutta steppers at all. It solves u' = −u up to T = 1 (identity operator, r = −1) and checks the result against exp(−1) within the accuracy expected of each method's order — explicit Euler, SSP2, SSP3 and classic RK4, which validates the Butcher tableaus — and calls `find_suitable_dt`. The solve exercises the DoF data handle in every time step, so the test covers all three fixes.

https://claude.ai/code/session_01Y7KJSzR6ei1J6UJUuVc4pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests verifying explicit Runge–Kutta methods converge with expected orders and that adaptive time-step discovery accepts and returns a stable step.

* **Bug Fixes**
  * Fixed state restoration and time-stepping invocation so rollbacks and step constraints behave correctly.

* **Changed Behavior**
  * Constructor now accepts mutable initial state (non-const reference), affecting how initial values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->