### PR TITLE
docs: require clangquill>=0.3.0 and group C++ API by class

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,7 +149,10 @@ clangquill_include_dirs = ["../.."]
 clangquill_std = "c++17"
 clangquill_clang_resource_dir = _clang_resource_dir()
 clangquill_output_dir = "cpp_api"
-clangquill_group_by = "file"
+# Group at class granularity (clangquill >= 0.3.0): descend through namespaces so
+# a single huge dune::{gdt,xt} namespace becomes one page per member class. This
+# keeps Sphinx's C++ domain resolver fast and gives each class its own URL.
+clangquill_group_by = "class"
 # Emit every symbol clangquill extracts, including the (largely templated)
 # undocumented internals, so the C++ API pages cover all in-tree headers rather
 # than only those carrying a documentation comment.

--- a/python/xt/setup.py.in
+++ b/python/xt/setup.py.in
@@ -31,7 +31,7 @@ visualization_packages = [ 'k3d>=2.15.2', 'vtk', 'ipywidgets', 'lxml', 'xmljson'
 # clangquill parses the in-tree dune-gdt/dune-xt C++ headers with libclang and
 # renders the MyST C++ API pages consumed by the Sphinx build (see
 # docs/source/conf.py); it replaces the previous Doxygen-based API setup.
-docs_packages = ['python-slugify', 'sphinxcontrib-bibtex', 'furo', 'myst-nb>=0.16', 'pymor', 'clangquill>=0.1.1', 'plotly',
+docs_packages = ['python-slugify', 'sphinxcontrib-bibtex', 'furo', 'myst-nb>=0.16', 'pymor', 'clangquill>=0.3.0', 'plotly',
                  # meshio is required by pymor's discretize_gmsh (used in the gmsh tutorial)
                  # to read Gmsh meshes, and the tutorial uses it to re-write a dune-grid
                  # readable version 2.2 mesh


### PR DESCRIPTION
## Summary

Adopts [clangquill v0.3.0](https://github.com/renefritze/clangquill/releases/tag/v0.3.0) and switches the C++ API documentation to its new class-granularity grouping.

- Bump the `clangquill` docs dependency from `>=0.1.1` to `>=0.3.0` (`python/xt/setup.py.in`).
- Set `clangquill_group_by = "class"` (was `"file"`) in `docs/source/conf.py`.

## Why

The new `group_by="class"` mode (introduced in v0.3.0) descends through namespaces so that a single huge namespace like `dune::gdt` / `dune::xt` is split into one page per member class instead of one giant namespace page. This keeps Sphinx's C++ domain resolver fast and gives each class its own URL.

https://claude.ai/code/session_01VXnHawPdAUsZQgyQrYV2Hu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXnHawPdAUsZQgyQrYV2Hu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * C++ API documentation is now organized by class instead of file, with each member class displayed as its own documentation page.

* **Chores**
  * Updated minimum version requirement for a project dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->