### PR TITLE
Fix SonarCloud BLOCKER cpp:S912 + cpp:S3584 in vendored mathexpr parser

### DIFF
--- a/dune/xt/functions/expression/mathexpr.cc
+++ b/dune/xt/functions/expression/mathexpr.cc
@@ -883,8 +883,12 @@ void IsolateVars(char*& s, int nvar, PRVar* ppvar, int nfunc, PRFunction* ppfunc
         return;
       continue;
     };
-    if (((j = IsVar(s, i, nvar, ppvar)) > IsFunction(s, i, nfunc, ppfunc))
-        || ((CompStr(s, i, "pi") || CompStr(s, i, "PI") || CompStr(s, i, "Pi")) && (j = 2))) {
+    j = IsVar(s, i, nvar, ppvar);
+    const bool is_var = (j > IsFunction(s, i, nfunc, ppfunc));
+    const bool is_pi = (CompStr(s, i, "pi") || CompStr(s, i, "PI") || CompStr(s, i, "Pi"));
+    if (!is_var && is_pi)
+      j = 2;
+    if (is_var || is_pi) {
       InsStr(s, i, '(');
       InsStr(s, i + j + 1, ')');
       i += j + 1;
@@ -1608,8 +1612,10 @@ char* ROperation::Expr() const
   s = new char[n];
   switch (op) {
     case Num:
+      delete[] s;
       return ValToStr(ValC);
     case Var:
+      delete[] s;
       return CopyStr(pvar->name);
     case Juxt:
       sprintf(s, "%s , %s", s1, s2);
@@ -1780,7 +1786,10 @@ char* ROperation::Expr() const
       sprintf(s, "%s(%s)", pfunc->name, s2);
       break;
     default:
-      return CopyStr("Error");
+      // n >= 10, so "Error" always fits; routing through the common cleanup
+      // path below avoids leaking the buffer s (and s1/s2).
+      sprintf(s, "Error");
+      break;
   };
   if (s1 != NULL)
     delete[] s1;


### PR DESCRIPTION
Closes #211.

Patches the three BLOCKER-severity SonarCloud findings in the vendored math-expression parser `dune/xt/functions/expression/mathexpr.cc` in place (option 1 of the three discussed in the issue).

## `cpp:S912` ×2 — `IsolateVars` (was line 887)

The loop condition assigned `j` as a side effect inside the right-hand operand of `||`:

```cpp
if (((j = IsVar(s, i, nvar, ppvar)) > IsFunction(s, i, nfunc, ppfunc))
    || ((CompStr(s, i, "pi") || CompStr(s, i, "PI") || CompStr(s, i, "Pi")) && (j = 2))) {
```

`(j = 2)` only ran when the left operand was false (short-circuit). Hoisted out into named locals so the assignments always run explicitly, preserving the original semantics (`j` = `IsVar` length when a variable matches, otherwise `2` for `pi`/`PI`/`Pi`):

```cpp
j = IsVar(s, i, nvar, ppvar);
const bool is_var = (j > IsFunction(s, i, nfunc, ppfunc));
const bool is_pi = (CompStr(s, i, "pi") || CompStr(s, i, "PI") || CompStr(s, i, "Pi"));
if (!is_var && is_pi)
  j = 2;
if (is_var || is_pi) {
  ...
```

## `cpp:S3584` ×1 — `ROperation::Expr` (was line 1783)

`s = new char[n]` is allocated before the `switch`, but the `default` case returned early via `CopyStr("Error")`, leaking `s`. Now it writes `"Error"` into `s` (n is initialized to 10, so it always fits) and `break`s, so the existing single cleanup path at the end frees `s1`/`s2` and returns `s` — same heap-owned `"Error"` string the caller already `delete[]`s.

The early-returning `Num` and `Var` cases leaked `s` for the same reason, so they now `delete[] s` before returning.

## Notes

- Semantics are unchanged; these are targeted in-place patches carried on top of the vendored `mathexpr.cpp` v2.0 (Yann Ollivier).
- Could not run a full compile here (boost headers unavailable in this environment); the changes use only constructs already present in the file (`sprintf`, `delete[]`, local declarations) and were syntax-reviewed.


---
_Generated by [Claude Code](https://claude.ai/code/session_012cfaP8tA43JiZUk9oSUypA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management in expression evaluation to prevent resource leaks.
  * Enhanced detection and handling of mathematical variables and constants in expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->