### PR TITLE
Reduce control-flow nesting in la/solver/eigen.hh & container/eigen/sparse.hh (cpp:S134, batch 6/12)

### DIFF
--- a/dune/xt/la/container/eigen/sparse.hh
+++ b/dune/xt/la/container/eigen/sparse.hh
@@ -110,30 +110,30 @@ public:
           std::make_shared<BackendType>(Common::numeric_cast<EIGEN_size_t>(rr), Common::numeric_cast<EIGEN_size_t>(cc)))
     , mutexes_(std::make_unique<MutexesType>(num_mutexes))
   {
-    if (rr > 0 && cc > 0) {
-      if (size_t(pattern_in.size()) != rr)
-        DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                   "The size of the pattern (" << pattern_in.size() << ") does not match the number of rows of this ("
-                                               << rr << ")!");
-      for (size_t row = 0; row < size_t(pattern_in.size()); ++row) {
-        backend_->startVec(static_cast<EIGEN_size_t>(row));
-        const auto& columns = pattern_in.inner(row);
-        for (const auto& column : columns) {
+    if (!(rr > 0 && cc > 0))
+      return;
+    if (size_t(pattern_in.size()) != rr)
+      DUNE_THROW(Common::Exceptions::shapes_do_not_match,
+                 "The size of the pattern (" << pattern_in.size() << ") does not match the number of rows of this ("
+                                             << rr << ")!");
+    for (size_t row = 0; row < size_t(pattern_in.size()); ++row) {
+      backend_->startVec(static_cast<EIGEN_size_t>(row));
+      const auto& columns = pattern_in.inner(row);
+      for (const auto& column : columns) {
 #ifndef NDEBUG
-          if (column >= cc)
-            DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                       "The size of row " << row << " of the pattern does not match the number of columns of this ("
-                                          << cc << ")!");
+        if (column >= cc)
+          DUNE_THROW(Common::Exceptions::shapes_do_not_match,
+                     "The size of row " << row << " of the pattern does not match the number of columns of this (" << cc
+                                        << ")!");
 #endif // NDEBUG
-          backend_->insertBackByOuterInner(static_cast<EIGEN_size_t>(row), static_cast<EIGEN_size_t>(column));
-        }
-        // create entry (insertBackByOuterInner() can not handle empty rows)
-        if (columns.empty())
-          backend_->insertBackByOuterInner(static_cast<EIGEN_size_t>(row), 0);
+        backend_->insertBackByOuterInner(static_cast<EIGEN_size_t>(row), static_cast<EIGEN_size_t>(column));
       }
-      backend_->finalize();
-      backend_->makeCompressed();
+      // create entry (insertBackByOuterInner() can not handle empty rows)
+      if (columns.empty())
+        backend_->insertBackByOuterInner(static_cast<EIGEN_size_t>(row), 0);
     }
+    backend_->finalize();
+    backend_->makeCompressed();
   } // EigenRowMajorSparseMatrix(...)
 
   explicit EigenRowMajorSparseMatrix(const size_t rr = 0, const size_t cc = 0, const size_t num_mutexes = 1)
@@ -173,25 +173,26 @@ public:
                                      const size_t num_mutexes = 1)
     : mutexes_(std::make_unique<MutexesType>(num_mutexes))
   {
-    if (prune) {
-      // we do this here instead of using pattern(true), since we can build the triplets along the way which is more
-      // efficient
-      using TripletType = ::Eigen::Triplet<ScalarType>;
-      const ScalarType zero(0);
-      std::vector<TripletType> triplets;
-      triplets.reserve(mat.nonZeros());
-      for (EIGEN_size_t row = 0; row < mat.outerSize(); ++row) {
-        for (typename BackendType::InnerIterator row_it(mat, row); row_it; ++row_it) {
-          const EIGEN_size_t col = row_it.col();
-          const auto val = mat.coeff(row, col);
-          if (Common::FloatCmp::ne<Common::FloatCmp::Style::absolute>(val, zero, eps))
-            triplets.emplace_back(row, col, val);
-        }
-      }
-      backend_ = std::make_shared<BackendType>(mat.rows(), mat.cols());
-      backend_->setFromTriplets(triplets.begin(), triplets.end());
-    } else
+    if (!prune) {
       backend_ = std::make_shared<BackendType>(mat);
+      return;
+    }
+    // we do this here instead of using pattern(true), since we can build the triplets along the way which is more
+    // efficient
+    using TripletType = ::Eigen::Triplet<ScalarType>;
+    const ScalarType zero(0);
+    std::vector<TripletType> triplets;
+    triplets.reserve(mat.nonZeros());
+    for (EIGEN_size_t row = 0; row < mat.outerSize(); ++row) {
+      for (typename BackendType::InnerIterator row_it(mat, row); row_it; ++row_it) {
+        const EIGEN_size_t col = row_it.col();
+        const auto val = mat.coeff(row, col);
+        if (Common::FloatCmp::ne<Common::FloatCmp::Style::absolute>(val, zero, eps))
+          triplets.emplace_back(row, col, val);
+      }
+    }
+    backend_ = std::make_shared<BackendType>(mat.rows(), mat.cols());
+    backend_->setFromTriplets(triplets.begin(), triplets.end());
   } // EigenRowMajorSparseMatrix(...)
 
   /**
@@ -405,15 +406,15 @@ public:
     for (size_t row = 0; static_cast<EIGEN_size_t>(row) < backend().outerSize(); ++row) {
       for (typename BackendType::InnerIterator row_it(backend(), static_cast<EIGEN_size_t>(row)); row_it; ++row_it) {
         const size_t col = row_it.col();
-        if (col == jj) {
-          if (col == row)
-            backend().coeffRef(static_cast<EIGEN_size_t>(row), static_cast<EIGEN_size_t>(col)) = ScalarType(1);
-          else
-            backend().coeffRef(static_cast<EIGEN_size_t>(row), static_cast<EIGEN_size_t>(jj)) = ScalarType(0);
-          break;
-        }
         if (col > jj)
           break;
+        if (col != jj)
+          continue;
+        if (col == row)
+          backend().coeffRef(static_cast<EIGEN_size_t>(row), static_cast<EIGEN_size_t>(col)) = ScalarType(1);
+        else
+          backend().coeffRef(static_cast<EIGEN_size_t>(row), static_cast<EIGEN_size_t>(jj)) = ScalarType(0);
+        break;
       }
     }
   } // ... unit_col(...)
@@ -442,19 +443,20 @@ public:
   {
     SparsityPatternDefault ret(rows());
     const auto zero = typename Common::FloatCmp::DefaultEpsilon<ScalarType>::Type(0);
-    if (prune) {
-      for (EIGEN_size_t row = 0; row < backend().outerSize(); ++row) {
-        for (typename BackendType::InnerIterator row_it(backend(), row); row_it; ++row_it) {
-          const EIGEN_size_t col = row_it.col();
-          const auto val = backend().coeff(row, col);
-          if (Common::FloatCmp::ne(val, zero, eps))
-            ret.insert(static_cast<size_t>(row), static_cast<size_t>(col));
-        }
-      }
-    } else {
+    if (!prune) {
       for (EIGEN_size_t row = 0; row < backend().outerSize(); ++row) {
         for (typename BackendType::InnerIterator row_it(backend(), row); row_it; ++row_it)
           ret.insert(static_cast<size_t>(row), static_cast<size_t>(row_it.col()));
+      }
+      ret.sort();
+      return ret;
+    }
+    for (EIGEN_size_t row = 0; row < backend().outerSize(); ++row) {
+      for (typename BackendType::InnerIterator row_it(backend(), row); row_it; ++row_it) {
+        const EIGEN_size_t col = row_it.col();
+        const auto val = backend().coeff(row, col);
+        if (Common::FloatCmp::ne(val, zero, eps))
+          ret.insert(static_cast<size_t>(row), static_cast<size_t>(col));
       }
     }
     ret.sort();

--- a/dune/xt/la/solver/eigen.hh
+++ b/dune/xt/la/solver/eigen.hh
@@ -48,6 +48,59 @@
 
 namespace Dune::XT::LA {
 
+// Helpers to keep the apply() implementations below within the allowed control-flow nesting depth.
+template <class MatrixType, class VectorType, class ConfigType>
+void eigen_solver_check_dense_matrix_for_inf_nan(const MatrixType& matrix,
+                                                 const VectorType& rhs,
+                                                 const ConfigType& opts)
+{
+  for (size_t ii = 0; ii < matrix.rows(); ++ii)
+    for (size_t jj = 0; jj < matrix.cols(); ++jj) {
+      const auto& val = matrix.backend()(ii, jj);
+      if (!(Common::isnan(val) || Common::isinf(val)))
+        continue;
+      std::stringstream msg;
+      msg << "Given matrix contains inf or nan and you requested checking (see options below)!\n"
+          << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
+          << "Those were the given options:\n\n"
+          << opts;
+      if (rhs.size() <= internal::max_size_to_print)
+        msg << "\nThis was the given matrix:\n\n" << matrix << "\n";
+      DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
+    }
+}
+
+template <class BackendType, class ConfigType>
+void eigen_solver_check_sparse_matrix_for_inf_nan(const BackendType& backend, const ConfigType& opts)
+{
+  using InnerIterator = typename BackendType::InnerIterator;
+  for (typename BackendType::Index ii = 0; ii < backend.outerSize(); ++ii)
+    for (InnerIterator it(backend, ii); it; ++it)
+      if (Common::isnan(std::real(it.value())) || Common::isnan(std::imag(it.value()))
+          || Common::isinf(std::abs(it.value())))
+        DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements,
+                   "Given matrix contains inf or nan and you requested checking (see options below)!\n"
+                       << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
+                       << "Those were the given options:\n\n"
+                       << opts);
+}
+
+template <class BackendType, class FieldType, class ConfigType>
+void eigen_solver_check_sparse_matrix_symmetry(const BackendType& colmajor_copy,
+                                               const FieldType& pre_check_symmetry_threshhold,
+                                               const ConfigType& opts)
+{
+  using InnerIterator = typename BackendType::InnerIterator;
+  for (typename BackendType::Index ii = 0; ii < colmajor_copy.outerSize(); ++ii)
+    for (InnerIterator it(colmajor_copy, ii); it; ++it)
+      if (std::max(std::abs(std::real(it.value())), std::abs(std::imag(it.value()))) > pre_check_symmetry_threshhold)
+        DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements,
+                   "Given matrix is not symmetric/hermitian and you requested checking (see options below)!\n"
+                       << "If you want to disable this check, set 'pre_check_symmetry = 0' in the options.\n\n"
+                       << "Those were the given options:\n\n"
+                       << opts);
+}
+
 /// \brief Available solver options for EigenDenseMatrix (direct LU, QR and Cholesky factorizations).
 template <class S, class CommunicatorType>
 class SolverOptions<EigenDenseMatrix<S>, CommunicatorType> : protected internal::SolverUtils
@@ -134,53 +187,37 @@ public:
     // check for inf or nan
     const bool check_for_inf_nan = opts.get("check_for_inf_nan", default_opts.get<bool>("check_for_inf_nan"));
     if (check_for_inf_nan) {
-      for (size_t ii = 0; ii < matrix_.rows(); ++ii) {
-        for (size_t jj = 0; jj < matrix_.cols(); ++jj) {
-          const S& val = matrix_.backend()(ii, jj);
-          if (Common::isnan(val) || Common::isinf(val)) {
-            std::stringstream msg;
-            msg << "Given matrix contains inf or nan and you requested checking (see options below)!\n"
-                << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
-                << "Those were the given options:\n\n"
-                << opts;
-            if (rhs.size() <= internal::max_size_to_print)
-              msg << "\nThis was the given matrix:\n\n" << matrix_ << "\n";
-            DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
-          }
-        }
-      }
+      eigen_solver_check_dense_matrix_for_inf_nan(matrix_, rhs, opts);
       for (size_t ii = 0; ii < rhs.size(); ++ii) {
         const S val = rhs.get_entry(ii);
-        if (Common::isnan(val) || Common::isinf(val)) {
-          std::stringstream msg;
-          msg << "Given rhs contains inf or nan and you requested checking (see options below)!\n"
-              << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
-              << "Those were the given options:\n\n"
-              << opts;
-          if (rhs.size() <= internal::max_size_to_print)
-            msg << "\nThis was the given right hand side:\n\n" << rhs << "\n";
-          DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
-        }
+        if (!(Common::isnan(val) || Common::isinf(val)))
+          continue;
+        std::stringstream msg;
+        msg << "Given rhs contains inf or nan and you requested checking (see options below)!\n"
+            << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
+            << "Those were the given options:\n\n"
+            << opts;
+        if (rhs.size() <= internal::max_size_to_print)
+          msg << "\nThis was the given right hand side:\n\n" << rhs << "\n";
+        DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
       }
     }
     // check for symmetry (if solver needs it)
-    if (type == "ldlt" || type == "llt") {
-      const R pre_check_symmetry_threshhold = opts.get("pre_check_symmetry", default_opts.get<R>("pre_check_symmetry"));
-      if (pre_check_symmetry_threshhold > 0) {
-        const MatrixType tmp(matrix_.backend() - matrix_.backend().adjoint());
-        // serialize difference to compute L^\infty error (no copy done here)
-        const R error = std::max(tmp.backend().cwiseAbs().minCoeff(), tmp.backend().cwiseAbs().maxCoeff());
-        if (error > pre_check_symmetry_threshhold) {
-          std::stringstream msg;
-          msg << "Given matrix is not symmetric and you requested checking (see options below)!\n"
-              << "If you want to disable this check, set 'pre_check_symmetry = 0' in the options.\n\n"
-              << "  (A - A').sup_norm() = " << error << "\n\n"
-              << "Those were the given options:\n\n"
-              << opts;
-          if (rhs.size() <= internal::max_size_to_print)
-            msg << "\nThis was the given matrix A:\n\n" << matrix_ << "\n";
-          DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
-        }
+    const R pre_check_symmetry_threshhold = opts.get("pre_check_symmetry", default_opts.get<R>("pre_check_symmetry"));
+    if ((type == "ldlt" || type == "llt") && pre_check_symmetry_threshhold > 0) {
+      const MatrixType tmp(matrix_.backend() - matrix_.backend().adjoint());
+      // serialize difference to compute L^\infty error (no copy done here)
+      const R error = std::max(tmp.backend().cwiseAbs().minCoeff(), tmp.backend().cwiseAbs().maxCoeff());
+      if (error > pre_check_symmetry_threshhold) {
+        std::stringstream msg;
+        msg << "Given matrix is not symmetric and you requested checking (see options below)!\n"
+            << "If you want to disable this check, set 'pre_check_symmetry = 0' in the options.\n\n"
+            << "  (A - A').sup_norm() = " << error << "\n\n"
+            << "Those were the given options:\n\n"
+            << opts;
+        if (rhs.size() <= internal::max_size_to_print)
+          msg << "\nThis was the given matrix A:\n\n" << matrix_ << "\n";
+        DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
       }
     }
     // solve
@@ -205,19 +242,19 @@ public:
     if (check_for_inf_nan)
       for (size_t ii = 0; ii < solution.size(); ++ii) {
         const S val = solution.get_entry(ii);
-        if (Common::isnan(val) || Common::isinf(val)) {
-          std::stringstream msg;
-          msg << "The computed solution contains inf or nan and you requested checking (see options " << "below)!\n"
-              << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
-              << "Those were the given options:\n\n"
-              << opts;
-          if (rhs.size() <= internal::max_size_to_print)
-            msg << "\nThis was the given matrix A:\n\n"
-                << matrix_ << "\nThis was the given right hand side b:\n\n"
-                << rhs << "\nThis is the computed solution:\n\n"
-                << solution << "\n";
-          DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
-        }
+        if (!(Common::isnan(val) || Common::isinf(val)))
+          continue;
+        std::stringstream msg;
+        msg << "The computed solution contains inf or nan and you requested checking (see options " << "below)!\n"
+            << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
+            << "Those were the given options:\n\n"
+            << opts;
+        if (rhs.size() <= internal::max_size_to_print)
+          msg << "\nThis was the given matrix A:\n\n"
+              << matrix_ << "\nThis was the given right hand side b:\n\n"
+              << rhs << "\nThis is the computed solution:\n\n"
+              << solution << "\n";
+        DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements, msg.str());
       }
     const R post_check_solves_system_threshold =
         opts.get("post_check_solves_system", default_opts.get<R>("post_check_solves_system"));
@@ -384,18 +421,7 @@ public:
     const bool check_for_inf_nan = opts.get("check_for_inf_nan", default_opts.get<bool>("check_for_inf_nan"));
     if (check_for_inf_nan) {
       // iterates over the non-zero entries of matrix_.backend() and checks them
-      using InnerIterator = typename MatrixType::BackendType::InnerIterator;
-      for (EIGEN_size_t ii = 0; ii < matrix_.backend().outerSize(); ++ii) {
-        for (InnerIterator it(matrix_.backend(), ii); it; ++it) {
-          if (Common::isnan(std::real(it.value())) || Common::isnan(std::imag(it.value()))
-              || Common::isinf(std::abs(it.value())))
-            DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements,
-                       "Given matrix contains inf or nan and you requested checking (see options below)!\n"
-                           << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
-                           << "Those were the given options:\n\n"
-                           << opts);
-        }
-      }
+      eigen_solver_check_sparse_matrix_for_inf_nan(matrix_.backend(), opts);
       for (size_t ii = 0; ii < rhs.size(); ++ii) {
         const S val = rhs.get_entry(ii);
         if (Common::isnan(val) || Common::isinf(val))
@@ -413,18 +439,7 @@ public:
         ColMajorBackendType colmajor_copy(matrix_.backend());
         colmajor_copy -= matrix_.backend().adjoint();
         // iterates over non-zero entries as above
-        using InnerIterator = typename ColMajorBackendType::InnerIterator;
-        for (EIGEN_size_t ii = 0; ii < colmajor_copy.outerSize(); ++ii) {
-          for (InnerIterator it(colmajor_copy, ii); it; ++it) {
-            if (std::max(std::abs(std::real(it.value())), std::abs(std::imag(it.value())))
-                > pre_check_symmetry_threshhold)
-              DUNE_THROW(Exceptions::linear_solver_failed_bc_data_did_not_fulfill_requirements,
-                         "Given matrix is not symmetric/hermitian and you requested checking (see options below)!\n"
-                             << "If you want to disable this check, set 'pre_check_symmetry = 0' in the options.\n\n"
-                             << "Those were the given options:\n\n"
-                             << opts);
-          }
-        }
+        eigen_solver_check_sparse_matrix_symmetry(colmajor_copy, pre_check_symmetry_threshhold, opts);
       }
     }
     ::Eigen::ComputationInfo info;


### PR DESCRIPTION
## Summary

Batch 6 of 12 addressing SonarCloud rule **cpp:S134** ("Refactor this code to not nest more than 3 `if`/`for`/`do`/`while`/`switch` statements"), HIGH maintainability impact.

This batch fixes **10 issues**:
- `dune/xt/la/solver/eigen.hh` (lines 144, 164, 184, 219, 396, 424)
- `dune/xt/la/container/eigen/sparse.hh` (lines 127, 191, 413, 454)

## Approach

Behavior-preserving nesting reduction:
- **Guard clauses / condition merging** for most sites (early `continue`/`return`, `&&`-merging) — no new functions.
- **Named helper free-function templates** (3 added in `solver/eigen.hh`, ≤3 params each) only where guard clauses were insufficient, e.g. the inf/nan and symmetry double-loops. Helper message strings are unique to this file (no sibling solver shares them), avoiding cross-file duplication.

Logic, values, iteration order and throw messages unchanged. Formatted with clang-format.

## Verification

Not compiled locally (full DUNE stack unavailable) — relying on CI build + SonarCloud analysis.

Part of a series of 12 PRs, one per batch of ~10 issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172svLSMvrsvfVYuXgAmuNR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal control flow in sparse matrix initialization and solver validation logic for better code maintainability and reduced duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->