### PR TITLE
Reduce control-flow nesting in search/common-sparse/matrix-interface/test-base (cpp:S134, batch 9/12)

### DIFF
--- a/dune/gdt/test/spaces/base.hh
+++ b/dune/gdt/test/spaces/base.hh
@@ -111,14 +111,14 @@ struct SpaceTestBase : public ::testing::Test
       EXPECT_EQ(lagrange_points.size(), basis->size() / r);
       for (size_t ii = 0; ii < lagrange_points.size(); ++ii) {
         const auto values = basis->evaluate_set(lagrange_points[ii]);
-        for (size_t rr = 0; rr < r; ++rr) {
-          for (size_t jj = 0; jj < lagrange_points.size(); ++jj) {
-            EXPECT_TRUE(XT::Common::FloatCmp::eq(
-                values[rr * lagrange_points.size() + jj][rr], ii == jj ? 1. : 0., tolerance, tolerance))
-                << "ii = " << ii << "\nrr = " << rr << "\njj = " << jj
-                << "\nlagrange_points[ii] = " << lagrange_points[ii]
-                << "\nbasis->evaluate_set(lagrange_points[ii])[jj] = " << values[jj];
-          }
+        for (size_t rr_jj = 0; rr_jj < r * lagrange_points.size(); ++rr_jj) {
+          const size_t rr = rr_jj / lagrange_points.size();
+          const size_t jj = rr_jj % lagrange_points.size();
+          EXPECT_TRUE(XT::Common::FloatCmp::eq(
+              values[rr * lagrange_points.size() + jj][rr], ii == jj ? 1. : 0., tolerance, tolerance))
+              << "ii = " << ii << "\nrr = " << rr << "\njj = " << jj
+              << "\nlagrange_points[ii] = " << lagrange_points[ii]
+              << "\nbasis->evaluate_set(lagrange_points[ii])[jj] = " << values[jj];
         }
       }
     }

--- a/dune/xt/grid/search.hh
+++ b/dune/xt/grid/search.hh
@@ -186,6 +186,30 @@ private:
     return nullptr;
   }
 
+  // Scans the entities in [first, last) for one containing point; on success stores it in ret[idx], advances idx,
+  // updates it_last_ and returns true.
+  template <class PointType>
+  bool scan_range(const IteratorType& first,
+                  const IteratorType& last,
+                  const PointType& point,
+                  EntityVectorType& ret,
+                  typename EntityVectorType::size_type& idx)
+  {
+    typename EntityVectorType::value_type tmp_ptr(nullptr);
+    for (IteratorType it_current = first; it_current != last; ++it_current) {
+      const auto& entity = *it_current;
+      for (unsigned int local_index = 0; local_index < entity.subEntities(codim); ++local_index) {
+        const auto& sub_entity = entity.template subEntity<codim>(local_index);
+        if ((tmp_ptr = check_add(sub_entity, point))) {
+          ret[idx++] = std::move(tmp_ptr);
+          it_last_ = it_current;
+          return true;
+        }
+      } // loop over subentities
+    } // loop over codim 0 entities
+    return false;
+  }
+
 public:
   FallbackEntityInlevelSearch(const GridLayerType& grid_layer)
     : grid_layer_(grid_layer)
@@ -205,42 +229,10 @@ public:
     EntityVectorType ret(points.size());
     typename EntityVectorType::size_type idx(0);
     for (const auto& point : points) {
-      IteratorType it_current = it_last_;
-      bool it_reset = true;
-      typename EntityVectorType::value_type tmp_ptr(nullptr);
-      for (; it_current != end; ++it_current) {
-        const auto& entity = *it_current;
-        for (unsigned int local_index = 0; local_index < entity.subEntities(codim); ++local_index) {
-          const auto& sub_entity = entity.template subEntity<codim>(local_index);
-          if ((tmp_ptr = check_add(sub_entity, point))) {
-            ret[idx++] = std::move(tmp_ptr);
-            tmp_ptr = nullptr;
-            it_reset = false;
-            it_last_ = it_current;
-            break;
-          }
-        } // loop over subentities
-        if (!it_reset)
-          break;
-      } // loop over codim 0 entities
-      if (!it_reset)
+      const IteratorType search_start = it_last_;
+      if (scan_range(search_start, end, point, ret, idx))
         continue;
-      for (it_current = begin; it_current != it_last_; ++it_current) {
-        const auto& entity = *it_current;
-        for (unsigned int local_index = 0; local_index < entity.subEntities(codim); ++local_index) {
-          const auto& sub_entity = entity.template subEntity<codim>(local_index);
-          if ((tmp_ptr = check_add(sub_entity, point))) {
-            ret[idx++] = std::move(tmp_ptr);
-            tmp_ptr = nullptr;
-            it_reset = false;
-            it_last_ = it_current;
-            break;
-          }
-        } // loop over subentities
-        if (!it_reset)
-          break;
-      } // loop over codim 0 entities
-      if (!it_reset)
+      if (scan_range(begin, search_start, point, ret, idx))
         continue;
       idx++;
     } // loop over points
@@ -290,17 +282,17 @@ private:
       const auto& geometry = my_ent.geometry();
       const auto& refElement = reference_element(geometry);
       for (const auto& point : quad_points) {
-        if (refElement.checkInside(geometry.local(point))) {
-          // if I cannot descend further add this entity even if it's not my view
-          if (grid_layer_.grid().maxLevel() <= my_level || grid_layer_.contains(my_ent)) {
-            ret.emplace_back(my_ent);
-          } else {
-            const auto h_end = my_ent.hend(my_level + 1);
-            const auto h_begin = my_ent.hbegin(my_level + 1);
-            const auto h_range = boost::make_iterator_range(h_begin, h_end);
-            const auto kids = process(QuadpointContainerType(1, point), h_range);
-            ret.insert(ret.end(), kids.begin(), kids.end());
-          }
+        if (!refElement.checkInside(geometry.local(point)))
+          continue;
+        // if I cannot descend further add this entity even if it's not my view
+        if (grid_layer_.grid().maxLevel() <= my_level || grid_layer_.contains(my_ent)) {
+          ret.emplace_back(my_ent);
+        } else {
+          const auto h_end = my_ent.hend(my_level + 1);
+          const auto h_begin = my_ent.hbegin(my_level + 1);
+          const auto h_range = boost::make_iterator_range(h_begin, h_end);
+          const auto kids = process(QuadpointContainerType(1, point), h_range);
+          ret.insert(ret.end(), kids.begin(), kids.end());
         }
       }
     }

--- a/dune/xt/la/container/common/matrix/sparse.hh
+++ b/dune/xt/la/container/common/matrix/sparse.hh
@@ -111,28 +111,28 @@ public:
     , mutexes_(std::make_unique<MutexesType>(num_mutexes))
     , eps_(eps)
   {
-    if (num_rows_ > 0 && num_cols_ > 0) {
-      if (size_t(patt.size()) != num_rows_)
-        DUNE_THROW(XT::Common::Exceptions::shapes_do_not_match,
-                   "The size of the pattern (" << patt.size() << ") does not match the number of rows of this ("
-                                               << num_rows_ << ")!");
-      for (size_t row = 0; row < num_rows_; ++row) {
-        const auto& columns = patt.inner(row);
-        const auto num_nonzero_entries_in_row = columns.size();
-        assert(columns.size() <= num_cols_);
-        row_pointers_->operator[](row + 1) = row_pointers_->operator[](row) + num_nonzero_entries_in_row;
-        for (size_t kk = 0; kk < num_nonzero_entries_in_row; ++kk) {
+    if (!(num_rows_ > 0 && num_cols_ > 0))
+      return;
+    if (size_t(patt.size()) != num_rows_)
+      DUNE_THROW(XT::Common::Exceptions::shapes_do_not_match,
+                 "The size of the pattern (" << patt.size() << ") does not match the number of rows of this ("
+                                             << num_rows_ << ")!");
+    for (size_t row = 0; row < num_rows_; ++row) {
+      const auto& columns = patt.inner(row);
+      const auto num_nonzero_entries_in_row = columns.size();
+      assert(columns.size() <= num_cols_);
+      row_pointers_->operator[](row + 1) = row_pointers_->operator[](row) + num_nonzero_entries_in_row;
+      for (size_t kk = 0; kk < num_nonzero_entries_in_row; ++kk) {
 #ifndef NDEBUG
-          if (columns[kk] >= num_cols_)
-            DUNE_THROW(XT::Common::Exceptions::shapes_do_not_match,
-                       "The size of row " << row << " of the pattern does not match the number of columns of this ("
-                                          << num_cols_ << ")!");
+        if (columns[kk] >= num_cols_)
+          DUNE_THROW(XT::Common::Exceptions::shapes_do_not_match,
+                     "The size of row " << row << " of the pattern does not match the number of columns of this ("
+                                        << num_cols_ << ")!");
 #endif // NDEBUG
-          column_indices_->push_back(columns[kk]);
-        } // kk
-        entries_->resize(column_indices_->size(), 0.);
-      } // row
-    }
+        column_indices_->push_back(columns[kk]);
+      } // kk
+      entries_->resize(column_indices_->size(), 0.);
+    } // row
   } // CommonSparseMatrix(rr, cc, patt, num_mutexes)
 
   CommonSparseMatrix(const size_t rr = 0,
@@ -581,21 +581,21 @@ public:
     , mutexes_(std::make_unique<MutexesType>(num_mutexes))
     , eps_(eps)
   {
-    if (num_rows_ > 0 && num_cols_ > 0) {
-      if (size_t(patt.size()) != num_rows_)
-        DUNE_THROW(XT::Common::Exceptions::shapes_do_not_match,
-                   "The size of the pattern (" << patt.size() << ") does not match the number of rows of this ("
-                                               << num_rows_ << ")!");
-      for (size_t col = 0; col < num_cols_; ++col) {
-        for (size_t row = 0; row < num_rows_; ++row) {
-          const auto& column_indices = patt.inner(row);
-          if (std::find(column_indices.begin(), column_indices.end(), col) != column_indices.end())
-            row_indices_->push_back(row);
-        } // row
-        (*column_pointers_)[col + 1] = row_indices_->size();
-      } // col
-      entries_->resize(row_indices_->size());
-    }
+    if (!(num_rows_ > 0 && num_cols_ > 0))
+      return;
+    if (size_t(patt.size()) != num_rows_)
+      DUNE_THROW(XT::Common::Exceptions::shapes_do_not_match,
+                 "The size of the pattern (" << patt.size() << ") does not match the number of rows of this ("
+                                             << num_rows_ << ")!");
+    for (size_t col = 0; col < num_cols_; ++col) {
+      for (size_t row = 0; row < num_rows_; ++row) {
+        const auto& column_indices = patt.inner(row);
+        if (std::find(column_indices.begin(), column_indices.end(), col) != column_indices.end())
+          row_indices_->push_back(row);
+      } // row
+      (*column_pointers_)[col + 1] = row_indices_->size();
+    } // col
+    entries_->resize(row_indices_->size());
   } // CommonSparseMatrix(rr, cc, patt, num_mutexes)
 
   CommonSparseMatrix(const size_t rr = 0,
@@ -969,6 +969,21 @@ public:
 
   /// \}
 
+private:
+  // Computes the entry (rr, cc) of this * other for the generic-matrix rightmultiply below.
+  template <class OtherMatrixImp>
+  ScalarType rightmultiply_entry(const OtherMatrixImp& other, const size_t rr, const size_t cc) const
+  {
+    ScalarType new_entry(0);
+    for (size_t col = 0; col < num_cols_; ++col) {
+      for (size_t kk = (*column_pointers_)[col]; kk < (*column_pointers_)[col + 1]; ++kk)
+        if ((*row_indices_)[kk] == rr)
+          new_entry += (*entries_)[kk] * XT::Common::MatrixAbstraction<OtherMatrixImp>::get_entry(other, col, cc);
+    } // col
+    return new_entry;
+  }
+
+public:
   template <class OtherMatrixImp>
   typename std::enable_if_t<XT::Common::MatrixAbstraction<OtherMatrixImp>::is_matrix
                                 && !(std::is_base_of<ThisType, OtherMatrixImp>::value),
@@ -980,16 +995,10 @@ public:
     IndexVectorType new_column_pointers(num_cols_ + 1, 0);
     IndexVectorType new_row_indices;
     new_row_indices.reserve(row_indices_->size());
-    ScalarType new_entry(0);
     size_t index = 0;
     for (size_t cc = 0; cc < num_cols_; ++cc) {
       for (size_t rr = 0; rr < num_rows_; ++rr) {
-        new_entry = 0;
-        for (size_t col = 0; col < num_cols_; ++col) {
-          for (size_t kk = (*column_pointers_)[col]; kk < (*column_pointers_)[col + 1]; ++kk)
-            if ((*row_indices_)[kk] == rr)
-              new_entry += (*entries_)[kk] * XT::Common::MatrixAbstraction<OtherMatrixImp>::get_entry(other, col, cc);
-        } // col
+        const ScalarType new_entry = rightmultiply_entry(other, rr, cc);
         if (XT::Common::FloatCmp::ne(new_entry, 0., 0., eps_ / num_cols_)) {
           new_entries.push_back(new_entry);
           new_row_indices.push_back(rr);

--- a/dune/xt/la/container/matrix-interface.hh
+++ b/dune/xt/la/container/matrix-interface.hh
@@ -289,16 +289,17 @@ public:
   {
     SparsityPatternDefault ret(rows());
     const ScalarType zero(0);
-    if (prune) {
-      for (size_t ii = 0; ii < rows(); ++ii)
-        for (size_t jj = 0; jj < cols(); ++jj)
-          if (Common::FloatCmp::ne<Common::FloatCmp::Style::absolute>(get_entry(ii, jj), zero, eps))
-            ret.insert(ii, jj);
-    } else {
+    if (!prune) {
       for (size_t ii = 0; ii < rows(); ++ii)
         for (size_t jj = 0; jj < cols(); ++jj)
           ret.insert(ii, jj);
+      ret.sort();
+      return ret;
     }
+    for (size_t ii = 0; ii < rows(); ++ii)
+      for (size_t jj = 0; jj < cols(); ++jj)
+        if (Common::FloatCmp::ne<Common::FloatCmp::Style::absolute>(get_entry(ii, jj), zero, eps))
+          ret.insert(ii, jj);
     ret.sort();
     return ret;
   } // ... pattern(...)
@@ -328,25 +329,20 @@ public:
   {
     if (other.rows() != rows())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "rows(): " << rows() << "\n   "
-                            << "other.rows(): " << other.rows());
+                 "rows(): " << rows() << "\n   " << "other.rows(): " << other.rows());
     if (other.cols() != cols())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match,
-                 "cols(): " << cols() << "\n   "
-                            << "other.cols(): " << other.cols());
+                 "cols(): " << cols() << "\n   " << "other.cols(): " << other.cols());
     auto my_pattern = pattern();
     auto other_pattern = other.pattern();
     for (size_t ii = 0; ii < rows(); ++ii) {
       const auto my_cols = std::set<size_t>(my_pattern.inner(ii).begin(), my_pattern.inner(ii).end());
       const auto other_cols = std::set<size_t>(other_pattern.inner(ii).begin(), other_pattern.inner(ii).end());
-      for (const auto& jj : my_cols)
-        if (other_cols.count(jj) == 0) {
-          if (Common::FloatCmp::ne(get_entry(ii, jj), ScalarType(0.), epsilon))
-            return false;
-        } else {
-          if (Common::FloatCmp::ne(get_entry(ii, jj), other.get_entry(ii, jj), epsilon))
-            return false;
-        }
+      for (const auto& jj : my_cols) {
+        const ScalarType reference = (other_cols.count(jj) == 0) ? ScalarType(0.) : other.get_entry(ii, jj);
+        if (Common::FloatCmp::ne(get_entry(ii, jj), reference, epsilon))
+          return false;
+      }
       for (const auto& jj : other_cols)
         if (my_cols.count(jj) == 0 && Common::FloatCmp::ne(other.get_entry(ii, jj), ScalarType(0.), epsilon))
           return false;


### PR DESCRIPTION
## Summary

Batch 9 of 12 addressing SonarCloud rule **cpp:S134** ("Refactor this code to not nest more than 3 `if`/`for`/`do`/`while`/`switch` statements"), HIGH maintainability impact.

This batch fixes **10 issues**:
- `dune/xt/grid/search.hh` (lines 215, 232, 295)
- `dune/xt/la/container/common/matrix/sparse.hh` (lines 126, 592, 989)
- `dune/xt/la/container/matrix-interface.hh` (lines 295, 344, 347)
- `dune/gdt/test/spaces/base.hh` (line 114)

## Approach

Behavior-preserving nesting reduction:
- **Guard clauses** (early `continue`/`return`) for most sites.
- **Shared/named helpers** where deeper nests required it: `FallbackEntityInlevelSearch::scan_range` (factors two identical scan loops into one helper — also avoids duplication) and `CommonSparseMatrix::rightmultiply_entry`.
- **Loop flattening / branch collapsing** where equivalent: the Lagrange-basis double loop is flattened into a single index loop (`rr = k/N`, `jj = k%N`, same order), and `almost_equal`'s if/else (both branches identical `if (ne(...)) return false;`) is collapsed via a ternary reference value.

Sibling backend files (`eigen/sparse.hh`, `istl.hh`) were checked to confirm moved/dedented blocks are unique. Logic, values, iteration order and assertion messages unchanged. Formatted with clang-format.

## Verification

Not compiled locally (full DUNE stack unavailable) — relying on CI build + SonarCloud analysis.

Part of a series of 12 PRs, one per batch of ~10 issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172svLSMvrsvfVYuXgAmuNR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code restructuring across spatial search and matrix container implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->