### PR TITLE
timestepper: accept const-ref initial values (copy internally)

### DIFF
--- a/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
+++ b/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
@@ -189,7 +189,8 @@ public:
   /**
    * \brief Constructor for AdaptiveRungeKuttaTimeStepper time stepper
    * \param op Operator L
-   * \param initial_values Discrete function containing initial values for u at time t_0.
+   * \param initial_values Discrete function containing initial values for u at time t_0. The values are copied; the
+   *        passed function is not modified. The evolved state is available via current_solution().
    * \param r Scalar factor (see above, default is 1)
    * \param t_0 Initial time (default is 0)
    * \param tol Error tolerance for the adaptive scheme (default is 1e-4)
@@ -201,7 +202,7 @@ public:
    * \param c Coefficients for time steps (only provide if you use AdaptiveRungeKuttaMethods::other)
    */
   AdaptiveRungeKuttaTimeStepper(const OperatorType& op,
-                                DiscreteFunctionType& initial_values,
+                                const DiscreteFunctionType& initial_values,
                                 const RangeFieldType r = 1.0,
                                 const double t_0 = 0.0,
                                 const RangeFieldType tol = 1e-4,

--- a/dune/gdt/tools/timestepper/explicit-rungekutta.hh
+++ b/dune/gdt/tools/timestepper/explicit-rungekutta.hh
@@ -188,7 +188,8 @@ public:
   /**
    * \brief Constructor for RungeKutta time stepper
    * \param op Operator L
-   * \param initial_values Discrete function containing initial values for u at time t_0.
+   * \param initial_values Discrete function containing initial values for u at time t_0. The values are copied; the
+   *        passed function is not modified. The evolved state is available via current_solution().
    * \param r Scalar factor (see above, default is 1)
    * \param t_0 Initial time (default is 0)
    * \param A Coefficient matrix (only provide if you use ExplicitRungeKuttaMethods::other)
@@ -196,7 +197,7 @@ public:
    * \param c Coefficients for time steps (only provide if you use ExplicitRungeKuttaMethods::other)
    */
   ExplicitRungeKuttaTimeStepper(const OperatorType& op,
-                                DiscreteFunctionType& initial_values,
+                                const DiscreteFunctionType& initial_values,
                                 const RangeFieldType r = 1.0,
                                 const double t_0 = 0.0,
                                 const MatrixType& A = ButcherArrayProviderType::A(),

--- a/dune/gdt/tools/timestepper/interface.hh
+++ b/dune/gdt/tools/timestepper/interface.hh
@@ -88,8 +88,15 @@ private:
   using SolutionStorageProviderType = typename Dune::XT::Common::StorageProvider<DiscreteSolutionType>;
 
 protected:
-  TimeStepperInterface(const RangeFieldType t_0, DiscreteFunctionType& initial_values)
-    : CurrentSolutionStorageProviderType(initial_values)
+  /**
+   * \note The initial values are copied: the time stepper evolves its own internal copy in place and never modifies
+   *       the discrete function passed in here. Obtain the evolved state via current_solution().
+   */
+  TimeStepperInterface(const RangeFieldType t_0, const DiscreteFunctionType& initial_values)
+    // own a mutable copy: the stepper evolves u_n_ in place, so it must not alias the caller's (const) data. We cannot
+    // use initial_values.copy_as_discrete_function() here, as its const overload yields an immutable ConstDiscreteFunction.
+    : CurrentSolutionStorageProviderType(
+          new DiscreteFunctionType(initial_values.space(), initial_values.dofs().vector().copy()))
     , SolutionStorageProviderType(new DiscreteSolutionType())
     , t_(t_0)
     , u_n_(&CurrentSolutionStorageProviderType::access())

--- a/dune/gdt/tools/timestepper/interface.hh
+++ b/dune/gdt/tools/timestepper/interface.hh
@@ -94,7 +94,8 @@ protected:
    */
   TimeStepperInterface(const RangeFieldType t_0, const DiscreteFunctionType& initial_values)
     // own a mutable copy: the stepper evolves u_n_ in place, so it must not alias the caller's (const) data. We cannot
-    // use initial_values.copy_as_discrete_function() here, as its const overload yields an immutable ConstDiscreteFunction.
+    // use initial_values.copy_as_discrete_function() here, as its const overload yields an immutable
+    // ConstDiscreteFunction.
     : CurrentSolutionStorageProviderType(
           new DiscreteFunctionType(initial_values.space(), initial_values.dofs().vector().copy()))
     , SolutionStorageProviderType(new DiscreteSolutionType())


### PR DESCRIPTION
## What

Makes the time stepper constructors accept the initial data by `const` reference:

- `TimeStepperInterface(const RangeFieldType, const DiscreteFunctionType&)`
- `ExplicitRungeKuttaTimeStepper(..., const DiscreteFunctionType& initial_values, ...)`
- `AdaptiveRungeKuttaTimeStepper(..., const DiscreteFunctionType& initial_values, ...)`

`FractionalTimeStepper` / `StrangSplittingTimeStepper` need no signature change.

## Why this requires a semantics change

The stepper evolves its *current solution* in place. Previously it aliased the caller's `initial_values` **by reference** (`StorageProvider`'s `AccessByReference`), which is exactly why the constructor needed a mutable `DiscreteFunctionType&` — the solve loop wrote the evolving state straight back into the caller's buffer.

To accept a `const&` the stepper can no longer alias the caller's data, so the base now **owns a mutable copy** of the initial values (`StorageProvider`'s `AccessByPointer`) and evolves that. Net effect:

- The discrete function passed to the constructor is **never modified**.
- The evolved state is read via `current_solution()` — which is how every existing call site (including the test added in #199) already reads results.

No code in the repository relies on the old in-place mutation of the passed `initial_values`, so this is safe in-tree. A `const&` also strictly widens what the constructors accept (mutable lvalues still bind; temporaries now bind too).

## Implementation note

The copy is built from the space and a copy of the DoF vector:

```cpp
new DiscreteFunctionType(initial_values.space(), initial_values.dofs().vector().copy())
```

`initial_values.copy_as_discrete_function()` is deliberately **not** used: on a `const` object its overload returns an immutable `ConstDiscreteFunction`, which would not bind to `StorageProvider<DiscreteFunction>`.

## Relationship to #199

This is the **opposite direction** to #199, which resolved the `ExplicitRungeKuttaTimeStepper` compatibility-constructor const-mismatch by making everything *non-const*. Here the same mismatch is resolved by making everything *const* instead. The two approaches conflict on the ERK compatibility constructor; this PR is offered as the const-correct alternative.

This PR is scoped to the const-ref change only. The other latent defects #199 addresses (`find_suitable_dt` calling the one-arg `step()`, its deleted-copy-constructor state save, and the `fixedsize`→`fixedSize` data-handle fix) are left to #199.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NP9jLqENmC3WW6yQ5MJrG2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Time stepper constructors now require const references for initial values, clarifying that input data is copied internally and not modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->