### PR TITLE
engine: insert implicit '*' for ')(' juxtaposition (fix docs build)

### DIFF
--- a/dune/xt/functions/expression/engine.cc
+++ b/dune/xt/functions/expression/engine.cc
@@ -163,11 +163,11 @@ private:
    * registered variable (function names, the constant pi, numeric literals, operators) is passed
    * through unchanged.
    *
-   * Two identifier tokens written directly next to each other ("x[0]t_") denote implicit
-   * multiplication. Because each is rewritten to a placeholder, naive concatenation would glue them
-   * into a single unknown identifier ("dxtvar0dxtvar1"). We therefore emit an explicit '*' between
-   * directly adjacent identifier tokens, which is exactly the multiplication ExprTk's commutative
-   * check would insert for the original (non-remapped) names.
+   * Juxtaposition denotes implicit multiplication. ExprTk's commutative check does not cover every
+   * such case (and the variable remapping can defeat it), so we insert the explicit '*' ourselves
+   * for: two adjacent identifier tokens ("x[0]t_", which would otherwise fuse into one unknown
+   * identifier "dxtvar0dxtvar1"), a digit right after an identifier ("x[0]2"), and a "(" right after
+   * a ")" ("sin(...)(...)", which ExprTk rejects rather than reading as multiplication).
    */
   std::string translate(const std::string& expr) const
   {
@@ -180,10 +180,12 @@ private:
     std::size_t prev_ident_end = std::string::npos;
     while (i < n) {
       if (!is_ident_start(expr[i])) {
-        // A digit directly following an identifier token (e.g. "x[0]2") is implicit multiplication too.
-        // The placeholder ends in a digit ("dxtvar0"), so without a separator it would fuse with the
-        // literal into one symbol ("dxtvar02"); emit the '*' that ExprTk would insert for the raw "]2".
-        if (i == prev_ident_end && is_digit(expr[i]))
+        // Implicit multiplications that ExprTk's commutative check does not insert on its own:
+        //   - a digit directly after an identifier token ("x[0]2"): the placeholder ends in a digit
+        //     ("dxtvar0"), so without a separator it would fuse with the literal into one symbol;
+        //   - a "(" directly after a ")" ("sin(...)(...)"): ExprTk rejects ")(" rather than reading it
+        //     as multiplication.
+        if ((i == prev_ident_end && is_digit(expr[i])) || (expr[i] == '(' && !out.empty() && out.back() == ')'))
           out += '*';
         out += expr[i];
         prev_ident_end = std::string::npos;

--- a/dune/xt/functions/expression/engine.hh
+++ b/dune/xt/functions/expression/engine.hh
@@ -33,8 +33,9 @@ namespace Dune::XT::Functions::internal {
  * \c sin, \c cos, \c tan, \c exp, \c log (alias \c ln), \c sqrt, \c abs, \c asin, \c acos, \c atan and
  * the constant \c pi (plus the additional functionality ExprTk provides).
  *
- * \note Unlike the bundled parser, implicit multiplication by juxtaposition (e.g. "x[0]t" meaning
- *       "x[0]*t") is not supported; use an explicit \c * instead.
+ * \note Implicit multiplication by juxtaposition is supported, e.g. "x[0]t" means "x[0]*t",
+ *       "x[0]2" means "x[0]*2" and "sin(t)(x)" means "sin(t)*(x)". An explicit \c * is still
+ *       recommended for readability.
  */
 class MathExpressionEngine
 {


### PR DESCRIPTION
## Why

Follow-up to #223. That PR reverted the explicit-`*` workaround in the heat-equation example back to the juxtaposed form `…sin(20*pi*_t)(x[0]*x[0]+x[1]*x[1])…`, on the assumption that ExprTk's commutative check would read the `)(` as multiplication. It does **not** — the docs build (which executes the notebook against the freshly built wheels) fails to parse it:

```
ExprTk reported: ERR239 - Expected ')' instead of: '('
```

The `)(` fix didn't make it into #223 before that PR entered the merge queue, so `main`'s docs build is currently red on this expression.

## What

Extend `MathExpressionEngine`'s `translate()` to insert an explicit `*` when a `(` directly follows a `)` (`sin(...)(...)` → `sin(...)*(...)`), alongside the existing identifier↔identifier and identifier↔digit adjacency handling. An existing `*` between the parentheses is preserved (no double operator), and function calls (`name(`) are unaffected since the `(` there does not follow a `)`.

This makes the reverted example expression evaluate exactly as the pre-revert explicit-`*` form did, so the docs build passes again while keeping the juxtaposition syntax that #215's author (ExprTk's Arash Partow) confirmed should work.

## Verification

Simulated `translate()` against the failing doc expression and regression cases:
- `sin(20*pi*_t)(x[0]*x[0]+x[1]*x[1])` → inserts `*` at the `)(`, identical to the explicit-`*` form
- `exp(x)*(y)` → unchanged (no double `*`)
- `(x+1)(y-2)` → `(x+1)*(y-2)`
- `sin(x[0])`, `1e-5*x[0]`, `x[0]2`, `sin(x[0]t_)` → unaffected / correct

https://claude.ai/code/session_015eLU6XZpGBQo7pSb4NNWPd

---
_Generated by [Claude Code](https://claude.ai/code/session_015eLU6XZpGBQo7pSb4NNWPd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression parsing to better handle implicit multiplication—covers cases where a digit or an opening parenthesis follows prior tokens (e.g., preventing token fusion and accepting juxtaposed parentheses).
* **Documentation**
  * Clarified that implicit multiplication by juxtaposition is supported (examples added), while recommending explicit '*' where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->