### PR TITLE
Remove virtual from comparison operators (cpp:S3692)

### DIFF
--- a/dune/xt/grid/boundaryinfo/interfaces.hh
+++ b/dune/xt/grid/boundaryinfo/interfaces.hh
@@ -39,12 +39,12 @@ public:
 
   virtual BoundaryType* copy() const = 0;
 
-  virtual bool operator==(const BoundaryType& other) const
+  bool operator==(const BoundaryType& other) const
   {
     return id() == other.id();
   }
 
-  virtual bool operator!=(const BoundaryType& other) const
+  bool operator!=(const BoundaryType& other) const
   {
     return !operator==(other);
   }

--- a/dune/xt/la/container/vector-interface.hh
+++ b/dune/xt/la/container/vector-interface.hh
@@ -563,7 +563,7 @@ public:
    *  \return Truth value of the comparison.
    *  \see    almost_equal()
    */
-  virtual bool operator==(const derived_type& other) const
+  bool operator==(const derived_type& other) const
   {
     return almost_equal(other);
   }
@@ -573,7 +573,7 @@ public:
    *  \param  other   A vector of same size to compare with.
    *  \return Truth value of the comparison.
    */
-  virtual bool operator!=(const derived_type& other) const
+  bool operator!=(const derived_type& other) const
   {
     return !(this->operator==(other));
   }


### PR DESCRIPTION
Resolves #209.

## Summary

SonarCloud reports `cpp:S3692` (BLOCKER) for four `virtual` comparison operators. Virtual comparison operators break the symmetry/substitution expectations of comparison and are discouraged by the C++ Core Guidelines.

This PR removes the `virtual` specifier from:

- `BoundaryType::operator==` / `operator!=` (`dune/xt/grid/boundaryinfo/interfaces.hh`)
- `VectorInterface::operator==` / `operator!=` (`dune/xt/la/container/vector-interface.hh`)

## Why this is safe

Both operators already delegate to a **named virtual helper**, which is exactly the non-virtual-interface idiom recommended in the issue:

- `BoundaryType::operator==` delegates to the pure-virtual `id()`.
- `VectorInterface::operator==` delegates to the virtual `almost_equal()`.

So all required polymorphism remains routed through those helpers and runtime behavior is unchanged. A repo-wide search confirms **no derived class overrides** these operators (no `override` on any comparison operator), so removing `virtual` does not break any virtual dispatch.

## Acceptance

- [x] No `virtual` comparison operators remain in the flagged files
- [x] Required polymorphism routed through named virtual helpers (`id()`, `almost_equal()`)

Reference: https://rules.sonarsource.com/cpp/RSPEC-3692/

https://claude.ai/code/session_01WyP4LYVnxvAd94qoMq6WCa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyP4LYVnxvAd94qoMq6WCa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated comparison operations in core interfaces for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->