### PR TITLE
ci/cmake: fix intermittent merge-queue configure failure (corrupted dune-env)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -52,6 +52,13 @@ jobs:
           rm -rf build
         fi
 
+    - name: Discard cached dune-env virtualenv
+      # See non_docker_build.yml: a venv reused from the cache can hold a
+      # dune-common Python package that mismatches the current vcpkg wheelhouse
+      # and break configure ("Dune python package could not be found"); configure
+      # recreates it from the current wheelhouse in seconds.
+      run: rm -rf build/*/dune-env
+
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -55,11 +55,9 @@ jobs:
         # Key on the inputs that determine the toolchain/manifest so the cache is
         # rebuilt when they change. The trailing-dash restore-key only matches
         # caches written by this (consistent) scheme, never the legacy build-only one.
-        # The -v2- generation token deliberately invalidates older caches: a cancelled
-        # run left a corrupted dune-env (a half-installed "~une-common" distribution and
-        # conflicting dune-common versions) in the cached build/, which broke configure
-        # ("Dune python package could not be found"). Bump this token to force a clean
-        # rebuild if the cached dune-env is ever poisoned again.
+        # Note the cached dune-env virtualenv is never reused: it is deleted right
+        # after restore (see "Discard cached dune-env virtualenv" below), so a stale
+        # or corrupted venv in the cache cannot break configure.
         key: ${{ runner.os }}-build-v2-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
         restore-keys: |
           ${{ runner.os }}-build-v2-
@@ -71,6 +69,18 @@ jobs:
                "build/ so CMake re-bootstraps vcpkg from scratch."
           rm -rf build
         fi
+
+    - name: Discard cached dune-env virtualenv
+      # The dune-env virtualenv inside build/ must not be reused across runs: a
+      # cached venv can hold a dune-common Python package whose version differs
+      # from the current vcpkg wheelhouse, and the in-configure pip downgrade that
+      # follows is fragile (an interrupted uninstall leaves a half-removed
+      # "~une-common" distribution and a dune package without __main__, failing
+      # configure with "Dune python package could not be found"). Deleting the
+      # venv here makes dune-common's CMake recreate it during configure and
+      # install the wheels from the current wheelhouse — a few seconds of work
+      # that removes this whole class of random merge-queue failures.
+      run: rm -rf build/*/dune-env
 
     - name: Install dependencies
       run: |

--- a/cmake/modules/DuneGdtMacros.cmake
+++ b/cmake/modules/DuneGdtMacros.cmake
@@ -153,14 +153,13 @@ dune_execute_process(
   install
   jinja2
   pyparsing)
-# Install the dune wheels from the vcpkg wheelhouse into the virtualenv. The wheel filenames are
-# globbed (can't use dune-common_WHEELHOUSE here, because it is not set yet) so a vcpkg port bump
-# cannot silently leave this pointing at a wheel that no longer exists. The installs run strictly
-# sequentially, one execute_process each: passing several COMMANDs to a single execute_process
-# runs them as a concurrent pipeline, and two pip processes racing in the same virtualenv corrupt
-# site-packages (half-uninstalled "~une-common" leftovers, BrokenPipeError). --no-index pins the
-# resolution to the wheelhouse: pip can never fall back to PyPI and install a dune-common release
-# that mismatches the vcpkg-built one.
+# Install the dune wheels from the vcpkg wheelhouse into the virtualenv. The wheel filenames are globbed (can't use
+# dune-common_WHEELHOUSE here, because it is not set yet) so a vcpkg port bump cannot silently leave this pointing at a
+# wheel that no longer exists. The installs run strictly sequentially, one execute_process each: passing several
+# COMMANDs to a single execute_process runs them as a concurrent pipeline, and two pip processes racing in the same
+# virtualenv corrupt site-packages (half-uninstalled "~une-common" leftovers, BrokenPipeError). --no-index pins the
+# resolution to the wheelhouse: pip can never fall back to PyPI and install a dune-common release that mismatches the
+# vcpkg-built one.
 set(_dune_wheelhouse ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-linux/share/dune/wheelhouse)
 foreach(_dune_wheel_pkg dune_common dune_testtools)
   file(GLOB _dune_wheel ${_dune_wheelhouse}/${_dune_wheel_pkg}-*.whl)

--- a/cmake/modules/DuneGdtMacros.cmake
+++ b/cmake/modules/DuneGdtMacros.cmake
@@ -160,8 +160,11 @@ dune_execute_process(
 # here, because it is not set yet) so a vcpkg port bump cannot silently leave this pointing at a wheel that no longer
 # exists. The installs run strictly sequentially, one execute_process each: passing several COMMANDs to a single
 # execute_process runs them as a concurrent pipeline, and two pip processes racing in the same virtualenv corrupt
-# site-packages (half-uninstalled "~une-common" leftovers, BrokenPipeError). --no-index pins the resolution to the
-# wheelhouse: pip can never fall back to PyPI and install a dune-common release that mismatches the vcpkg-built one.
+# site-packages (half-uninstalled "~une-common" leftovers, BrokenPipeError). The dune-common version is pinned by
+# installing the exact wheelhouse wheel by path before anything depends on it: pip then never resolves "dune-common" as
+# an abstract requirement (and won't upgrade an already-satisfied one), so it cannot pull a mismatching release from
+# PyPI. --no-index would pin even harder but breaks the install: the wheels' third-party dependencies (portalocker,
+# numpy, ...) are not in the wheelhouse and must come from PyPI.
 if(EXISTS ${CMAKE_BINARY_DIR}/dune-env/bin/python)
   if(NOT VCPKG_TARGET_TRIPLET)
     set(VCPKG_TARGET_TRIPLET x64-linux)
@@ -175,8 +178,7 @@ if(EXISTS ${CMAKE_BINARY_DIR}/dune-env/bin/python)
         FATAL_ERROR "Expected exactly one ${dune_wheel_pkg} wheel in ${_dune_wheelhouse}, found: '${_dune_wheel}'")
     endif()
     execute_process(
-      COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install --no-index --find-links=${_dune_wheelhouse}
-              ${_dune_wheel}
+      COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install --find-links=${_dune_wheelhouse} ${_dune_wheel}
       RESULT_VARIABLE _pip_install_result
       OUTPUT_VARIABLE pip_install_log ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
       ERROR_VARIABLE pip_install_log

--- a/cmake/modules/DuneGdtMacros.cmake
+++ b/cmake/modules/DuneGdtMacros.cmake
@@ -145,8 +145,6 @@ include(DunePybindxiUtils)
 
 # TODO there's no real way to require packages present at configure time? - jinja2,pyparsing is needed for test
 # templating can't use the run-in-env script here, because it will try to use dune.common which we're trying to install
-# can't use dune-common_WHEELHOUSE here, because it is not set yet can't use a wildcard here, because no shell expansion
-# is done
 dune_execute_process(
   COMMAND
   ${CMAKE_BINARY_DIR}/dune-env/bin/python
@@ -155,11 +153,29 @@ dune_execute_process(
   install
   jinja2
   pyparsing)
-execute_process(
-  COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install
-          ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-linux/share/dune/wheelhouse/dune_common-2.10.0-py3-none-any.whl
-  COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install
-          ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-linux/share/dune/wheelhouse/dune_testtools-2.4-py3-none-any.whl
-  OUTPUT_VARIABLE pip_install_log ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
-  ERROR_VARIABLE pip_install_log
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Install the dune wheels from the vcpkg wheelhouse into the virtualenv. The wheel filenames are
+# globbed (can't use dune-common_WHEELHOUSE here, because it is not set yet) so a vcpkg port bump
+# cannot silently leave this pointing at a wheel that no longer exists. The installs run strictly
+# sequentially, one execute_process each: passing several COMMANDs to a single execute_process
+# runs them as a concurrent pipeline, and two pip processes racing in the same virtualenv corrupt
+# site-packages (half-uninstalled "~une-common" leftovers, BrokenPipeError). --no-index pins the
+# resolution to the wheelhouse: pip can never fall back to PyPI and install a dune-common release
+# that mismatches the vcpkg-built one.
+set(_dune_wheelhouse ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-linux/share/dune/wheelhouse)
+foreach(_dune_wheel_pkg dune_common dune_testtools)
+  file(GLOB _dune_wheel ${_dune_wheelhouse}/${_dune_wheel_pkg}-*.whl)
+  list(LENGTH _dune_wheel _dune_wheel_count)
+  if(NOT _dune_wheel_count EQUAL 1)
+    message(FATAL_ERROR "Expected exactly one ${_dune_wheel_pkg} wheel in ${_dune_wheelhouse}, found: '${_dune_wheel}'")
+  endif()
+  execute_process(
+    COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install --no-index --find-links=${_dune_wheelhouse}
+            ${_dune_wheel}
+    RESULT_VARIABLE _pip_install_result
+    OUTPUT_VARIABLE pip_install_log ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
+    ERROR_VARIABLE pip_install_log
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT _pip_install_result EQUAL 0)
+    message(FATAL_ERROR "Installing ${_dune_wheel} into the virtualenv failed:\n${pip_install_log}")
+  endif()
+endforeach()

--- a/cmake/modules/DuneGdtMacros.cmake
+++ b/cmake/modules/DuneGdtMacros.cmake
@@ -161,11 +161,11 @@ dune_execute_process(
 # resolution to the wheelhouse: pip can never fall back to PyPI and install a dune-common release that mismatches the
 # vcpkg-built one.
 set(_dune_wheelhouse ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-linux/share/dune/wheelhouse)
-foreach(_dune_wheel_pkg dune_common dune_testtools)
-  file(GLOB _dune_wheel ${_dune_wheelhouse}/${_dune_wheel_pkg}-*.whl)
+foreach(dune_wheel_pkg dune_common dune_testtools)
+  file(GLOB _dune_wheel ${_dune_wheelhouse}/${dune_wheel_pkg}-*.whl)
   list(LENGTH _dune_wheel _dune_wheel_count)
   if(NOT _dune_wheel_count EQUAL 1)
-    message(FATAL_ERROR "Expected exactly one ${_dune_wheel_pkg} wheel in ${_dune_wheelhouse}, found: '${_dune_wheel}'")
+    message(FATAL_ERROR "Expected exactly one ${dune_wheel_pkg} wheel in ${_dune_wheelhouse}, found: '${_dune_wheel}'")
   endif()
   execute_process(
     COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install --no-index --find-links=${_dune_wheelhouse}

--- a/cmake/modules/DuneGdtMacros.cmake
+++ b/cmake/modules/DuneGdtMacros.cmake
@@ -153,28 +153,42 @@ dune_execute_process(
   install
   jinja2
   pyparsing)
-# Install the dune wheels from the vcpkg wheelhouse into the virtualenv. The wheel filenames are globbed (can't use
-# dune-common_WHEELHOUSE here, because it is not set yet) so a vcpkg port bump cannot silently leave this pointing at a
-# wheel that no longer exists. The installs run strictly sequentially, one execute_process each: passing several
-# COMMANDs to a single execute_process runs them as a concurrent pipeline, and two pip processes racing in the same
-# virtualenv corrupt site-packages (half-uninstalled "~une-common" leftovers, BrokenPipeError). --no-index pins the
-# resolution to the wheelhouse: pip can never fall back to PyPI and install a dune-common release that mismatches the
-# vcpkg-built one.
-set(_dune_wheelhouse ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-linux/share/dune/wheelhouse)
-foreach(dune_wheel_pkg dune_common dune_testtools)
-  file(GLOB _dune_wheel ${_dune_wheelhouse}/${dune_wheel_pkg}-*.whl)
-  list(LENGTH _dune_wheel _dune_wheel_count)
-  if(NOT _dune_wheel_count EQUAL 1)
-    message(FATAL_ERROR "Expected exactly one ${dune_wheel_pkg} wheel in ${_dune_wheelhouse}, found: '${_dune_wheel}'")
+# Install the dune wheels from the vcpkg wheelhouse into the virtualenv. This file runs twice during configure: once
+# when included from the top-level CMakeLists.txt — possibly before dune-common's cmake has created the virtualenv, in
+# which case the installs are skipped — and once as dune-gdt's module-test macros after the virtualenv exists, which is
+# the pass that actually installs into a fresh venv. The wheel filenames are globbed (can't use dune-common_WHEELHOUSE
+# here, because it is not set yet) so a vcpkg port bump cannot silently leave this pointing at a wheel that no longer
+# exists. The installs run strictly sequentially, one execute_process each: passing several COMMANDs to a single
+# execute_process runs them as a concurrent pipeline, and two pip processes racing in the same virtualenv corrupt
+# site-packages (half-uninstalled "~une-common" leftovers, BrokenPipeError). --no-index pins the resolution to the
+# wheelhouse: pip can never fall back to PyPI and install a dune-common release that mismatches the vcpkg-built one.
+if(EXISTS ${CMAKE_BINARY_DIR}/dune-env/bin/python)
+  if(NOT VCPKG_TARGET_TRIPLET)
+    set(VCPKG_TARGET_TRIPLET x64-linux)
   endif()
-  execute_process(
-    COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install --no-index --find-links=${_dune_wheelhouse}
-            ${_dune_wheel}
-    RESULT_VARIABLE _pip_install_result
-    OUTPUT_VARIABLE pip_install_log ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
-    ERROR_VARIABLE pip_install_log
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(NOT _pip_install_result EQUAL 0)
-    message(FATAL_ERROR "Installing ${_dune_wheel} into the virtualenv failed:\n${pip_install_log}")
-  endif()
-endforeach()
+  set(_dune_wheelhouse ${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/share/dune/wheelhouse)
+  foreach(dune_wheel_pkg dune_common dune_testtools)
+    file(GLOB _dune_wheel ${_dune_wheelhouse}/${dune_wheel_pkg}-*.whl)
+    list(LENGTH _dune_wheel _dune_wheel_count)
+    if(NOT _dune_wheel_count EQUAL 1)
+      message(
+        FATAL_ERROR "Expected exactly one ${dune_wheel_pkg} wheel in ${_dune_wheelhouse}, found: '${_dune_wheel}'")
+    endif()
+    execute_process(
+      COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install --no-index --find-links=${_dune_wheelhouse}
+              ${_dune_wheel}
+      RESULT_VARIABLE _pip_install_result
+      OUTPUT_VARIABLE pip_install_log ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
+      ERROR_VARIABLE pip_install_log
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _pip_install_result EQUAL 0)
+      message(FATAL_ERROR "Installing ${_dune_wheel} into the virtualenv failed:\n${pip_install_log}")
+    endif()
+  endforeach()
+  unset(_dune_wheelhouse)
+  unset(_dune_wheel)
+  unset(_dune_wheel_count)
+  unset(_pip_install_result)
+else()
+  message(STATUS "Skipping dune wheel installs, the virtualenv does not exist yet")
+endif()

--- a/python/xt/dune/xt/common/vtk/plot.py
+++ b/python/xt/dune/xt/common/vtk/plot.py
@@ -23,13 +23,13 @@ if config.HAVE_K3D:
     from ipywidgets import IntSlider, Play, interact, widgets
     from k3d.helpers import minmax
     from k3d.plot import Plot as k3dPlot
-    from matplotlib.cm import get_cmap
+    from matplotlib import colormaps
     from matplotlib.colors import Colormap
     from vtk.util import numpy_support
 
     from .reader import read_vtkfile
 
-    DEFAULT_COLOR_MAP = get_cmap("viridis")
+    DEFAULT_COLOR_MAP = colormaps["viridis"]
 
     def _transform_to_k3d(timestep, poly_data, color_attribute_name):
         """


### PR DESCRIPTION
## Problem

Merge-queue runs of *Non-docker Build and Test* intermittently fail at CMake configure with

```
Error extracting static info from dune/xt/test/common/float_cmp.mini
/.../dune-env/bin/python: No module named dune.__main__; 'dune' is a package and cannot be directly executed
Dune python package could not be found.
```

(e.g. [run 27435847326](https://github.com/dune-gdt/dune-gdt/actions/runs/27435847326/job/81097439446), seen on at least two merge-queue runs for #213).

## Root cause

`cmake/modules/DuneGdtMacros.cmake` installed the `dune_common`/`dune_testtools` wheels at configure time with three defects:

1. **Both pip installs were two `COMMAND`s in a single `execute_process`** — CMake runs those as a concurrent *pipeline*: two pip processes raced in the same virtualenv, and the first died with `BrokenPipeError: [Errno 32]` when the second exited without reading its stdin. An interrupted uninstall leaves a half-removed `~une-common` distribution and a `dune` package without `__main__` (both visible in the failing log).
2. **No `--find-links`** — pip could resolve the dune-testtools wheel's `dune-common` dependency from PyPI. The failing run's venv held **dune-common 2.12.0.2** (a PyPI release) while the vcpkg wheelhouse ships **2.10.0**, so every configure ran a fragile in-place downgrade.
3. **Hardcoded wheel filename** (`dune_common-2.10.0-py3-none-any.whl`) — a vcpkg port bump silently breaks the install.

The corrupted/stale venv was then carried between runs by the build cache (`build/` + `.vcpkg-root`); merge-queue runs were hit "randomly" because they restore whichever cache in main's scope was saved last. The earlier `-v2-` cache-key bump only discarded one poisoned cache without preventing the next.

## Fix

**`cmake/modules/DuneGdtMacros.cmake`** (root cause):
- Install the wheels strictly sequentially, one `execute_process` each, skipped on the early include pass before dune-common's CMake has created the virtualenv.
- Resolve wheel filenames by `file(GLOB)` from the wheelhouse (path derived from `VCPKG_TARGET_TRIPLET`) instead of hardcoding versions.
- Pass `--find-links=<wheelhouse>` so the dune-common requirement is satisfied from the wheelhouse; the version is **pinned by construction** because the exact vcpkg-built wheel (whose version the overlay port pins via git REF) is installed by path before anything depends on it. (`--no-index` was tried and reverted: the wheels' third-party deps like portalocker only exist on PyPI.)
- Fail configure loudly (with the pip log) if a wheel is missing or pip fails, instead of carrying on with a broken venv.

**`.github/workflows/non_docker_build.yml`, `.github/workflows/benchmarks.yml`** (defense in depth):
- Delete `build/*/dune-env` right after restoring the build cache. dune-common's CMake recreates the venv during configure from the current wheelhouse in seconds, so a stale or corrupted cached venv (including the currently poisoned one — no cache-key bump/cold rebuild needed) can never break configure again.

**`python/xt/dune/xt/common/vtk/plot.py`** (unrelated drift, surfaced by this PR's CI):
- `matplotlib.cm.get_cmap` was removed in matplotlib 3.9; the unpinned matplotlib in the docs/visualisation extras now resolves to a version without it, breaking `import dune.gdt` in the docs build. Switched to the `matplotlib.colormaps` registry (supported since 3.5).

## Verification

On this PR's CI: "Configure CMake" — the exact step that failed in the merge queue — passes against the restored, previously-poisoning cache; the full Build on Linux and Build wheels jobs completed on the cmake fix, and the docs job exercises the matplotlib fix.

https://claude.ai/code/session_01KhVZMujG7jda7UVM9c5sDp