### PR TITLE
Document won't-fix rationale for cpp:S3519 in vendored mathexpr parser (#210)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,23 @@
 # SonarCloud project configuration.
 #
 # Exclude vendored third-party sources from analysis. These files are not
-# maintained by dune-gdt and their findings (e.g. cpp:S6069 sprintf, cpp:S5813
-# buffer handling) are upstream concerns:
+# maintained by dune-gdt and their findings are upstream concerns, consciously
+# accepted as won't-fix rather than carried as a local patch that diverges from
+# upstream:
 #   - mathexpr.{cc,hh}: math expression parser, Copyright Yann Ollivier 1997-2000
 #   - dune/xt/test/gtest/**: bundled GoogleTest
+#
+# The reported findings in mathexpr.{cc,hh} include security/maintainability
+# rules (e.g. cpp:S6069 sprintf, cpp:S5813 buffer handling) as well as
+# BLOCKER-severity reliability rules surfaced by symbolic execution:
+#   - cpp:S3519 (out-of-bounds heap read, issue #210, 8x): the flagged accesses
+#     are false positives -- e.g. the `i += IsFunction(...) - 1` index at :895 is
+#     guarded so it never goes negative, and the `new double[n1 + n2 + 1]` buffers
+#     at :2027/:2029/:2030/:2075/:2076/:2117/:2118 are written by loops that
+#     iterate exactly the allocated count; the analyzer cannot prove the bound.
+#   - cpp:S912 / cpp:S3584 (issue #211).
+# The parser's inputs are trusted expression strings from the build/config, not
+# untrusted I/O, so these are accepted as won't-fix for the vendored file.
 #
 # The same exclusion is also configured on the SonarCloud project itself so it
 # takes effect under Automatic Analysis; this file keeps it under version control


### PR DESCRIPTION
Resolves #210.

## Summary

The 8 `cpp:S3519` BLOCKER findings ("Access of the heap area at negative byte offset -1") are all in `dune/xt/functions/expression/mathexpr.cc`, the vendored math-expression parser (Copyright Yann Ollivier 1997–2000).

This file (`mathexpr.{cc,hh}`) is **already excluded** from SonarCloud analysis via `sonar-project.properties` (added in commit `f599ef4`, "Address SonarCloud security findings", already on `main`) and on the SonarCloud project itself for Automatic Analysis. Issues #210/#211 were filed *after* that exclusion landed, from the #206 triage snapshot.

The project's established choice for this vendored file is **option 2 — accept / won't-fix** rather than carrying a local patch that diverges from upstream. This PR makes that decision explicit in version control for the reliability findings (the existing comment only mentioned the security rules `S6069`/`S5813`).

## Why these are accepted as won't-fix

The flagged accesses are symbolic-execution **false positives** on **trusted inputs** (expression strings come from the build/config, not untrusted I/O):

- `:895` — `if (!s[i])` follows `i += IsFunction(...) - 1`, and `IsFunction(...) > 0` is guaranteed by the guard on line 893, so `i` never goes negative.
- `:2027/:2029/:2030`, `:2075/:2076`, `:2117/:2118` — all writes (`*pp3 = 0` / `*pp3 = ErrVal`) into a buffer freshly allocated as `new double[n1 + n2 + 1]` and filled by loops that iterate exactly the allocated count; the analyzer cannot prove the loop/allocation bound.

## Change

Expands the rationale comment in `sonar-project.properties` to document the BLOCKER reliability findings (`cpp:S3519` for #210, and `cpp:S912` / `cpp:S3584` for the companion #211) covered by the existing vendored-file exclusion. No code changes — the parser stays as vendored.

https://claude.ai/code/session_011FsC8aSoZGnik9HiiSWHnw

---
_Generated by [Claude Code](https://claude.ai/code/session_011FsC8aSoZGnik9HiiSWHnw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and analysis configuration documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->