### PR TITLE
Address SonarCloud security findings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Limit what `COPY . /src/` pulls into the build image (SonarCloud docker:S6470).
+# Keep version-control metadata, local build trees, caches and any credentials
+# out of the image context.
+.git
+.github
+**/build
+**/build-*
+**/*.o
+**/*.so
+**/*.pyc
+**/__pycache__
+.ccache
+.vcpkg-root
+*.key
+*.pem
+id_rsa*
+.env

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -14,18 +14,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least-privilege default for the whole workflow: every job gets read-only access
-# to repo contents unless it overrides this. The jobs that need more declare it
-# explicitly (deploy_docs: pages/id-token write; test_publish/publish: id-token
-# write for PyPI Trusted Publishing).
-permissions:
-  contents: read
+# Permissions are declared per job (least privilege) rather than at workflow level,
+# as recommended by SonarCloud rule githubactions:S8264. The build jobs only need
+# read access to repo contents; deploy_docs and test_publish/publish declare the
+# extra scopes they require (pages / id-token write for Trusted Publishing).
 
 jobs:
   build-linux:
     name: Build on Linux
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    permissions:
+      contents: read
     env:
       # Compiler-level cache. Unlike the build/ cache (keyed on the vcpkg/preset
       # hash), the ccache survives manifest changes and partial rebuilds, so the
@@ -146,6 +146,8 @@ jobs:
     name: Build wheels
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.13"] #, "3.9", "3.10", "3.11", "3.12"]
@@ -180,6 +182,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build_wheels
     timeout-minutes: 60
+    permissions:
+      contents: read
     env:
       # the documentation notebooks are executed against the freshly built wheels
       # (current, git-derived version), not the stale dune-gdt release on PyPI

--- a/python/xt/dune/xt/cmake.py
+++ b/python/xt/dune/xt/cmake.py
@@ -37,5 +37,11 @@ def parse_cache(filepath):
 
 
 if __name__ == "__main__":
-    kv, types = parse_cache("/tmp/CMakeCache.txt")
+    import sys
+
+    # Read the cache path from the command line (default to the CMakeCache.txt in
+    # the current build directory). Avoids reading from a hardcoded, publicly
+    # writable location such as /tmp (SonarCloud python:S5443).
+    cache_file = sys.argv[1] if len(sys.argv) > 1 else "CMakeCache.txt"
+    kv, types = parse_cache(cache_file)
     pprint.pprint(kv)

--- a/python/xt/dune/xt/common/vtk/plot.py
+++ b/python/xt/dune/xt/common/vtk/plot.py
@@ -23,13 +23,13 @@ if config.HAVE_K3D:
     from ipywidgets import IntSlider, Play, interact, widgets
     from k3d.helpers import minmax
     from k3d.plot import Plot as k3dPlot
-    from matplotlib.cm import get_cmap
+    from matplotlib import colormaps
     from matplotlib.colors import Colormap
     from vtk.util import numpy_support
 
     from .reader import read_vtkfile
 
-    DEFAULT_COLOR_MAP = get_cmap("viridis")
+    DEFAULT_COLOR_MAP = colormaps["viridis"]
 
     def _transform_to_k3d(timestep, poly_data, color_attribute_name):
         """

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+# SonarCloud project configuration.
+#
+# Exclude vendored third-party sources from analysis. These files are not
+# maintained by dune-gdt and their findings (e.g. cpp:S6069 sprintf, cpp:S5813
+# buffer handling) are upstream concerns:
+#   - mathexpr.{cc,hh}: math expression parser, Copyright Yann Ollivier 1997-2000
+#   - dune/xt/test/gtest/**: bundled GoogleTest
+#
+# The same exclusion is also configured on the SonarCloud project itself so it
+# takes effect under Automatic Analysis; this file keeps it under version control
+# and applies it to CI-based scans.
+sonar.projectKey=dune-gdt_dune-gdt
+sonar.organization=dune-gdt
+
+sonar.exclusions=dune/xt/functions/expression/mathexpr.cc,dune/xt/functions/expression/mathexpr.hh,dune/xt/test/gtest/**


### PR DESCRIPTION
Resolves the **134 security findings** (59 vulnerabilities + 75 security hotspots) reported by SonarCloud for `dune-gdt_dune-gdt`, using the right mechanism for each category rather than blanket suppression.

## The big picture

**115 of 134 findings live in vendored third-party code** we don't maintain:
- `dune/xt/functions/expression/mathexpr.{cc,hh}` — math expression parser (Copyright Yann Ollivier 1997–2000): 55× `cpp:S6069` (sprintf) + 54× `cpp:S5813` (buffer handling) = **109**
- `dune/xt/test/gtest/**` — bundled GoogleTest: **6× `cpp:S5813`**

These are excluded from analysis (committed `sonar-project.properties` **and** set on the SonarCloud project so it also applies under Automatic Analysis).

## Changes in this PR

| Finding | Rule | Fix |
|---|---|---|
| Hardcoded publicly-writable `/tmp/CMakeCache.txt` | `python:S5443` (HIGH) | `cmake.py` now reads the cache path from `argv` |
| Read permission at workflow level | `githubactions:S8264` | `non_docker_build.yml` declares `permissions:` per job; build jobs get `contents: read`, publish jobs keep their explicit scopes |
| Recursive `COPY . /src/` into build image | `docker:S6470` | added `.dockerignore` excluding VCS metadata, build trees, caches, credentials |
| Vendored sprintf / buffer findings (×115) | `cpp:S6069`, `cpp:S5813` | `sonar.exclusions` (file + project setting) |

## Resolved directly on SonarCloud (reviewed → Safe)

Genuine false positives in code we own — done via the SonarCloud API as part of this work, no code change warranted:

- `dune/xt/common/random.hh` ×11 (`cpp:S2245`) — scientific `mt19937` / `default_random_engine` RNG for numerics & tests, not cryptography
- `dune/xt/common/string.hh:203` (`cpp:S5801`) — `strcpy` into a buffer sized `new char[len+1]`; already carried a reviewed `NOLINT`
- `dune/xt/common/debug.hh:34` (`cpp:S5813`) — `strlen` in a bounded `charcopy` helper
- `deps/Dockerfile:4` (`docker:S6471`) — `USER root` required for `apt`/`venv` in a CI build image
- `deps/Dockerfile:27` (`docker:S6470`) — mitigated by the new `.dockerignore`

## Tracked separately

- **#202** — `text:S8565` (×2) missing lock files for `python/{gdt,xt}/pyproject.toml`. These files are autogenerated from `dependencies.py`, so a lock file is a build-pipeline decision rather than a direct edit.

## Out of scope

The ~75 non-security code-smell issues (e.g. `cpp:S1186`, `cpp:S5025`, `python:S117`) are not security findings and are not touched here.

https://claude.ai/code/session_013DQdCM8L4XY5GFB1WXBvrN

---
_Generated by [Claude Code](https://claude.ai/code/session_013DQdCM8L4XY5GFB1WXBvrN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Docker ignore rules to reduce build context (exclude VCS metadata, build artifacts, caches, credentials, env files)
  * Integrated SonarCloud configuration with source exclusions
  * Applied least-privilege CI job permissions (moved from workflow-level to per-job)

* **Improvements**
  * Build tooling now accepts CMake cache path via command-line
  * Updated default plotting colormap handling for visualization consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->