### PR TITLE
Reduce control-flow nesting in shifted-qr.hh, istl.hh & symmetrized-laplace.hh (cpp:S134, batch 7/12)

### DIFF
--- a/dune/gdt/local/integrands/symmetrized-laplace.hh
+++ b/dune/gdt/local/integrands/symmetrized-laplace.hh
@@ -22,6 +22,27 @@
 
 namespace Dune {
 namespace GDT {
+namespace internal {
+
+
+// Accumulates the symmetrized-gradient contribution sum_{rr,cc} sym_grad[rr][cc] * test_grad[rr][cc] * diffusion for a
+// single (test, ansatz) basis function pair (extracted to keep control-flow nesting <= 3, cpp:S134).
+template <class SymGradType, class TestGradType, class F>
+F symmetrized_laplace_pair(const SymGradType& sym_ansatz_grad,
+                           const TestGradType& test_grad,
+                           const size_t r,
+                           const size_t d,
+                           const F& diffusion)
+{
+  F ret(0);
+  for (size_t rr = 0; rr < r; ++rr)
+    for (size_t cc = 0; cc < d; ++cc)
+      ret += sym_ansatz_grad[rr][cc] * test_grad[rr][cc] * diffusion;
+  return ret;
+}
+
+
+} // namespace internal
 
 
 /**
@@ -107,9 +128,8 @@ public:
     // compute elliptic evaluation
     for (size_t ii = 0; ii < rows; ++ii)
       for (size_t jj = 0; jj < cols; ++jj)
-        for (size_t rr = 0; rr < r; ++rr)
-          for (size_t cc = 0; cc < d; ++cc)
-            result[ii][jj] += symmetric_ansatz_basis_grads_[jj][rr][cc] * test_basis_grads_[ii][rr][cc] * diffusion;
+        result[ii][jj] += internal::symmetrized_laplace_pair(
+            symmetric_ansatz_basis_grads_[jj], test_basis_grads_[ii], r, d, diffusion);
   } // ... evaluate(...)
 
 private:

--- a/dune/xt/la/container/istl.hh
+++ b/dune/xt/la/container/istl.hh
@@ -436,12 +436,12 @@ public:
       build_sparse_matrix(mat.N(), mat.M(), pruned_patt);
       for (size_t ii = 0; ii < pruned_patt.size(); ++ii) {
         const auto& row_indices = pruned_patt.inner(ii);
-        if (row_indices.size() > 0) {
-          const auto& mat_row = mat[ii];
-          auto& backend_row = backend_->operator[](ii);
-          for (const auto& jj : row_indices)
-            backend_row[jj][0][0] = mat_row[jj][0][0];
-        }
+        if (row_indices.size() == 0)
+          continue;
+        const auto& mat_row = mat[ii];
+        auto& backend_row = backend_->operator[](ii);
+        for (const auto& jj : row_indices)
+          backend_row[jj][0][0] = mat_row[jj][0][0];
       }
     } else
       backend_ = std::shared_ptr<BackendType>(new BackendType(mat));
@@ -696,12 +696,13 @@ public:
   {
     for (size_t ii = 0; ii < rows(); ++ii) {
       const auto& row_vec = backend_->operator[](ii);
-      for (size_t jj = 0; jj < cols(); ++jj)
-        if (backend_->exists(ii, jj)) {
-          const auto& entry = row_vec[jj][0];
-          if (Common::isnan(entry[0]) || Common::isinf(entry[0]))
-            return false;
-        }
+      for (size_t jj = 0; jj < cols(); ++jj) {
+        if (!backend_->exists(ii, jj))
+          continue;
+        const auto& entry = row_vec[jj][0];
+        if (Common::isnan(entry[0]) || Common::isinf(entry[0]))
+          return false;
+      }
     }
     return true;
   } // ... valid(...)
@@ -769,14 +770,14 @@ private:
   {
     SparsityPatternDefault ret(mat.N());
     for (size_t ii = 0; ii < mat.N(); ++ii) {
-      if (mat.getrowsize(ii) > 0) {
-        const auto& row = mat[ii];
-        const auto it_end = row.end();
-        for (auto it = row.begin(); it != it_end; ++it) {
-          const auto val = it->operator[](0)[0];
-          if (Common::FloatCmp::ne<Common::FloatCmp::Style::absolute>(val, decltype(val)(0), eps))
-            ret.insert(ii, it.index());
-        }
+      if (mat.getrowsize(ii) == 0)
+        continue;
+      const auto& row = mat[ii];
+      const auto it_end = row.end();
+      for (auto it = row.begin(); it != it_end; ++it) {
+        const auto val = it->operator[](0)[0];
+        if (Common::FloatCmp::ne<Common::FloatCmp::Style::absolute>(val, decltype(val)(0), eps))
+          ret.insert(ii, it.index());
       }
     }
     ret.sort();
@@ -826,29 +827,30 @@ std::ostream& operator<<(std::ostream& out, const IstlRowMajorSparseMatrix<S>& m
   out << "[";
   const size_t rows = matrix.rows();
   const size_t cols = matrix.cols();
-  if (rows > 0 && cols > 0) {
-    for (size_t ii = 0; ii < rows; ++ii) {
-      if (ii > 0)
-        out << "\n ";
-      out << "[";
-      if (matrix.backend().exists(ii, 0))
-        out << matrix.get_entry(ii, 0);
+  if (!(rows > 0 && cols > 0)) {
+    out << "[ ]]";
+    return out;
+  }
+  for (size_t ii = 0; ii < rows; ++ii) {
+    if (ii > 0)
+      out << "\n ";
+    out << "[";
+    if (matrix.backend().exists(ii, 0))
+      out << matrix.get_entry(ii, 0);
+    else
+      out << "0";
+    for (size_t jj = 1; jj < cols; ++jj) {
+      out << " ";
+      if (matrix.backend().exists(ii, jj))
+        out << matrix.get_entry(ii, jj);
       else
         out << "0";
-      for (size_t jj = 1; jj < cols; ++jj) {
-        out << " ";
-        if (matrix.backend().exists(ii, jj))
-          out << matrix.get_entry(ii, jj);
-        else
-          out << "0";
-      }
-      out << "]";
-      if (rows > 1 && ii < (rows - 1))
-        out << ",";
     }
     out << "]";
-  } else
-    out << "[ ]]";
+    if (rows > 1 && ii < (rows - 1))
+      out << ",";
+  }
+  out << "]";
   return out;
 } // ... operator<<(...)
 

--- a/dune/xt/la/eigen-solver/internal/shifted-qr.hh
+++ b/dune/xt/la/eigen-solver/internal/shifted-qr.hh
@@ -47,6 +47,41 @@ struct RealQrEigenSolver
   {
   }
 
+  // Computes out[rr][cc] = sum_ll lhs[rr][ll] * rhs_transposed[cc][ll] for rr in [0, out_rows), cc in [0, out_cols).
+  // Extracted to keep control-flow nesting <= 3 (cpp:S134).
+  static void mat_mult_rhs_transposed(MatrixType& out,
+                                      const MatrixType& lhs,
+                                      const MatrixType& rhs_transposed,
+                                      const size_t out_rows,
+                                      const size_t out_cols,
+                                      const size_t inner)
+  {
+    for (size_t rr = 0; rr < out_rows; ++rr)
+      for (size_t cc = 0; cc < out_cols; ++cc) {
+        out[rr][cc] = 0.;
+        for (size_t ll = 0; ll < inner; ++ll)
+          out[rr][cc] += lhs[rr][ll] * rhs_transposed[cc][ll];
+      }
+  }
+
+  // Computes out[rr][cc] = sum_ll lhs[rr][ll] * rhs[ll][cc] for rr in [0, out_rows), cc in [cc_begin, cc_end).
+  // Extracted to keep control-flow nesting <= 3 (cpp:S134).
+  static void mat_mult(MatrixType& out,
+                       const MatrixType& lhs,
+                       const MatrixType& rhs,
+                       const size_t out_rows,
+                       const size_t cc_begin,
+                       const size_t cc_end,
+                       const size_t inner)
+  {
+    for (size_t rr = 0; rr < out_rows; ++rr)
+      for (size_t cc = cc_begin; cc < cc_end; ++cc) {
+        out[rr][cc] = 0.;
+        for (size_t ll = 0; ll < inner; ++ll)
+          out[rr][cc] += lhs[rr][ll] * rhs[ll][cc];
+      }
+  }
+
   static void
   calculate_eigenvalues_by_shifted_qr(MatrixType& A, const std::unique_ptr<MatrixType>& Q, std::vector<double>& eigvals)
   {
@@ -93,37 +128,20 @@ struct RealQrEigenSolver
         // Calculate A_{k+1} = R_k Q_k + shift I. With the QR decomposition above, this
         // is calculated as A_{k+1} = [R1*Q1+shift*I Q1^T*A2; 0 A3]
         // calculate upper left part
-        for (size_t rr = 0; rr < num_remaining_rows; ++rr) {
-          for (size_t cc = 0; cc < num_remaining_cols; ++cc) {
-            A[rr][cc] = 0.;
-            for (size_t ll = 0; ll < num_remaining_rows; ++ll)
-              A[rr][cc] += (*R_k)[rr][ll] * (*Q_k)[cc][ll];
-          } // cc
+        mat_mult_rhs_transposed(A, *R_k, *Q_k, num_remaining_rows, num_remaining_cols, num_remaining_rows);
+        for (size_t rr = 0; rr < num_remaining_rows; ++rr)
           A[rr][rr] += shift;
-        } // rr
         // update upper right part
         // we do not need R_k anymore in this step, so use it as temporary storage
         auto& A_copy = *R_k;
         A_copy = A;
-        for (size_t rr = 0; rr < num_remaining_rows; ++rr) {
-          for (size_t cc = num_remaining_cols; cc < num_cols; ++cc) {
-            A[rr][cc] = 0.;
-            for (size_t ll = 0; ll < num_remaining_rows; ++ll)
-              A[rr][cc] += (*Q_k)[rr][ll] * A_copy[ll][cc];
-          } // cc
-        } // rr
+        mat_mult(A, *Q_k, A_copy, num_remaining_rows, num_remaining_cols, num_cols, num_remaining_rows);
 
         if (Q) {
           // Update Q by multiplicating Q_k from the right
           auto& Q_copy = *R_k;
           Q_copy = *Q;
-          for (size_t rr = 0; rr < num_rows; ++rr) {
-            for (size_t cc = 0; cc < num_remaining_cols; ++cc) {
-              (*Q)[rr][cc] = 0.;
-              for (size_t ll = 0; ll < num_remaining_rows; ++ll)
-                (*Q)[rr][cc] += Q_copy[rr][ll] * (*Q_k)[cc][ll];
-            } // cc
-          } // rr
+          mat_mult_rhs_transposed(*Q, Q_copy, *Q_k, num_rows, num_remaining_cols, num_remaining_rows);
         } // if (Q)
 
         ++kk;
@@ -165,11 +183,11 @@ struct RealQrEigenSolver
       assert(kk <= size_t(std::numeric_limits<int>::max()));
       for (int rr = static_cast<int>(kk) - 1; rr >= 0; --rr) {
         eigvec[rr] = 0.;
-        if (XT::Common::FloatCmp::ne(A[rr][rr], A[kk][kk])) {
-          for (size_t cc = rr + 1; cc <= kk; ++cc)
-            eigvec[rr] -= A[rr][cc] * eigvec[cc];
-          eigvec[rr] /= A[rr][rr] - A[kk][kk];
-        }
+        if (!XT::Common::FloatCmp::ne(A[rr][rr], A[kk][kk]))
+          continue;
+        for (size_t cc = rr + 1; cc <= kk; ++cc)
+          eigvec[rr] -= A[rr][cc] * eigvec[cc];
+        eigvec[rr] /= A[rr][rr] - A[kk][kk];
       } // rr
       // apply matrix Q
       for (size_t rr = 0; rr < M::rows(A); ++rr) {
@@ -268,35 +286,35 @@ struct RealQrEigenSolver
     FieldType tau;
     for (size_t jj = 0; jj < std::min(num_rows - 1, num_cols); ++jj) {
       const auto norm_x = get_norm_x(R, jj, num_rows);
-      if (XT::Common::FloatCmp::gt(norm_x, 0.)) {
-        // find entry with greatest absolute value for pivoting
-        size_t index = jj;
-        FieldType max = std::abs(R[jj][jj]);
-        for (size_t kk = jj + 1; kk < num_rows; ++kk) {
-          if (XT::Common::FloatCmp::gt(std::abs(R[kk][jj]), max)) {
-            max = std::abs(R[kk][jj]);
-            index = kk;
-          }
+      if (!XT::Common::FloatCmp::gt(norm_x, 0.))
+        continue;
+      // find entry with greatest absolute value for pivoting
+      size_t index = jj;
+      FieldType max = std::abs(R[jj][jj]);
+      for (size_t kk = jj + 1; kk < num_rows; ++kk) {
+        if (XT::Common::FloatCmp::gt(std::abs(R[kk][jj]), max)) {
+          max = std::abs(R[kk][jj]);
+          index = kk;
         }
-        if (index != jj) { // swap rows
-          // swapping of rows i,j can be done by Householder I - (e_i - e_j)(e_i-e_j)^T
-          e_diff = V::create(M::rows(A), 0.);
-          e_diff[jj] = 1.;
-          e_diff[index] = -1.;
-          multiply_householder_from_left(R, 1., e_diff, jj, num_rows);
-          multiply_householder_from_right_col_major(Q, 1., e_diff, jj, num_cols);
-        }
-        const auto s = -sign(R[jj][jj]);
-        const FieldType u1 = R[jj][jj] - s * norm_x;
-        w[jj] = 1.;
-        for (size_t rr = jj + 1; rr < num_rows; ++rr)
-          w[rr] = R[rr][jj] / u1;
-        tau = -s * u1 / norm_x;
+      }
+      if (index != jj) { // swap rows
+        // swapping of rows i,j can be done by Householder I - (e_i - e_j)(e_i-e_j)^T
+        e_diff = V::create(M::rows(A), 0.);
+        e_diff[jj] = 1.;
+        e_diff[index] = -1.;
+        multiply_householder_from_left(R, 1., e_diff, jj, num_rows);
+        multiply_householder_from_right_col_major(Q, 1., e_diff, jj, num_cols);
+      }
+      const auto s = -sign(R[jj][jj]);
+      const FieldType u1 = R[jj][jj] - s * norm_x;
+      w[jj] = 1.;
+      for (size_t rr = jj + 1; rr < num_rows; ++rr)
+        w[rr] = R[rr][jj] / u1;
+      tau = -s * u1 / norm_x;
 
-        // calculate R = Q_k R and Q = Q Q_k
-        multiply_householder_from_left(R, tau, w, jj, num_rows);
-        multiply_householder_from_right_col_major(Q, tau, w, jj, num_cols);
-      } // if (norm_x != 0)
+      // calculate R = Q_k R and Q = Q Q_k
+      multiply_householder_from_left(R, tau, w, jj, num_rows);
+      multiply_householder_from_right_col_major(Q, tau, w, jj, num_cols);
     } // jj
 
     // choose Q such that largest entry of each column is positive


### PR DESCRIPTION
## Summary

Batch 7 of 12 addressing SonarCloud rule **cpp:S134** ("Refactor this code to not nest more than 3 `if`/`for`/`do`/`while`/`switch` statements"), HIGH maintainability impact.

This batch fixes **10 issues**:
- `dune/xt/la/eigen-solver/internal/shifted-qr.hh` (lines 97, 109, 120, 169, 276)
- `dune/xt/la/container/istl.hh` (lines 442, 702, 777, 840)
- `dune/gdt/local/integrands/symmetrized-laplace.hh` (line 111)

## Approach

Behavior-preserving nesting reduction:
- **Guard clauses** (early `continue`/`return`) for the `istl.hh` sites and several `shifted-qr.hh`/`symmetrized-laplace.hh` sites.
- **Named helpers** where deeper loop nests required it: `internal::symmetrized_laplace_pair` (free function template) and two static members `mat_mult_rhs_transposed` / `mat_mult` in the QR solver. Sibling files were checked to confirm the moved/dedented blocks are unique to these files (no cross-file duplication).

Logic, values, iteration order and throw messages unchanged. Formatted with clang-format.

## Verification

Not compiled locally (full DUNE stack unavailable) — relying on CI build + SonarCloud analysis.

Part of a series of 12 PRs, one per batch of ~10 issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172svLSMvrsvfVYuXgAmuNR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal computation helpers for symmetrized Laplacian operations.
  * Optimized sparse matrix container operations with improved handling of empty structures and non-existent entries.
  * Enhanced eigen-solver matrix multiplication routines for improved computational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->