### PR TITLE
Reduce control-flow nesting in sparsity-pattern.hh & convergence-study.cc (cpp:S134, batch 5/12)

### DIFF
--- a/dune/gdt/tools/sparsity-pattern.hh
+++ b/dune/gdt/tools/sparsity-pattern.hh
@@ -28,6 +28,21 @@
 
 namespace Dune {
 namespace GDT {
+namespace internal {
+
+
+// Inserts pattern.insert(row_indices[i], col_indices[j]) for all i in [0, n_rows) and j in [0, n_cols).
+template <class P, class V>
+void insert_index_cross_product(
+    P& pattern, const size_t n_rows, const size_t n_cols, const V& row_indices, const V& col_indices)
+{
+  for (size_t i = 0; i < n_rows; ++i)
+    for (size_t j = 0; j < n_cols; ++j)
+      pattern.insert(row_indices[i], col_indices[j]);
+}
+
+
+} // namespace internal
 
 
 /**
@@ -85,13 +100,13 @@ make_intersection_sparsity_pattern(const SpaceInterface<TGV, t_r, t_rC, TR>& tes
   for (auto&& element : elements(grid_view)) {
     test_space.mapper().global_indices(element, row_indices);
     for (auto&& intersection : intersections(grid_view, element)) {
-      if (intersection.neighbor()) {
-        const auto neighbour = intersection.outside();
-        ansatz_space.mapper().global_indices(neighbour, column_indices);
-        for (size_t ii = 0; ii < test_space.mapper().local_size(element); ++ii)
-          for (size_t jj = 0; jj < ansatz_space.mapper().local_size(neighbour); ++jj)
-            pattern.insert(row_indices[ii], column_indices[jj]);
-      }
+      if (!intersection.neighbor())
+        continue;
+      const auto neighbour = intersection.outside();
+      ansatz_space.mapper().global_indices(neighbour, column_indices);
+      for (size_t ii = 0; ii < test_space.mapper().local_size(element); ++ii)
+        for (size_t jj = 0; jj < ansatz_space.mapper().local_size(neighbour); ++jj)
+          pattern.insert(row_indices[ii], column_indices[jj]);
     }
   }
   pattern.sort();
@@ -134,13 +149,13 @@ make_element_and_intersection_sparsity_pattern(const SpaceInterface<TGV, t_r, t_
       for (size_t jj = 0; jj < ansatz_space.mapper().local_size(element); ++jj)
         pattern.insert(row_indices[ii], column_indices[jj]);
     for (auto&& intersection : intersections(grid_view, element)) {
-      if (intersection.neighbor()) {
-        const auto neighbour = intersection.outside();
-        ansatz_space.mapper().global_indices(neighbour, column_indices);
-        for (size_t ii = 0; ii < test_space.mapper().local_size(element); ++ii)
-          for (size_t jj = 0; jj < ansatz_space.mapper().local_size(neighbour); ++jj)
-            pattern.insert(row_indices[ii], column_indices[jj]);
-      }
+      if (!intersection.neighbor())
+        continue;
+      const auto neighbour = intersection.outside();
+      ansatz_space.mapper().global_indices(neighbour, column_indices);
+      for (size_t ii = 0; ii < test_space.mapper().local_size(element); ++ii)
+        for (size_t jj = 0; jj < ansatz_space.mapper().local_size(neighbour); ++jj)
+          pattern.insert(row_indices[ii], column_indices[jj]);
     }
   }
   pattern.sort();
@@ -220,18 +235,12 @@ XT::LA::SparsityPatternDefault make_coupling_sparsity_pattern(const SpaceInterfa
       const auto outside = intersection.outside();
       test_space.mapper().global_indices(inside, global_indices_in);
       ansatz_space.mapper().global_indices(outside, global_indices_out);
-      for (size_t ii = 0; ii < test_space.mapper().local_size(inside); ++ii)
-        for (size_t jj = 0; jj < test_space.mapper().local_size(inside); ++jj)
-          pattern.insert(global_indices_in[ii], global_indices_in[jj]);
-      for (size_t ii = 0; ii < test_space.mapper().local_size(inside); ++ii)
-        for (size_t jj = 0; jj < ansatz_space.mapper().local_size(outside); ++jj)
-          pattern.insert(global_indices_in[ii], global_indices_out[jj]);
-      for (size_t ii = 0; ii < ansatz_space.mapper().local_size(outside); ++ii)
-        for (size_t jj = 0; jj < test_space.mapper().local_size(inside); ++jj)
-          pattern.insert(global_indices_out[jj], global_indices_in[ii]);
-      for (size_t ii = 0; ii < ansatz_space.mapper().local_size(outside); ++ii)
-        for (size_t jj = 0; jj < ansatz_space.mapper().local_size(outside); ++jj)
-          pattern.insert(global_indices_out[ii], global_indices_out[jj]);
+      const size_t inside_size = test_space.mapper().local_size(inside);
+      const size_t outside_size = ansatz_space.mapper().local_size(outside);
+      internal::insert_index_cross_product(pattern, inside_size, inside_size, global_indices_in, global_indices_in);
+      internal::insert_index_cross_product(pattern, inside_size, outside_size, global_indices_in, global_indices_out);
+      internal::insert_index_cross_product(pattern, inside_size, outside_size, global_indices_out, global_indices_in);
+      internal::insert_index_cross_product(pattern, outside_size, outside_size, global_indices_out, global_indices_out);
     }
   }
   pattern.sort();

--- a/dune/gdt/tools/sparsity-pattern.hh
+++ b/dune/gdt/tools/sparsity-pattern.hh
@@ -31,7 +31,7 @@ namespace GDT {
 namespace internal {
 
 
-// Inserts pattern.insert(row_indices[i], col_indices[j]) for all i in [0, n_rows) and j in [0, n_cols).
+// Inserts all (row_indices[i], col_indices[j]) pairs for i in [0, n_rows), j in [0, n_cols) into the pattern.
 template <class P, class V>
 void insert_index_cross_product(
     P& pattern, const size_t n_rows, const size_t n_cols, const V& row_indices, const V& col_indices)
@@ -39,6 +39,32 @@ void insert_index_cross_product(
   for (size_t i = 0; i < n_rows; ++i)
     for (size_t j = 0; j < n_cols; ++j)
       pattern.insert(row_indices[i], col_indices[j]);
+}
+
+
+// Adds the coupling entries between an element and all its (existing) neighbours to the pattern. Keeping this in a
+// dedicated helper avoids deeply nested control flow (cpp:S134) and the duplication of this loop between the
+// intersection-only and element-and-intersection pattern builders.
+template <class P, class TestSpace, class AnsatzSpace, class GV, class Element, class V>
+void insert_intersection_couplings(P& pattern,
+                                   const TestSpace& test_space,
+                                   const AnsatzSpace& ansatz_space,
+                                   const GV& grid_view,
+                                   const Element& element,
+                                   const V& row_indices,
+                                   V& column_indices)
+{
+  for (auto&& intersection : intersections(grid_view, element)) {
+    if (!intersection.neighbor())
+      continue;
+    const auto neighbour = intersection.outside();
+    ansatz_space.mapper().global_indices(neighbour, column_indices);
+    insert_index_cross_product(pattern,
+                               test_space.mapper().local_size(element),
+                               ansatz_space.mapper().local_size(neighbour),
+                               row_indices,
+                               column_indices);
+  }
 }
 
 
@@ -99,15 +125,8 @@ make_intersection_sparsity_pattern(const SpaceInterface<TGV, t_r, t_rC, TR>& tes
   DynamicVector<size_t> column_indices(ansatz_space.mapper().max_local_size(), 0);
   for (auto&& element : elements(grid_view)) {
     test_space.mapper().global_indices(element, row_indices);
-    for (auto&& intersection : intersections(grid_view, element)) {
-      if (!intersection.neighbor())
-        continue;
-      const auto neighbour = intersection.outside();
-      ansatz_space.mapper().global_indices(neighbour, column_indices);
-      for (size_t ii = 0; ii < test_space.mapper().local_size(element); ++ii)
-        for (size_t jj = 0; jj < ansatz_space.mapper().local_size(neighbour); ++jj)
-          pattern.insert(row_indices[ii], column_indices[jj]);
-    }
+    internal::insert_intersection_couplings(
+        pattern, test_space, ansatz_space, grid_view, element, row_indices, column_indices);
   }
   pattern.sort();
   return pattern;
@@ -148,15 +167,8 @@ make_element_and_intersection_sparsity_pattern(const SpaceInterface<TGV, t_r, t_
     for (size_t ii = 0; ii < test_space.mapper().local_size(element); ++ii)
       for (size_t jj = 0; jj < ansatz_space.mapper().local_size(element); ++jj)
         pattern.insert(row_indices[ii], column_indices[jj]);
-    for (auto&& intersection : intersections(grid_view, element)) {
-      if (!intersection.neighbor())
-        continue;
-      const auto neighbour = intersection.outside();
-      ansatz_space.mapper().global_indices(neighbour, column_indices);
-      for (size_t ii = 0; ii < test_space.mapper().local_size(element); ++ii)
-        for (size_t jj = 0; jj < ansatz_space.mapper().local_size(neighbour); ++jj)
-          pattern.insert(row_indices[ii], column_indices[jj]);
-    }
+    internal::insert_intersection_couplings(
+        pattern, test_space, ansatz_space, grid_view, element, row_indices, column_indices);
   }
   pattern.sort();
   return pattern;
@@ -235,8 +247,8 @@ XT::LA::SparsityPatternDefault make_coupling_sparsity_pattern(const SpaceInterfa
       const auto outside = intersection.outside();
       test_space.mapper().global_indices(inside, global_indices_in);
       ansatz_space.mapper().global_indices(outside, global_indices_out);
-      const size_t inside_size = test_space.mapper().local_size(inside);
-      const size_t outside_size = ansatz_space.mapper().local_size(outside);
+      const auto inside_size = test_space.mapper().local_size(inside);
+      const auto outside_size = ansatz_space.mapper().local_size(outside);
       internal::insert_index_cross_product(pattern, inside_size, inside_size, global_indices_in, global_indices_in);
       internal::insert_index_cross_product(pattern, inside_size, outside_size, global_indices_in, global_indices_out);
       internal::insert_index_cross_product(pattern, inside_size, outside_size, global_indices_out, global_indices_in);

--- a/dune/xt/common/convergence-study.cc
+++ b/dune/xt/common/convergence-study.cc
@@ -142,6 +142,85 @@ void ConvergenceStudy::print_eoc(std::ostream& out,
   }
 } // ... print_eoc(...)
 
+std::array<std::string, 3> ConvergenceStudy::wrap_quantity_id(const std::string& id, const size_t column_width) const
+{
+  std::string first_row;
+  std::string second_row;
+  std::string third_row;
+  auto words = tokenize(id, " ");
+  if (id.size() <= column_width) {
+    first_row = std::string(column_width, ' ');
+    second_row = lfill(id, column_width);
+    third_row = std::string(column_width, ' ');
+    return {first_row, second_row, third_row};
+  }
+  // lets see if we can fit all words in these rows somehow nicely
+  int last_row = 0;
+  // Note: erase() invalidates word_it and already yields the iterator to the next word, so the loop must not
+  // advance on its own after a word was consumed (doing so skipped a word and, once the last one was erased,
+  // stepped past end() -- from where the loop condition never held again and the iteration ran off the vector).
+  for (auto word_it = words.begin(); word_it != words.end();) {
+    const auto& word = *word_it;
+    if (word.size() > column_width)
+      break;
+    if (last_row <= 1 && word.size() <= (column_width - first_row.size() - (first_row.empty() ? 0 : 1))) {
+      first_row += (first_row.empty() ? "" : " ") + word;
+      last_row = 1;
+      word_it = words.erase(word_it);
+    } else if (last_row <= 2 && word.size() <= (column_width - second_row.size() - (second_row.empty() ? 0 : 1))) {
+      second_row += (second_row.empty() ? "" : " ") + word;
+      last_row = 2;
+      word_it = words.erase(word_it);
+    } else if (last_row <= 3 && word.size() <= (column_width - third_row.size() - (third_row.empty() ? 0 : 1))) {
+      third_row += (third_row.empty() ? "" : " ") + word;
+      last_row = 3;
+      word_it = words.erase(word_it);
+    } else
+      ++word_it;
+  }
+  if (words.empty()) {
+    // this worked, align right
+    first_row = lfill(first_row, column_width);
+    second_row = lfill(second_row, column_width);
+    third_row = lfill(third_row, column_width);
+    return {first_row, second_row, third_row};
+  }
+  // the above did not work/cover all words, now brute force
+  if (id.size() <= column_width) {
+    first_row = lfill(id, column_width);
+    second_row = std::string(column_width, ' ');
+    third_row = std::string(column_width, ' ');
+  } else if (id.size() <= 2 * column_width) {
+    first_row = id.substr(0, column_width);
+    second_row = lfill(id.substr(column_width, column_width), column_width);
+    third_row = std::string(column_width, ' ');
+  } else {
+    first_row = id.substr(0, column_width);
+    second_row = id.substr(column_width, column_width);
+    third_row = lfill(id.substr(2 * column_width), column_width);
+  }
+  return {first_row, second_row, third_row};
+} // ... wrap_quantity_id(...)
+
+void ConvergenceStudy::print_norm_eocs(
+    std::ostream& out,
+    const size_t eoc_column_width,
+    const std::map<size_t, std::map<std::string, std::map<std::string, double>>>& data,
+    const size_t level,
+    const std::string& id,
+    const std::vector<std::string>& actual_targets) const
+{
+  for (const auto& target_id : actual_targets) {
+    if (level == 0)
+      out << "| " << lfill("----", eoc_column_width) << " " << std::flush;
+    else {
+      out << "| ";
+      print_eoc(out, eoc_column_width, data, level, "norm", id, target_id);
+      out << " " << std::flush;
+    }
+  }
+} // ... print_norm_eocs(...)
+
 std::map<std::string, std::map<std::string, std::map<size_t, double>>>
 ConvergenceStudy::run(const std::vector<std::string>& only_these, std::ostream& out)
 {
@@ -209,64 +288,10 @@ ConvergenceStudy::run(const std::vector<std::string>& only_these, std::ostream& 
 #endif // 0
   // - quantities
   for (const auto& id : actual_quantities) {
-    std::string first_row;
-    std::string second_row;
-    std::string third_row;
-    auto words = tokenize(id, " ");
-    if (id.size() <= column_width) {
-      first_row = std::string(column_width, ' ');
-      second_row = lfill(id, column_width);
-      third_row = std::string(column_width, ' ');
-    } else {
-      // lets see if we can fit all words in these rows somehow nicely
-      int last_row = 0;
-      // Note: erase() invalidates word_it and already yields the iterator to the next word, so the loop must not
-      // advance on its own after a word was consumed (doing so skipped a word and, once the last one was erased,
-      // stepped past end() -- from where the loop condition never held again and the iteration ran off the vector).
-      for (auto word_it = words.begin(); word_it != words.end();) {
-        const auto& word = *word_it;
-        if (word.size() > column_width)
-          break;
-        if (last_row <= 1 && word.size() <= (column_width - first_row.size() - (first_row.empty() ? 0 : 1))) {
-          first_row += (first_row.empty() ? "" : " ") + word;
-          last_row = 1;
-          word_it = words.erase(word_it);
-        } else if (last_row <= 2 && word.size() <= (column_width - second_row.size() - (second_row.empty() ? 0 : 1))) {
-          second_row += (second_row.empty() ? "" : " ") + word;
-          last_row = 2;
-          word_it = words.erase(word_it);
-        } else if (last_row <= 3 && word.size() <= (column_width - third_row.size() - (third_row.empty() ? 0 : 1))) {
-          third_row += (third_row.empty() ? "" : " ") + word;
-          last_row = 3;
-          word_it = words.erase(word_it);
-        } else
-          ++word_it;
-      }
-      if (words.empty()) {
-        // this worked, align right
-        first_row = lfill(first_row, column_width);
-        second_row = lfill(second_row, column_width);
-        third_row = lfill(third_row, column_width);
-      } else {
-        // the above did not work/cover all words, now brute force
-        if (id.size() <= column_width) {
-          first_row = lfill(id, column_width);
-          second_row = std::string(column_width, ' ');
-          third_row = std::string(column_width, ' ');
-        } else if (id.size() <= 2 * column_width) {
-          first_row = id.substr(0, column_width);
-          second_row = lfill(id.substr(column_width, column_width), column_width);
-          third_row = std::string(column_width, ' ');
-        } else {
-          first_row = id.substr(0, column_width);
-          second_row = id.substr(column_width, column_width);
-          third_row = lfill(id.substr(2 * column_width), column_width);
-        }
-      }
-    }
-    h1 += "| " + first_row + " ";
-    d1 += "+ " + second_row + " ";
-    h2 += "| " + third_row + " ";
+    const auto rows = wrap_quantity_id(id, column_width);
+    h1 += "| " + rows[0] + " ";
+    d1 += "+ " + rows[1] + " ";
+    h2 += "| " + rows[2] + " ";
     delim += "+" + std::string(column_width + 2, '-');
   }
   // print header
@@ -294,15 +319,7 @@ ConvergenceStudy::run(const std::vector<std::string>& only_these, std::ostream& 
       std::stringstream ss;
       ss << std::setprecision(2) << std::scientific << extract(data, level, "norm", id);
       out << "| " << lfill(ss.str(), column_width) << " " << std::flush;
-      for (const auto& target_id : actual_targets) {
-        if (level == 0)
-          out << "| " << lfill("----", eoc_column_width) << " " << std::flush;
-        else {
-          out << "| ";
-          print_eoc(out, eoc_column_width, data, level, "norm", id, target_id);
-          out << " " << std::flush;
-        }
-      }
+      print_norm_eocs(out, eoc_column_width, data, level, id, actual_targets);
     }
 // - estimates
 #if 0

--- a/dune/xt/common/convergence-study.hh
+++ b/dune/xt/common/convergence-study.hh
@@ -15,6 +15,7 @@
 #ifndef DUNE_XT_COMMON_CONVERGENCE_STUDY_HH
 #define DUNE_XT_COMMON_CONVERGENCE_STUDY_HH
 
+#include <array>
 #include <vector>
 #include <map>
 #include <string>
@@ -140,6 +141,15 @@ protected:
                  const std::string& type,
                  const std::string& id,
                  const std::string& target_id) const;
+
+  std::array<std::string, 3> wrap_quantity_id(const std::string& id, const size_t column_width) const;
+
+  void print_norm_eocs(std::ostream& out,
+                       const size_t eoc_column_width,
+                       const std::map<size_t, std::map<std::string, std::map<std::string, double>>>& data,
+                       const size_t level,
+                       const std::string& id,
+                       const std::vector<std::string>& actual_targets) const;
 
 public:
   /**


### PR DESCRIPTION
## Summary

Batch 5 of 12 addressing SonarCloud rule **cpp:S134** ("Refactor this code to not nest more than 3 `if`/`for`/`do`/`while`/`switch` statements"), HIGH maintainability impact.

This batch fixes **10 issues**:
- `dune/gdt/tools/sparsity-pattern.hh` (lines 91, 140, 224, 227, 230, 233)
- `dune/xt/common/convergence-study.cc` (lines 225, 227, 248, 294)

## Approach

Behavior-preserving nesting reduction via guard clauses (early `continue`/`return`) and, where guard clauses were insufficient, extraction of nested blocks into named helpers (`wrap_quantity_id`, `print_norm_eocs` declared in `convergence-study.hh`). Logic, values and iteration order are unchanged. Formatted with clang-format.

## Verification

Not compiled locally (full DUNE stack unavailable) — relying on CI build + SonarCloud analysis. Both files are unique (no near-identical twins), so duplication-on-new-code is expected to be 0%, as in batches 1–2.

Part of a series of 12 PRs, one per batch of ~10 issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172svLSMvrsvfVYuXgAmuNR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved sparsity pattern generation while preserving existing coupling results.
  * Streamlined convergence study output with more consistent quantity-ID wrapping and clearer norm convergence-rate tables.
  * Improved handling of multi-line labels and level-zero entries in convergence reports for more readable console output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->