### PR TITLE
Replace non-reentrant ctime() with ctime_r() in stringFromTime

### DIFF
--- a/dune/xt/common/string.hh
+++ b/dune/xt/common/string.hh
@@ -168,11 +168,20 @@ void trim(std::vector<std::string>& v);
 //! returns string with local time in current locale's format
 inline std::string stringFromTime(time_t cur_time = time(nullptr))
 {
-  // ctime_r is the reentrant variant of ctime; it requires a buffer of at least 26 bytes and,
-  // like ctime, writes a string terminated by a newline character, which we keep to match the
-  // previous behavior.
+  // Use the reentrant variant of ctime to avoid the data race on the shared static buffer that
+  // plain ctime uses. Both write a newline-terminated string into a buffer of at least 26 bytes,
+  // which we keep to match the previous behavior. MSVC does not provide POSIX ctime_r, so fall
+  // back to its ctime_s there. Either way an empty string is returned on conversion failure
+  // (e.g. an out-of-range time_t) to avoid constructing a std::string from a null pointer.
   char buf[26];
-  return ctime_r(&cur_time, buf);
+#ifdef _MSC_VER
+  if (ctime_s(buf, sizeof(buf), &cur_time) != 0)
+    return {};
+  return buf;
+#else
+  const char* result = ctime_r(&cur_time, buf);
+  return result ? std::string(result) : std::string();
+#endif
 }
 
 

--- a/dune/xt/common/string.hh
+++ b/dune/xt/common/string.hh
@@ -169,19 +169,20 @@ void trim(std::vector<std::string>& v);
 inline std::string stringFromTime(time_t cur_time = time(nullptr))
 {
   // Use the reentrant variant of ctime to avoid the data race on the shared static buffer that
-  // plain ctime uses. Both write a newline-terminated string into a buffer of at least 26 bytes,
-  // which we keep to match the previous behavior. MSVC does not provide POSIX ctime_r, so fall
-  // back to its ctime_s there. Either way an empty string is returned on conversion failure
-  // (e.g. an out-of-range time_t) to avoid constructing a std::string from a null pointer.
-  char buf[26];
+  // plain ctime uses. Both write a newline-terminated string of at least 26 bytes (including the
+  // terminating '\0') into the given buffer; we keep the trailing newline to match the previous
+  // behavior. MSVC does not provide POSIX ctime_r, so fall back to its ctime_s there. An empty
+  // string is returned on conversion failure (e.g. an out-of-range time_t).
+  std::string buffer(26, '\0');
 #ifdef _MSC_VER
-  if (ctime_s(buf, sizeof(buf), &cur_time) != 0)
+  if (ctime_s(buffer.data(), buffer.size(), &cur_time) != 0)
     return {};
-  return buf;
 #else
-  const char* result = ctime_r(&cur_time, buf);
-  return result ? std::string(result) : std::string();
+  if (ctime_r(&cur_time, buffer.data()) == nullptr)
+    return {};
 #endif
+  buffer.resize(buffer.find('\0'));
+  return buffer;
 }
 
 

--- a/dune/xt/common/string.hh
+++ b/dune/xt/common/string.hh
@@ -168,7 +168,11 @@ void trim(std::vector<std::string>& v);
 //! returns string with local time in current locale's format
 inline std::string stringFromTime(time_t cur_time = time(nullptr))
 {
-  return ctime(&cur_time);
+  // ctime_r is the reentrant variant of ctime; it requires a buffer of at least 26 bytes and,
+  // like ctime, writes a string terminated by a newline character, which we keep to match the
+  // previous behavior.
+  char buf[26];
+  return ctime_r(&cur_time, buf);
 }
 
 


### PR DESCRIPTION
## Summary

Resolves SonarCloud BLOCKER **`cpp:S1912`** in `dune/xt/common/string.hh:171` (`stringFromTime`).

`ctime()` returns a pointer to a shared static buffer, so concurrent calls race and clobber each other's results. This replaces it with the reentrant POSIX `ctime_r()` writing into a local 26-byte buffer.

## Behavior

The formatted output is unchanged — `ctime_r` produces the same string as `ctime`, including the trailing newline that `ctime` appends. Existing callers (`signals.cc`, the `TimeString` test) see the same result.

```cpp
inline std::string stringFromTime(time_t cur_time = time(nullptr))
{
  char buf[26];
  return ctime_r(&cur_time, buf);
}
```

## Acceptance

- [x] `cpp:S1912` finding resolved — `stringFromTime` now uses a reentrant time-formatting call.
- [x] Existing callers still get the same formatted string.

Fixes #212

https://claude.ai/code/session_016nCnewa1Fc2DCQn7LEYP3m

---
_Generated by [Claude Code](https://claude.ai/code/session_016nCnewa1Fc2DCQn7LEYP3m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and thread-safety of time formatting used by the app.
  * On invalid or failed time conversions, the app now returns a safe empty time string instead of risking undefined behavior.
  * Time strings are consistently produced with their expected newline termination when conversion succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->