### PR TITLE
Declare move operations noexcept (cpp:S5018)

### DIFF
--- a/dune/gdt/discretefunction/default.hh
+++ b/dune/gdt/discretefunction/default.hh
@@ -87,7 +87,7 @@ public:
 
   ConstDiscreteFunction(const ThisType&) = default;
 
-  ConstDiscreteFunction(ThisType&&) = default;
+  ConstDiscreteFunction(ThisType&&) noexcept = default;
 
   const SpaceType& space() const
   {
@@ -247,7 +247,7 @@ public:
 
   DiscreteFunction(ThisType& other) = delete;
 
-  DiscreteFunction(ThisType&&) = default;
+  DiscreteFunction(ThisType&&) noexcept = default;
 
   using BaseType::dofs;
 

--- a/dune/gdt/discretefunction/dof-vector.hh
+++ b/dune/gdt/discretefunction/dof-vector.hh
@@ -53,7 +53,7 @@ public:
 
   ConstDofVector(const ThisType&) = default;
 
-  ConstDofVector(ThisType&&) = default;
+  ConstDofVector(ThisType&&) noexcept = default;
 
   const VectorType& vector() const
   {
@@ -98,7 +98,7 @@ public:
 
   DofVector(const ThisType&) = default;
 
-  DofVector(ThisType&&) = default;
+  DofVector(ThisType&&) noexcept = default;
 
   using BaseType::vector;
 

--- a/dune/gdt/functionals/interfaces.hh
+++ b/dune/gdt/functionals/interfaces.hh
@@ -72,7 +72,7 @@ public:
   {
   }
 
-  FunctionalInterface(ThisType&& source) = default;
+  FunctionalInterface(ThisType&& source) noexcept = default;
 
   virtual ~FunctionalInterface() = default;
 

--- a/dune/gdt/functionals/vector-based.hh
+++ b/dune/gdt/functionals/vector-based.hh
@@ -70,7 +70,7 @@ public:
   }
 
   ConstVectorBasedFunctional(const ThisType&) = default;
-  ConstVectorBasedFunctional(ThisType&&) = default;
+  ConstVectorBasedFunctional(ThisType&&) noexcept = default;
 
   bool linear() const override
   {
@@ -201,7 +201,7 @@ public:
     // If this constructor is defaulted, the Intel Compiler thinks it is deleted (tested with icc 2021.1 Beta 20200827)
   }
 
-  VectorBasedFunctional(ThisType&&) = default;
+  VectorBasedFunctional(ThisType&&) noexcept = default;
 
   typename BaseWalkerType::BaseType* copy() override
   {

--- a/dune/gdt/interpolations/default.hh
+++ b/dune/gdt/interpolations/default.hh
@@ -76,7 +76,7 @@ public:
   {
   }
 
-  DefaultInterpolationElementFunctor(ThisType&&) = default;
+  DefaultInterpolationElementFunctor(ThisType&&) noexcept = default;
 
   XT::Grid::ElementFunctor<IGV>* copy() override final
   {

--- a/dune/gdt/local/assembler/bilinear-form-assemblers.hh
+++ b/dune/gdt/local/assembler/bilinear-form-assemblers.hh
@@ -108,7 +108,7 @@ public:
   {
   }
 
-  LocalElementBilinearFormAssembler(ThisType&& source) = default;
+  LocalElementBilinearFormAssembler(ThisType&& source) noexcept = default;
 
   BaseType* copy() override final
   {
@@ -241,7 +241,7 @@ public:
   {
   }
 
-  LocalCouplingIntersectionBilinearFormAssembler(ThisType&& source) = default;
+  LocalCouplingIntersectionBilinearFormAssembler(ThisType&& source) noexcept = default;
 
   BaseType* copy() override final
   {
@@ -388,7 +388,7 @@ public:
   {
   }
 
-  LocalIntersectionBilinearFormAssembler(ThisType&& source) = default;
+  LocalIntersectionBilinearFormAssembler(ThisType&& source) noexcept = default;
 
   BaseType* copy() override final
   {

--- a/dune/gdt/local/assembler/functional-accumulators.hh
+++ b/dune/gdt/local/assembler/functional-accumulators.hh
@@ -81,7 +81,7 @@ public:
   {
   }
 
-  LocalElementFunctionalAccumulator(ThisType&& other) = default;
+  LocalElementFunctionalAccumulator(ThisType&& other) noexcept = default;
 
   BaseType* copy() override final
   {

--- a/dune/gdt/local/assembler/functional-assemblers.hh
+++ b/dune/gdt/local/assembler/functional-assemblers.hh
@@ -75,7 +75,7 @@ public:
   {
   }
 
-  LocalElementFunctionalAssembler(ThisType&& source) = default;
+  LocalElementFunctionalAssembler(ThisType&& source) noexcept = default;
 
   BaseType* copy() override final
   {
@@ -155,7 +155,7 @@ public:
   {
   }
 
-  LocalIntersectionFunctionalAssembler(ThisType&& source) = default;
+  LocalIntersectionFunctionalAssembler(ThisType&& source) noexcept = default;
 
   BaseType* copy() override final
   {

--- a/dune/gdt/local/bilinear-forms/integrals.hh
+++ b/dune/gdt/local/bilinear-forms/integrals.hh
@@ -89,7 +89,7 @@ public:
   {
   }
 
-  LocalElementIntegralBilinearForm(ThisType&& source) = default;
+  LocalElementIntegralBilinearForm(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {
@@ -194,7 +194,7 @@ public:
   {
   }
 
-  LocalCouplingIntersectionIntegralBilinearForm(ThisType&& source) = default;
+  LocalCouplingIntersectionIntegralBilinearForm(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {
@@ -332,7 +332,7 @@ public:
   {
   }
 
-  LocalIntersectionIntegralBilinearForm(ThisType&& source) = default;
+  LocalIntersectionIntegralBilinearForm(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {

--- a/dune/gdt/local/bilinear-forms/interfaces.hh
+++ b/dune/gdt/local/bilinear-forms/interfaces.hh
@@ -98,7 +98,7 @@ public:
 
   LocalElementBilinearFormInterface(const ThisType&) = default;
 
-  LocalElementBilinearFormInterface(ThisType&&) = default;
+  LocalElementBilinearFormInterface(ThisType&&) noexcept = default;
 
   virtual ~LocalElementBilinearFormInterface() = default;
 
@@ -197,7 +197,7 @@ public:
 
   LocalCouplingIntersectionBilinearFormInterface(const ThisType&) = default;
 
-  LocalCouplingIntersectionBilinearFormInterface(ThisType&&) = default;
+  LocalCouplingIntersectionBilinearFormInterface(ThisType&&) noexcept = default;
 
   virtual ~LocalCouplingIntersectionBilinearFormInterface() = default;
 
@@ -316,7 +316,7 @@ public:
 
   LocalIntersectionBilinearFormInterface(const ThisType&) = default;
 
-  LocalIntersectionBilinearFormInterface(ThisType&&) = default;
+  LocalIntersectionBilinearFormInterface(ThisType&&) noexcept = default;
 
   virtual ~LocalIntersectionBilinearFormInterface() = default;
 

--- a/dune/gdt/local/bilinear-forms/restricted-integrals.hh
+++ b/dune/gdt/local/bilinear-forms/restricted-integrals.hh
@@ -71,7 +71,7 @@ public:
   {
   }
 
-  LocalCouplingIntersectionRestrictedIntegralBilinearForm(ThisType&& source) = default;
+  LocalCouplingIntersectionRestrictedIntegralBilinearForm(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {
@@ -213,7 +213,7 @@ public:
   {
   }
 
-  LocalIntersectionRestrictedIntegralBilinearForm(ThisType&& source) = default;
+  LocalIntersectionRestrictedIntegralBilinearForm(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {

--- a/dune/gdt/local/dof-vector.hh
+++ b/dune/gdt/local/dof-vector.hh
@@ -112,7 +112,7 @@ public:
   }
 
   ConstLocalDofVector(const ThisType& other) = default;
-  ConstLocalDofVector(ThisType&& source) = default;
+  ConstLocalDofVector(ThisType&& source) noexcept = default;
 
 protected:
   void post_bind(const ElementType& ele) override final
@@ -226,7 +226,7 @@ public:
   }
 
   LocalDofVector(const ThisType&) = default;
-  LocalDofVector(ThisType&&) = default;
+  LocalDofVector(ThisType&&) noexcept = default;
 
   using BaseType::global;
 

--- a/dune/gdt/local/finite-elements/default.hh
+++ b/dune/gdt/local/finite-elements/default.hh
@@ -185,7 +185,7 @@ public:
     // we do not even try to create the FEs in a thread safe way, they will just be recreated when required
   }
 
-  ThreadSafeDefaultLocalFiniteElementFamily(ThisType&& source)
+  ThreadSafeDefaultLocalFiniteElementFamily(ThisType&& source) noexcept
     : factory_(std::move(source.factory_))
     , fes_(std::move(source.fes_))
   {

--- a/dune/gdt/local/functionals/integrals.hh
+++ b/dune/gdt/local/functionals/integrals.hh
@@ -70,7 +70,7 @@ public:
   {
   }
 
-  LocalElementIntegralFunctional(ThisType&& source) = default;
+  LocalElementIntegralFunctional(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {
@@ -157,7 +157,7 @@ public:
   {
   }
 
-  LocalIntersectionIntegralFunctional(ThisType&& source) = default;
+  LocalIntersectionIntegralFunctional(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {

--- a/dune/gdt/local/functionals/restricted-integrals.hh
+++ b/dune/gdt/local/functionals/restricted-integrals.hh
@@ -64,7 +64,7 @@ public:
   {
   }
 
-  LocalIntersectionRestrictedIntegralFunctional(ThisType&& source) = default;
+  LocalIntersectionRestrictedIntegralFunctional(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {

--- a/dune/gdt/local/integrands/combined.hh
+++ b/dune/gdt/local/integrands/combined.hh
@@ -50,7 +50,7 @@ public:
   {
   }
 
-  LocalUnaryElementIntegrandSum(ThisType&& source) = default;
+  LocalUnaryElementIntegrandSum(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_unary_element_integrand() const final
   {
@@ -128,7 +128,7 @@ public:
   }
 #pragma GCC diagnostic pop
 
-  LocalUnaryIntersectionIntegrandSum(ThisType&& source) = default;
+  LocalUnaryIntersectionIntegrandSum(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_unary_intersection_integrand() const final
   {
@@ -206,7 +206,7 @@ public:
   {
   }
 
-  LocalBinaryElementIntegrandSum(ThisType&& source) = default;
+  LocalBinaryElementIntegrandSum(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const final
   {
@@ -292,7 +292,7 @@ public:
   }
 #pragma GCC diagnostic pop
 
-  LocalBinaryIntersectionIntegrandSum(ThisType&& source) = default;
+  LocalBinaryIntersectionIntegrandSum(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_intersection_integrand() const final
   {
@@ -377,7 +377,7 @@ public:
   {
   }
 
-  LocalQuaternaryIntersectionIntegrandSum(ThisType&& source) = default;
+  LocalQuaternaryIntersectionIntegrandSum(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_quaternary_intersection_integrand() const final
   {

--- a/dune/gdt/local/integrands/conversion.hh
+++ b/dune/gdt/local/integrands/conversion.hh
@@ -76,7 +76,7 @@ public:
   {
   }
 
-  LocalBinaryToUnaryElementIntegrand(ThisType&&) = default;
+  LocalBinaryToUnaryElementIntegrand(ThisType&&) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_unary_element_integrand() const override final
   {
@@ -176,7 +176,7 @@ public:
   }
 #pragma GCC diagnostic pop
 
-  LocalBinaryToUnaryIntersectionIntegrand(ThisType&&) = default;
+  LocalBinaryToUnaryIntersectionIntegrand(ThisType&&) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_unary_intersection_integrand() const override final
   {

--- a/dune/gdt/local/integrands/div.hh
+++ b/dune/gdt/local/integrands/div.hh
@@ -109,7 +109,7 @@ public:
   {
   }
 
-  LocalElementAnsatzValueTestDivProductIntegrand(ThisType&& source) = default;
+  LocalElementAnsatzValueTestDivProductIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const override final
   {
@@ -194,7 +194,7 @@ public:
   {
   }
 
-  LocalElementAnsatzDivTestValueProductIntegrand(ThisType&& source) = default;
+  LocalElementAnsatzDivTestValueProductIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const override final
   {

--- a/dune/gdt/local/integrands/gradient-value.hh
+++ b/dune/gdt/local/integrands/gradient-value.hh
@@ -73,7 +73,7 @@ public:
   {
   }
 
-  LocalElementGradientValueIntegrand(ThisType&& source) = default;
+  LocalElementGradientValueIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const override final
   {

--- a/dune/gdt/local/integrands/interfaces.hh
+++ b/dune/gdt/local/integrands/interfaces.hh
@@ -224,7 +224,7 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wextra"
   LocalBinaryElementIntegrandInterface(const LocalBinaryElementIntegrandInterface& other) = default;
-  LocalBinaryElementIntegrandInterface(LocalBinaryElementIntegrandInterface&& other) = default;
+  LocalBinaryElementIntegrandInterface(LocalBinaryElementIntegrandInterface&& other) noexcept = default;
 #pragma GCC diagnostic pop
 
   template <class... Args>

--- a/dune/gdt/local/integrands/ipdg.hh
+++ b/dune/gdt/local/integrands/ipdg.hh
@@ -90,7 +90,7 @@ public:
   {
   }
 
-  InnerPenalty(ThisType&& source) = default;
+  InnerPenalty(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_quaternary_intersection_integrand() const final
   {
@@ -239,7 +239,7 @@ public:
   }
 #pragma GCC diagnostic pop
 
-  BoundaryPenalty(ThisType&& source) = default;
+  BoundaryPenalty(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_intersection_integrand() const final
   {

--- a/dune/gdt/local/integrands/jump.hh
+++ b/dune/gdt/local/integrands/jump.hh
@@ -61,7 +61,7 @@ public:
   {
   }
 
-  Inner(ThisType&& source) = default;
+  Inner(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_quaternary_intersection_integrand() const override final
   {
@@ -203,7 +203,7 @@ public:
   }
 #pragma GCC diagnostic pop
 
-  Boundary(ThisType&& source) = default;
+  Boundary(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_intersection_integrand() const override final
   {

--- a/dune/gdt/local/integrands/laplace-ipdg.hh
+++ b/dune/gdt/local/integrands/laplace-ipdg.hh
@@ -78,7 +78,7 @@ public:
   {
   }
 
-  InnerCoupling(ThisType&& source) = default;
+  InnerCoupling(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_quaternary_intersection_integrand() const final
   {
@@ -275,7 +275,7 @@ public:
 #pragma GCC diagnostic pop
 
 
-  DirichletCoupling(ThisType&& source) = default;
+  DirichletCoupling(ThisType&& source) noexcept = default;
 
 protected:
   void post_bind(const IntersectionType& intersection) final

--- a/dune/gdt/local/integrands/laplace.hh
+++ b/dune/gdt/local/integrands/laplace.hh
@@ -59,7 +59,7 @@ public:
   {
   }
 
-  LocalLaplaceIntegrand(ThisType&& source) = default;
+  LocalLaplaceIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const override final
   {

--- a/dune/gdt/local/integrands/linear-advection-upwind.hh
+++ b/dune/gdt/local/integrands/linear-advection-upwind.hh
@@ -63,7 +63,7 @@ public:
   {
   }
 
-  InnerCoupling(ThisType&& source) = default;
+  InnerCoupling(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_quaternary_intersection_integrand() const final
   {
@@ -219,7 +219,7 @@ public:
   }
 #pragma GCC diagnostic pop
 
-  DirichletCoupling(ThisType&& source) = default;
+  DirichletCoupling(ThisType&& source) noexcept = default;
 
 protected:
   void post_bind(const IntersectionType& intersection) final

--- a/dune/gdt/local/integrands/linear-advection.hh
+++ b/dune/gdt/local/integrands/linear-advection.hh
@@ -68,7 +68,7 @@ public:
   {
   }
 
-  LocalLinearAdvectionIntegrand(ThisType&& source) = default;
+  LocalLinearAdvectionIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const override final
   {

--- a/dune/gdt/local/integrands/product.hh
+++ b/dune/gdt/local/integrands/product.hh
@@ -74,7 +74,7 @@ public:
   {
   }
 
-  LocalElementProductIntegrand(ThisType&& source) = default;
+  LocalElementProductIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const final
   {
@@ -183,7 +183,7 @@ public:
   {
   }
 
-  LocalCouplingIntersectionProductIntegrand(ThisType&& source) = default;
+  LocalCouplingIntersectionProductIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_quaternary_intersection_integrand() const final
   {
@@ -320,7 +320,7 @@ public:
   }
 #pragma GCC diagnostic pop
 
-  LocalIntersectionProductIntegrand(ThisType&& source) = default;
+  LocalIntersectionProductIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_intersection_integrand() const final
   {
@@ -438,7 +438,7 @@ public:
   {
   }
 
-  LocalIntersectionNormalComponentProductIntegrand(ThisType&& source) = default;
+  LocalIntersectionNormalComponentProductIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_intersection_integrand() const override final
   {

--- a/dune/gdt/local/integrands/symmetrized-laplace.hh
+++ b/dune/gdt/local/integrands/symmetrized-laplace.hh
@@ -61,7 +61,7 @@ public:
   {
   }
 
-  LocalSymmetrizedLaplaceIntegrand(ThisType&& source) = default;
+  LocalSymmetrizedLaplaceIntegrand(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy_as_binary_element_integrand() const override final
   {

--- a/dune/gdt/operators/advection-dg.hh
+++ b/dune/gdt/operators/advection-dg.hh
@@ -148,7 +148,7 @@ public:
         artificial_viscosity_component_)};
   } // AdvectionDgOperator(...)
 
-  AdvectionDgOperator(ThisType&& source) = default;
+  AdvectionDgOperator(ThisType&& source) noexcept = default;
 
   /// \name Required by BilinearFormInterface
   /// \{

--- a/dune/gdt/operators/advection-fv.hh
+++ b/dune/gdt/operators/advection-fv.hh
@@ -96,7 +96,7 @@ public:
               *(XT::Grid::ApplyOn::PeriodicBoundaryIntersectionsOnce<AGV>() && !(*periodicity_exception_))};
   }
 
-  AdvectionFvOperator(ThisType&& source)
+  AdvectionFvOperator(ThisType&& source) noexcept
     : BaseType(std::move(source))
     , numerical_flux_(std::move(source.numerical_flux_))
     , periodicity_exception_(std::move(source.periodicity_exception_))

--- a/dune/gdt/operators/bilinear-form.hh
+++ b/dune/gdt/operators/bilinear-form.hh
@@ -110,7 +110,7 @@ public:
     copy_local_data(other.intersection_data_, intersection_data_);
   } // BilinearForm(...)
 
-  BilinearForm(ThisType&&) = default;
+  BilinearForm(ThisType&&) noexcept = default;
 
   /// \brief allows to fix the arguments to apply2(), the resulting assembler can be appended to a GridWalker
   auto with(RangeFunctionType range_function,
@@ -354,7 +354,7 @@ public:
   {
   }
 
-  BilinearFormAssembler(ThisType&& source) = default;
+  BilinearFormAssembler(ThisType&& source) noexcept = default;
 
   /// \name Required by ElementAndIntersectionFunctor.
   /// \{

--- a/dune/gdt/operators/constant.hh
+++ b/dune/gdt/operators/constant.hh
@@ -80,7 +80,7 @@ public:
 
   ConstantForwardOperator(const ThisType& other) = default;
 
-  ConstantForwardOperator(ThisType&& source) = default;
+  ConstantForwardOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;
@@ -213,7 +213,7 @@ public:
 
   ConstantOperator(const ThisType& other) = default;
 
-  ConstantOperator(ThisType&& source) = default;
+  ConstantOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;

--- a/dune/gdt/operators/forward-operator.hh
+++ b/dune/gdt/operators/forward-operator.hh
@@ -94,7 +94,7 @@ public:
     copy_local_data(other.intersection_data_, intersection_data_);
   } // ForwardOperator(...)
 
-  ForwardOperator(ThisType&& source) = default;
+  ForwardOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;
@@ -288,7 +288,7 @@ public:
     set_source_in_local_ops(operator_.intersection_data(), intersection_data_);
   }
 
-  ForwardOperatorAssembler(ThisType&& source) = default;
+  ForwardOperatorAssembler(ThisType&& source) noexcept = default;
 
   /// \name Required by ElementAndIntersectionFunctor.
   /// \{

--- a/dune/gdt/operators/identity.hh
+++ b/dune/gdt/operators/identity.hh
@@ -55,7 +55,7 @@ public:
 
   IdentityOperator(const ThisType& other) = default;
 
-  IdentityOperator(ThisType&& source) = default;
+  IdentityOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;

--- a/dune/gdt/operators/interfaces.hh
+++ b/dune/gdt/operators/interfaces.hh
@@ -121,7 +121,7 @@ public:
 
   BilinearFormInterface(const ThisType& other) = default;
 
-  BilinearFormInterface(ThisType&& source) = default;
+  BilinearFormInterface(ThisType&& source) noexcept = default;
 
   virtual ~BilinearFormInterface() = default;
 
@@ -204,7 +204,7 @@ public:
 
   ForwardOperatorInterface(const ThisType& other) = default;
 
-  ForwardOperatorInterface(ThisType&& source) = default;
+  ForwardOperatorInterface(ThisType&& source) noexcept = default;
 
   virtual ~ForwardOperatorInterface() = default;
 
@@ -391,7 +391,7 @@ public:
 
   OperatorInterface(const ThisType& other) = default;
 
-  OperatorInterface(ThisType&& source) = default;
+  OperatorInterface(ThisType&& source) noexcept = default;
 
   ~OperatorInterface() override = default;
 

--- a/dune/gdt/operators/laplace-ipdg-flux-reconstruction.hh
+++ b/dune/gdt/operators/laplace-ipdg-flux-reconstruction.hh
@@ -107,7 +107,7 @@ public:
   {
   }
 
-  LaplaceIpdgFluxReconstructionOperator(ThisType&&) = default;
+  LaplaceIpdgFluxReconstructionOperator(ThisType&&) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;

--- a/dune/gdt/operators/lincomb.hh
+++ b/dune/gdt/operators/lincomb.hh
@@ -71,7 +71,7 @@ public:
 
   ConstLincombOperator(const ThisType& other) = default;
 
-  ConstLincombOperator(ThisType&& source) = default;
+  ConstLincombOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;
@@ -517,7 +517,7 @@ public:
 
   LincombOperator(ThisType& other) = default;
 
-  LincombOperator(ThisType&& source) = default;
+  LincombOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;

--- a/dune/gdt/operators/matrix.hh
+++ b/dune/gdt/operators/matrix.hh
@@ -110,7 +110,7 @@ public:
   {
   }
 
-  ConstMatrixOperator(ThisType&& source)
+  ConstMatrixOperator(ThisType&& source) noexcept
     : BaseType(source)
     , assembly_grid_view_(source.assembly_grid_view_)
     , source_space_(source.source_space_)
@@ -420,7 +420,7 @@ public:
     copy_local_data(other.intersection_fd_operator_data_, intersection_fd_operator_data_);
   } // ... MatrixOperator(...)
 
-  MatrixOperator(ThisType&& source) = default;
+  MatrixOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseOperatorType::matrix;

--- a/dune/gdt/operators/operator.hh
+++ b/dune/gdt/operators/operator.hh
@@ -96,7 +96,7 @@ public:
     copy_local_data(other.intersection_data_, intersection_data_);
   } // Operator(...)
 
-  Operator(ThisType&& source) = default;
+  Operator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;

--- a/dune/gdt/operators/oswald-interpolation.hh
+++ b/dune/gdt/operators/oswald-interpolation.hh
@@ -104,7 +104,7 @@ public:
 
   OswaldInterpolationOperator(const ThisType& other) = default;
 
-  OswaldInterpolationOperator(ThisType&& source) = default;
+  OswaldInterpolationOperator(ThisType&& source) noexcept = default;
 
   // pull in methods from various base classes
   using BaseType::apply;

--- a/dune/gdt/spaces/basis/default.hh
+++ b/dune/gdt/spaces/basis/default.hh
@@ -48,7 +48,7 @@ public:
   using FiniteElementFamilyType = LocalFiniteElementFamilyInterface<D, d, R, r, rC>;
 
   DefaultGlobalBasis(const ThisType&) = default;
-  DefaultGlobalBasis(ThisType&&) = default;
+  DefaultGlobalBasis(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
   ThisType& operator=(ThisType&&) = delete;
@@ -105,7 +105,7 @@ private:
     }
 
     LocalizedDefaultGlobalBasis(const ThisType&) = delete;
-    LocalizedDefaultGlobalBasis(ThisType&&) = default;
+    LocalizedDefaultGlobalBasis(ThisType&&) noexcept = default;
 
     ThisType& operator=(const ThisType&) = delete;
     ThisType& operator=(ThisType&&) = delete;

--- a/dune/gdt/spaces/basis/finite-volume.hh
+++ b/dune/gdt/spaces/basis/finite-volume.hh
@@ -51,7 +51,7 @@ private:
 
 public:
   FiniteVolumeGlobalBasis(const ThisType&) = default;
-  FiniteVolumeGlobalBasis(ThisType&&) = default;
+  FiniteVolumeGlobalBasis(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
   ThisType& operator=(ThisType&&) = delete;
@@ -105,7 +105,7 @@ private:
     }
 
     LocalizedFiniteVolumeGlobalBasis(const ThisType&) = default;
-    LocalizedFiniteVolumeGlobalBasis(ThisType&&) = default;
+    LocalizedFiniteVolumeGlobalBasis(ThisType&&) noexcept = default;
 
     ThisType& operator=(const ThisType&) = delete;
     ThisType& operator=(ThisType&&) = delete;

--- a/dune/gdt/spaces/basis/interface.hh
+++ b/dune/gdt/spaces/basis/interface.hh
@@ -57,7 +57,7 @@ public:
 
   LocalizedGlobalFiniteElementInterface(const ThisType&) = default;
 
-  LocalizedGlobalFiniteElementInterface(ThisType&&) = default;
+  LocalizedGlobalFiniteElementInterface(ThisType&&) noexcept = default;
 
   virtual ~LocalizedGlobalFiniteElementInterface() = default;
 
@@ -164,7 +164,7 @@ public:
 
   GlobalBasisInterface(const ThisType&) = default;
 
-  GlobalBasisInterface(ThisType&&) = default;
+  GlobalBasisInterface(ThisType&&) noexcept = default;
 
   virtual ~GlobalBasisInterface() = default;
 

--- a/dune/gdt/spaces/basis/raviart-thomas.hh
+++ b/dune/gdt/spaces/basis/raviart-thomas.hh
@@ -78,7 +78,7 @@ public:
 
   RaviartThomasGlobalBasis(const ThisType&) = default;
 
-  RaviartThomasGlobalBasis(ThisType&&) = default;
+  RaviartThomasGlobalBasis(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
 
@@ -133,7 +133,7 @@ private:
     }
 
     LocalizedRaviartThomasGlobalBasis(const ThisType&) = default;
-    LocalizedRaviartThomasGlobalBasis(ThisType&&) = default;
+    LocalizedRaviartThomasGlobalBasis(ThisType&&) noexcept = default;
 
     ThisType& operator=(const ThisType&) = delete;
     ThisType& operator=(ThisType&&) = delete;

--- a/dune/gdt/spaces/h1/continuous-lagrange.hh
+++ b/dune/gdt/spaces/h1/continuous-lagrange.hh
@@ -95,7 +95,7 @@ public:
     this->update_after_adapt();
   }
 
-  ContinuousLagrangeSpace(ThisType&&) = default;
+  ContinuousLagrangeSpace(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
 

--- a/dune/gdt/spaces/hdiv/raviart-thomas.hh
+++ b/dune/gdt/spaces/hdiv/raviart-thomas.hh
@@ -100,7 +100,7 @@ public:
 
   RaviartThomasSpace(const ThisType& other) = delete;
 
-  RaviartThomasSpace(ThisType&&) = default;
+  RaviartThomasSpace(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
 

--- a/dune/gdt/spaces/interface.hh
+++ b/dune/gdt/spaces/interface.hh
@@ -90,7 +90,7 @@ public:
 
   SpaceInterface(const ThisType& other) = default;
 
-  SpaceInterface(ThisType&& source) = default;
+  SpaceInterface(ThisType&& source) noexcept = default;
 
   virtual ThisType* copy() const = 0;
 

--- a/dune/gdt/spaces/l2/discontinuous-lagrange.hh
+++ b/dune/gdt/spaces/l2/discontinuous-lagrange.hh
@@ -103,7 +103,7 @@ public:
     this->update_after_adapt();
   }
 
-  DiscontinuousLagrangeSpace(ThisType&&) = default;
+  DiscontinuousLagrangeSpace(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
 

--- a/dune/gdt/spaces/l2/finite-volume.hh
+++ b/dune/gdt/spaces/l2/finite-volume.hh
@@ -83,7 +83,7 @@ public:
     this->update_after_adapt();
   }
 
-  FiniteVolumeSpace(ThisType&&) = default;
+  FiniteVolumeSpace(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
 

--- a/dune/gdt/spaces/mapper/continuous.hh
+++ b/dune/gdt/spaces/mapper/continuous.hh
@@ -73,7 +73,7 @@ public:
   }
 
   ContinuousMapper(const ThisType&) = default;
-  ContinuousMapper(ThisType&&) = default;
+  ContinuousMapper(ThisType&&) noexcept = default;
 
   ContinuousMapper& operator=(const ThisType&) = delete;
   ContinuousMapper& operator=(ThisType&&) = delete;

--- a/dune/gdt/spaces/mapper/discontinuous.hh
+++ b/dune/gdt/spaces/mapper/discontinuous.hh
@@ -74,7 +74,7 @@ public:
   }
 
   DiscontinuousMapper(const ThisType&) = default;
-  DiscontinuousMapper(ThisType&&) = default;
+  DiscontinuousMapper(ThisType&&) noexcept = default;
 
   DiscontinuousMapper& operator=(const ThisType&) = delete;
   DiscontinuousMapper& operator=(ThisType&&) = delete;

--- a/dune/gdt/spaces/mapper/finite-volume-skeleton.hh
+++ b/dune/gdt/spaces/mapper/finite-volume-skeleton.hh
@@ -70,7 +70,7 @@ public:
   }
 
   FiniteVolumeSkeletonMapper(const ThisType&) = default;
-  FiniteVolumeSkeletonMapper(ThisType&&) = default;
+  FiniteVolumeSkeletonMapper(ThisType&&) noexcept = default;
 
   FiniteVolumeSkeletonMapper& operator=(const ThisType&) = delete;
   FiniteVolumeSkeletonMapper& operator=(ThisType&&) = delete;

--- a/dune/gdt/spaces/mapper/finite-volume.hh
+++ b/dune/gdt/spaces/mapper/finite-volume.hh
@@ -65,7 +65,7 @@ public:
   }
 
   FiniteVolumeMapper(const ThisType&) = default;
-  FiniteVolumeMapper(ThisType&&) = default;
+  FiniteVolumeMapper(ThisType&&) noexcept = default;
 
   FiniteVolumeMapper& operator=(const ThisType&) = delete;
   FiniteVolumeMapper& operator=(ThisType&&) = delete;

--- a/dune/gdt/spaces/skeleton/finite-volume.hh
+++ b/dune/gdt/spaces/skeleton/finite-volume.hh
@@ -80,7 +80,7 @@ public:
     this->update_after_adapt();
   }
 
-  FiniteVolumeSkeletonSpace(ThisType&&) = default;
+  FiniteVolumeSkeletonSpace(ThisType&&) noexcept = default;
 
   ThisType& operator=(const ThisType&) = delete;
 

--- a/dune/xt/common/memory.hh
+++ b/dune/xt/common/memory.hh
@@ -359,7 +359,7 @@ public:
   {
   }
 
-  ConstStorageProvider(ConstStorageProvider<T>&& source) = default;
+  ConstStorageProvider(ConstStorageProvider<T>&& source) noexcept = default;
 
   ConstStorageProvider<T>& operator=(const ConstStorageProvider<T>& other)
   {
@@ -368,7 +368,7 @@ public:
     return *this;
   }
 
-  ConstStorageProvider<T>& operator=(ConstStorageProvider<T>&& source) = default;
+  ConstStorageProvider<T>& operator=(ConstStorageProvider<T>&& source) noexcept = default;
 
   bool valid() const
   {
@@ -443,7 +443,7 @@ public:
   {
   }
 
-  StorageProvider(StorageProvider<T>&& source) = default;
+  StorageProvider(StorageProvider<T>&& source) noexcept = default;
 
   StorageProvider<T>& operator=(const StorageProvider<T>& other) = delete;
 
@@ -454,7 +454,7 @@ public:
     return *this;
   }
 
-  StorageProvider<T>& operator=(StorageProvider<T>&& source) = default;
+  StorageProvider<T>& operator=(StorageProvider<T>&& source) noexcept = default;
 
   bool valid() const
   {
@@ -538,10 +538,10 @@ public:
   }
 
   ConstSharedStorageProvider(const ConstSharedStorageProvider<T>& other) = default;
-  ConstSharedStorageProvider(ConstSharedStorageProvider<T>&& source) = default;
+  ConstSharedStorageProvider(ConstSharedStorageProvider<T>&& source) noexcept = default;
 
   ConstSharedStorageProvider<T>& operator=(const ConstSharedStorageProvider<T>& other) = default;
-  ConstSharedStorageProvider<T>& operator=(ConstSharedStorageProvider<T>&& source) = default;
+  ConstSharedStorageProvider<T>& operator=(ConstSharedStorageProvider<T>&& source) noexcept = default;
 
   std::shared_ptr<const T> access() const
   {

--- a/dune/xt/common/parameter.hh
+++ b/dune/xt/common/parameter.hh
@@ -35,7 +35,7 @@ public:
 
   SimpleDict(const SimpleDict& other) = default;
 
-  SimpleDict(SimpleDict&& source) = default;
+  SimpleDict(SimpleDict&& source) noexcept = default;
 
   SimpleDict(const std::string& key, const ValueType& value)
     : dict_({std::make_pair(key, value)})

--- a/dune/xt/common/print.hh
+++ b/dune/xt/common/print.hh
@@ -65,7 +65,7 @@ public:
   }
 
   DefaultPrinter(const ThisType&) = default;
-  DefaultPrinter(ThisType&&) = default;
+  DefaultPrinter(ThisType&&) noexcept = default;
 
   virtual ~DefaultPrinter() = default;
 

--- a/dune/xt/common/timedlogging.hh
+++ b/dune/xt/common/timedlogging.hh
@@ -446,13 +446,13 @@ public:
 
   NoOpEnableDebugLoggingForCtors(const ThisType& other) = default;
 
-  NoOpEnableDebugLoggingForCtors(ThisType&& source) = default;
+  NoOpEnableDebugLoggingForCtors(ThisType&& source) noexcept = default;
 
   ~NoOpEnableDebugLoggingForCtors() = default;
 
   ThisType& operator=(const ThisType& other) = default;
 
-  ThisType& operator=(ThisType&& source) = default;
+  ThisType& operator=(ThisType&& source) noexcept = default;
 
 }; // class NoOpEnableDebugLoggingForCtors
 

--- a/dune/xt/functions/ESV2007.hh
+++ b/dune/xt/functions/ESV2007.hh
@@ -85,7 +85,7 @@ public:
 
   Testcase1Force(const ThisType&) = default;
 
-  Testcase1Force(ThisType&&) = default;
+  Testcase1Force(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override
@@ -185,7 +185,7 @@ public:
 
   Testcase1ExactSolution(const ThisType&) = default;
 
-  Testcase1ExactSolution(ThisType&&) = default;
+  Testcase1ExactSolution(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override
@@ -381,7 +381,7 @@ public:
   {
   }
 
-  CutoffFunction(ThisType&&) = default;
+  CutoffFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/base/combined-element-functions.hh
+++ b/dune/xt/functions/base/combined-element-functions.hh
@@ -93,7 +93,7 @@ public:
 
   CombinedConstElementFunction(const ThisType&) = default;
 
-  CombinedConstElementFunction(ThisType&&) = default;
+  CombinedConstElementFunction(ThisType&&) noexcept = default;
 
 protected:
   void post_bind(const ElementType& /*element*/) override
@@ -190,7 +190,7 @@ public:
 
   CombinedElementFunction(const ThisType&) = default;
 
-  CombinedElementFunction(ThisType&&) = default;
+  CombinedElementFunction(ThisType&&) noexcept = default;
 
 protected:
   void post_bind(const ElementType& element) final

--- a/dune/xt/functions/base/combined-functions.hh
+++ b/dune/xt/functions/base/combined-functions.hh
@@ -116,7 +116,7 @@ public:
   {
   }
 
-  CombinedFunction(ThisType&& source) = default;
+  CombinedFunction(ThisType&& source) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override

--- a/dune/xt/functions/base/combined-grid-functions.hh
+++ b/dune/xt/functions/base/combined-grid-functions.hh
@@ -129,7 +129,7 @@ public:
   {
   }
 
-  CombinedGridFunction(ThisType&& source) = default;
+  CombinedGridFunction(ThisType&& source) noexcept = default;
 
   std::unique_ptr<LocalFunctionType> local_function() const final
   {

--- a/dune/xt/functions/base/combined.hh
+++ b/dune/xt/functions/base/combined.hh
@@ -340,7 +340,7 @@ struct CombinedStorageProvider
 
   CombinedStorageProvider(ThisType&) = default;
 
-  CombinedStorageProvider(ThisType&&) = default;
+  CombinedStorageProvider(ThisType&&) noexcept = default;
 }; // struct CombinedStorageProvider
 
 

--- a/dune/xt/functions/base/function-as-grid-function.hh
+++ b/dune/xt/functions/base/function-as-grid-function.hh
@@ -63,7 +63,7 @@ public:
   {
   }
 
-  FunctionAsGridFunctionWrapper(ThisType&&) = default;
+  FunctionAsGridFunctionWrapper(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/base/reinterpret.hh
+++ b/dune/xt/functions/base/reinterpret.hh
@@ -70,7 +70,7 @@ public:
   {
   }
 
-  ReinterpretLocalizableFunction(ThisType&&) = default;
+  ReinterpretLocalizableFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/base/sliced.hh
+++ b/dune/xt/functions/base/sliced.hh
@@ -133,7 +133,7 @@ public:
   {
   }
 
-  SlicedGridFunction(ThisType&&) = default;
+  SlicedGridFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/base/transformed.hh
+++ b/dune/xt/functions/base/transformed.hh
@@ -134,7 +134,7 @@ public:
   {
   }
 
-  TransformedGridFunction(ThisType&&) = default;
+  TransformedGridFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/checkerboard.hh
+++ b/dune/xt/functions/checkerboard.hh
@@ -195,7 +195,7 @@ public:
 
   CheckerboardFunction(const ThisType& other) = default;
 
-  CheckerboardFunction(ThisType&& source) = default;
+  CheckerboardFunction(ThisType&& source) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/elementwise-diameter.hh
+++ b/dune/xt/functions/elementwise-diameter.hh
@@ -84,7 +84,7 @@ public:
 
   ElementwiseDiameterFunction(const ThisType&) = default;
 
-  ElementwiseDiameterFunction(ThisType&&) = default;
+  ElementwiseDiameterFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/elementwise-minimum.hh
+++ b/dune/xt/functions/elementwise-minimum.hh
@@ -176,7 +176,7 @@ public:
   {
   }
 
-  ElementwiseMinimumFunction(ThisType&&) = default;
+  ElementwiseMinimumFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/expression/base.hh
+++ b/dune/xt/functions/expression/base.hh
@@ -244,7 +244,7 @@ public:
     setup(other.variables(), other.expressions());
   }
 
-  DynamicMathExpressionBase(ThisType&&) = default;
+  DynamicMathExpressionBase(ThisType&&) noexcept = default;
 
   ~DynamicMathExpressionBase()
   {

--- a/dune/xt/functions/expression/default.hh
+++ b/dune/xt/functions/expression/default.hh
@@ -154,7 +154,7 @@ public:
     }
   }
 
-  ExpressionFunction(ThisType&&) = default;
+  ExpressionFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override
@@ -348,7 +348,7 @@ public:
       gradients_.emplace_back(new MathExpressionGradientType(*other.gradients_[ii]));
   }
 
-  ExpressionFunction(ThisType&&) = default;
+  ExpressionFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override

--- a/dune/xt/functions/expression/parametric.hh
+++ b/dune/xt/functions/expression/parametric.hh
@@ -105,7 +105,7 @@ public:
   {
   }
 
-  ParametricExpressionFunction(ThisType&&) = default;
+  ParametricExpressionFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override

--- a/dune/xt/functions/generic/function.hh
+++ b/dune/xt/functions/generic/function.hh
@@ -120,7 +120,7 @@ public:
 
   GenericFunction(const ThisType&) = default;
 
-  GenericFunction(ThisType&&) = default;
+  GenericFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override

--- a/dune/xt/functions/generic/grid-function.hh
+++ b/dune/xt/functions/generic/grid-function.hh
@@ -212,7 +212,7 @@ public:
 
   GenericGridFunction(const ThisType&) = default;
 
-  GenericGridFunction(ThisType&&) = default;
+  GenericGridFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_grid_function_impl() const override

--- a/dune/xt/functions/grid-function.hh
+++ b/dune/xt/functions/grid-function.hh
@@ -248,7 +248,7 @@ public:
   {
   }
 
-  GridFunction(ThisType&& source) = default;
+  GridFunction(ThisType&& source) noexcept = default;
 
 
 private:
@@ -482,7 +482,7 @@ public:
   {
   }
 
-  GridFunction(ThisType&&) = default;
+  GridFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_grid_function_impl() const override
@@ -682,7 +682,7 @@ public:
   {
   }
 
-  GridFunction(ThisType&&) = default;
+  GridFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/functions/indicator.hh
+++ b/dune/xt/functions/indicator.hh
@@ -156,7 +156,7 @@ FunctionType function({{{{0., 1.}, {0., 1.}}, 0.7}, {{{6., 10.}, {8., 10.}}, 0.9
 
   IndicatorGridFunction(const ThisType&) = default;
 
-  IndicatorGridFunction(ThisType&&) = default;
+  IndicatorGridFunction(ThisType&&) noexcept = default;
 
 
 private:
@@ -237,7 +237,7 @@ public:
 
   IndicatorFunction(const ThisType&) = default;
 
-  IndicatorFunction(ThisType&&) = default;
+  IndicatorFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override

--- a/dune/xt/functions/interfaces/element-flux-functions.hh
+++ b/dune/xt/functions/interfaces/element-flux-functions.hh
@@ -110,7 +110,7 @@ public:
 
   ElementFluxFunctionSetInterface(const ThisType& other) = default;
 
-  ElementFluxFunctionSetInterface(ThisType&& source) = default;
+  ElementFluxFunctionSetInterface(ThisType&& source) noexcept = default;
 
   ~ElementFluxFunctionSetInterface() override = default;
 
@@ -406,12 +406,12 @@ public:
   }
 
   ElementFluxFunctionInterface(const ThisType& other) = default;
-  ElementFluxFunctionInterface(ThisType&& source) = default;
+  ElementFluxFunctionInterface(ThisType&& source) noexcept = default;
 
   virtual ~ElementFluxFunctionInterface() = default;
 
   ThisType& operator=(const ThisType& other) = default;
-  ThisType& operator=(ThisType&& source) = default;
+  ThisType& operator=(ThisType&& source) noexcept = default;
 
   using BaseType::evaluate;
   using BaseType::jacobian;

--- a/dune/xt/functions/interfaces/element-functions.hh
+++ b/dune/xt/functions/interfaces/element-functions.hh
@@ -142,7 +142,7 @@ public:
 
   ElementFunctionSetInterface(const ThisType& other) = default;
 
-  ElementFunctionSetInterface(ThisType&& source) = default;
+  ElementFunctionSetInterface(ThisType&& source) noexcept = default;
 
   ~ElementFunctionSetInterface() override = default;
 
@@ -499,12 +499,12 @@ public:
   }
 
   ElementFunctionInterface(const ThisType& other) = default;
-  ElementFunctionInterface(ThisType&& source) = default;
+  ElementFunctionInterface(ThisType&& source) noexcept = default;
 
   ~ElementFunctionInterface() override = default;
 
   ThisType& operator=(const ThisType& other) = default;
-  ThisType& operator=(ThisType&& source) = default;
+  ThisType& operator=(ThisType&& source) noexcept = default;
 
   using BaseType::evaluate;
 

--- a/dune/xt/functions/inverse.hh
+++ b/dune/xt/functions/inverse.hh
@@ -181,7 +181,7 @@ public:
   {
   }
 
-  InverseFunction(ThisType&&) = default;
+  InverseFunction(ThisType&&) noexcept = default;
 
 private:
   ThisType* copy_as_function_impl() const override
@@ -258,7 +258,7 @@ public:
   {
   }
 
-  InverseGridFunction(ThisType&&) = default;
+  InverseGridFunction(ThisType&&) noexcept = default;
 
 
 private:

--- a/dune/xt/grid/bound-object.hh
+++ b/dune/xt/grid/bound-object.hh
@@ -145,7 +145,7 @@ public:
     }
   }
 
-  IntersectionBoundObject(ThisType&& source) = default;
+  IntersectionBoundObject(ThisType&& source) noexcept = default;
 
   virtual ~IntersectionBoundObject() = default;
 

--- a/dune/xt/grid/boundaryinfo/functionbased.hh
+++ b/dune/xt/grid/boundaryinfo/functionbased.hh
@@ -65,7 +65,7 @@ public:
 
   FunctionBasedBoundaryInfo(const ThisType&) = delete;
 
-  FunctionBasedBoundaryInfo(ThisType&& source) = default;
+  FunctionBasedBoundaryInfo(ThisType&& source) noexcept = default;
 
   void repr(std::ostream& out) const final
   {

--- a/dune/xt/grid/boundaryinfo/interfaces.hh
+++ b/dune/xt/grid/boundaryinfo/interfaces.hh
@@ -88,7 +88,7 @@ public:
 
   BoundaryInfo(const ThisType&) = default;
 
-  BoundaryInfo(ThisType&&) = default;
+  BoundaryInfo(ThisType&&) noexcept = default;
 
   virtual ~BoundaryInfo() = default;
 

--- a/dune/xt/grid/boundaryinfo/normalbased.hh
+++ b/dune/xt/grid/boundaryinfo/normalbased.hh
@@ -178,7 +178,7 @@ public:
 
   NormalBasedBoundaryInfo(const ThisType&) = delete;
 
-  NormalBasedBoundaryInfo(ThisType&& source) = default;
+  NormalBasedBoundaryInfo(ThisType&& source) noexcept = default;
 
   void repr(std::ostream& out) const final
   {

--- a/dune/xt/grid/filters/base.hh
+++ b/dune/xt/grid/filters/base.hh
@@ -140,7 +140,7 @@ public:
 
   IntersectionFilter(const IntersectionFilter<GL>&) = default;
 
-  IntersectionFilter(IntersectionFilter<GL>&&) = default;
+  IntersectionFilter(IntersectionFilter<GL>&&) noexcept = default;
 
   virtual ~IntersectionFilter() = default;
 

--- a/dune/xt/grid/view/coupling.hh
+++ b/dune/xt/grid/view/coupling.hh
@@ -253,9 +253,9 @@ public:
   } // constructor CouplingGridViewWrapper(...)
 
   CouplingGridViewWrapper(const ThisType& other) = default;
-  CouplingGridViewWrapper(ThisType&& other) = default;
+  CouplingGridViewWrapper(ThisType&& other) noexcept = default;
   ThisType& operator=(const ThisType& other) = default;
-  ThisType& operator=(ThisType&& other) = default;
+  ThisType& operator=(ThisType&& other) noexcept = default;
 
   // This is the only member function that actually changes the state of the CouplingGridView. The copy constructor and
   // copy assignment operators only do a shallow copy of the shared_ptrs, so we have to make sure that we reassign the

--- a/dune/xt/grid/view/periodic.hh
+++ b/dune/xt/grid/view/periodic.hh
@@ -275,7 +275,7 @@ public:
   }
 
   PeriodicIndexSet(const ThisType& other) = default;
-  PeriodicIndexSet(ThisType&& other) = default;
+  PeriodicIndexSet(ThisType&& other) noexcept = default;
   // assigment currently does not work due to the reference members
   ThisType& operator=(const ThisType& other) = delete;
   ThisType& operator=(ThisType&& other) = delete;
@@ -385,9 +385,9 @@ public:
   }
 
   PeriodicIntersectionImp(const PeriodicIntersectionImp& other) = default;
-  PeriodicIntersectionImp(PeriodicIntersectionImp&& other) = default;
+  PeriodicIntersectionImp(PeriodicIntersectionImp&& other) noexcept = default;
   PeriodicIntersectionImp& operator=(const PeriodicIntersectionImp& other) = default;
-  PeriodicIntersectionImp& operator=(PeriodicIntersectionImp&& other) = default;
+  PeriodicIntersectionImp& operator=(PeriodicIntersectionImp&& other) noexcept = default;
 
   // methods that differ from BaseType
   bool neighbor() const
@@ -493,8 +493,8 @@ public:
 
   ThisType& operator=(const ThisType& other) = default;
 
-  PeriodicIntersectionIterator(ThisType&& other) = default;
-  ThisType& operator=(ThisType&& other) = default;
+  PeriodicIntersectionIterator(ThisType&& other) noexcept = default;
+  ThisType& operator=(ThisType&& other) noexcept = default;
 
   // methods that differ from BaseType
   Intersection operator*() const
@@ -687,9 +687,9 @@ public:
   } // constructor PeriodicGridViewWrapper(...)
 
   PeriodicGridViewWrapper(const ThisType& other) = default;
-  PeriodicGridViewWrapper(ThisType&& other) = default;
+  PeriodicGridViewWrapper(ThisType&& other) noexcept = default;
   ThisType& operator=(const ThisType& other) = default;
-  ThisType& operator=(ThisType&& other) = default;
+  ThisType& operator=(ThisType&& other) noexcept = default;
 
   const BaseType& as_base_grid_view() const
   {

--- a/dune/xt/grid/walker.hh
+++ b/dune/xt/grid/walker.hh
@@ -259,7 +259,7 @@ public:
     reinitialize_thread_storage();
   }
 
-  Walker(ThisType&& source) = default;
+  Walker(ThisType&& source) noexcept = default;
 
   ~Walker() override = default;
 

--- a/dune/xt/la/container/container-interface.hh
+++ b/dune/xt/la/container/container-interface.hh
@@ -121,7 +121,7 @@ public:
     return *this;
   }
 
-  ThisType& operator=(ThisType&& other)
+  ThisType& operator=(ThisType&& other) noexcept
   {
     this->as_imp() = std::move(other.as_imp());
     return *this;
@@ -129,7 +129,7 @@ public:
 
 protected:
   ContainerInterface(const ThisType& other) = default;
-  ContainerInterface(ThisType&& other) = default;
+  ContainerInterface(ThisType&& other) noexcept = default;
 
 public:
   /// \name Have to be implemented by a derived class!

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -85,7 +85,7 @@ public:
   {
   }
 
-  EigenBaseVector(EigenBaseVector&& source) = default;
+  EigenBaseVector(EigenBaseVector&& source) noexcept = default;
 
   using InterfaceType::operator=;
 

--- a/dune/xt/la/container/matrix-view.hh
+++ b/dune/xt/la/container/matrix-view.hh
@@ -128,8 +128,8 @@ public:
   }
 
   // Moving from another view is fine
-  ConstMatrixView(ThisType&& other) = default;
-  ThisType& operator=(ThisType&& other) = default;
+  ConstMatrixView(ThisType&& other) noexcept = default;
+  ThisType& operator=(ThisType&& other) noexcept = default;
 
   // No assignment as this is a const view
   ThisType& operator=(const ThisType& other) = delete;
@@ -348,8 +348,8 @@ public:
   }
 
   // Moving from another view is fine
-  MatrixView(ThisType&& other) = default;
-  ThisType& operator=(ThisType&& other) = default;
+  MatrixView(ThisType&& other) noexcept = default;
+  ThisType& operator=(ThisType&& other) noexcept = default;
 
   // Allow copy assignment from any dune-xt-la matrix
   template <class Mat>

--- a/dune/xt/la/container/vector-view.hh
+++ b/dune/xt/la/container/vector-view.hh
@@ -126,7 +126,7 @@ public:
     DUNE_THROW(Dune::NotImplemented, "Copying is disabled, simply create a new view!");
   }
   // Moving from another view is fine
-  ConstVectorView(ThisType&& other) = default;
+  ConstVectorView(ThisType&& other) noexcept = default;
   // No assignment as this is a const view
   ThisType& operator=(const ThisType& other) = delete;
   ThisType& operator=(ThisType&& other) = delete;
@@ -306,8 +306,8 @@ public:
   }
 
   // Moving from another view is fine
-  VectorView(ThisType&& other) = default;
-  ThisType& operator=(VectorView&& other) = default;
+  VectorView(ThisType&& other) noexcept = default;
+  ThisType& operator=(VectorView&& other) noexcept = default;
 
   // Allow copy assignment from any vector
   template <class Vec>

--- a/dune/xt/la/eigen-solver/internal/base.hh
+++ b/dune/xt/la/eigen-solver/internal/base.hh
@@ -120,7 +120,7 @@ public:
 
   EigenSolverBase(const ThisType& other) = default;
 
-  EigenSolverBase(ThisType&& source) = default;
+  EigenSolverBase(ThisType&& source) noexcept = default;
 
   virtual ~EigenSolverBase() = default;
 

--- a/dune/xt/la/generalized-eigen-solver/internal/base.hh
+++ b/dune/xt/la/generalized-eigen-solver/internal/base.hh
@@ -123,7 +123,7 @@ public:
 
   GeneralizedEigenSolverBase(const ThisType& other) = default;
 
-  GeneralizedEigenSolverBase(ThisType&& source) = default;
+  GeneralizedEigenSolverBase(ThisType&& source) noexcept = default;
 
   virtual ~GeneralizedEigenSolverBase() = default;
 

--- a/dune/xt/la/solver/istl.hh
+++ b/dune/xt/la/solver/istl.hh
@@ -188,7 +188,7 @@ public:
   {
   }
 
-  Solver(Solver&& source) = default;
+  Solver(Solver&& source) noexcept = default;
 
   static std::vector<std::string> types()
   {

--- a/python/gdt/dune/gdt/local/bilinear-forms/vectorized_element_integrals.cc
+++ b/python/gdt/dune/gdt/local/bilinear-forms/vectorized_element_integrals.cc
@@ -170,7 +170,7 @@ public:
 
   VectorizedLocalElementIntegralBilinearForm(const ThisType& other) = default;
 
-  VectorizedLocalElementIntegralBilinearForm(ThisType&& source) = default;
+  VectorizedLocalElementIntegralBilinearForm(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {

--- a/python/gdt/dune/gdt/local/functionals/vectorized_element_integrals.cc
+++ b/python/gdt/dune/gdt/local/functionals/vectorized_element_integrals.cc
@@ -132,7 +132,7 @@ public:
 
   VectorizedLocalElementIntegralFunctional(const ThisType& other) = default;
 
-  VectorizedLocalElementIntegralFunctional(ThisType&& source) = default;
+  VectorizedLocalElementIntegralFunctional(ThisType&& source) noexcept = default;
 
   std::unique_ptr<BaseType> copy() const override final
   {


### PR DESCRIPTION
Resolves #207 — SonarCloud BLOCKER rule **`cpp:S5018`** ("declare move constructors `noexcept`"), the largest BLOCKER rule in the project.

## What

Added `noexcept` to all **165** user-defined move constructors and move-assignment operators flagged by SonarCloud, across 97 files in `dune/gdt/*`, `dune/xt/*` and the `python/gdt/*` bindings.

- **161** are one-line defaulted operations (`Name(ThisType&&) = default;` → `Name(ThisType&&) noexcept = default;`).
- **4** have explicit bodies and received `noexcept` on their signatures:
  - `dune/gdt/local/finite-elements/default.hh` — `ThreadSafeDefaultLocalFiniteElementFamily`
  - `dune/gdt/operators/advection-fv.hh` — `AdvectionFvOperator`
  - `dune/gdt/operators/matrix.hh` — `ConstMatrixOperator`
  - `dune/xt/la/container/container-interface.hh` — `operator=(ThisType&&)`

The flagged operations move only handles, pointers, `shared_ptr`s, grid views and other `noexcept`-movable members. Declaring them `noexcept` lets standard containers (e.g. `std::vector` reallocation) move rather than copy them, matching the `cppcoreguidelines` guidance.

## Why this is compile-safe

Forcing `noexcept` on a *defaulted* move whose implicit specification would be `noexcept(false)` does **not** delete it under P1286R2, which GCC and Clang apply retroactively across `-std=c++17`/`c++20`. Verified locally with both compilers (`g++ 13`, `clang 18`): the move stays move-constructible and becomes `nothrow`-move-constructible. So the only effect is the intended one — the moves are now `noexcept`.

## Verification

- All 165 lines confirmed to carry exactly one `noexcept` (no duplicates).
- `clang-format --dry-run` shows the inserted `noexcept` introduces no formatting changes.
- Full compile/SonarCloud re-scan is left to CI.

The issue suggested splitting `dune/xt/*` and `dune/gdt/*` into separate PRs; since the change is purely mechanical and uniform, it is kept as one reviewable diff (one line each). Happy to split if preferred.

Closes #207

https://claude.ai/code/session_01GLavGd9mL8q2HrwYRLQcLP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLavGd9mL8q2HrwYRLQcLP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated exception specifications for move operations across multiple components including discrete functions, operators, functionals, integrands, bilinear forms, spaces, and grid utilities by declaring move constructors and move assignment operators as non-throwing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->