### PR TITLE
Reduce control-flow nesting in pattern/eigen-solver/test matrix files (cpp:S134, batch 12/12)

### DIFF
--- a/dune/xt/la/container/pattern.cc
+++ b/dune/xt/la/container/pattern.cc
@@ -182,6 +182,26 @@ SparsityPatternDefault diagonal_pattern(const size_t rows, const size_t cols, co
   return pattern;
 }
 
+namespace internal {
+
+
+// Returns true if column jj is reachable from row ii through any entry of lhs_pattern's row.
+static bool multiplication_pattern_has_entry(const SparsityPatternDefault& lhs_pattern,
+                                             const SparsityPatternDefault& rhs_pattern,
+                                             const size_t ii,
+                                             const size_t jj)
+{
+  for (const auto& index : lhs_pattern.inner(ii)) // entries in lhs_pattern in current row
+    if (std::find(rhs_pattern.inner(index).begin(), rhs_pattern.inner(index).end(), jj)
+        != rhs_pattern.inner(index).end())
+      return true;
+  return false;
+}
+
+
+} // namespace internal
+
+
 SparsityPatternDefault multiplication_pattern(const SparsityPatternDefault& lhs_pattern,
                                               const SparsityPatternDefault& rhs_pattern,
                                               const size_t rhs_cols)
@@ -190,13 +210,8 @@ SparsityPatternDefault multiplication_pattern(const SparsityPatternDefault& lhs_
   SparsityPatternDefault pattern(lhs_rows);
   for (size_t ii = 0; ii < lhs_rows; ++ii) // rows of new pattern
     for (size_t jj = 0; jj < rhs_cols; ++jj) // cols of new pattern
-      for (const auto& index : lhs_pattern.inner(ii)) { // entries in lhs_pattern in current row
-        if (std::find(rhs_pattern.inner(index).begin(), rhs_pattern.inner(index).end(), jj)
-            != rhs_pattern.inner(index).end()) {
-          pattern.insert(ii, jj);
-          break;
-        }
-      }
+      if (internal::multiplication_pattern_has_entry(lhs_pattern, rhs_pattern, ii, jj))
+        pattern.insert(ii, jj);
   return pattern;
 }
 

--- a/dune/xt/la/eigen-solver/default.hh
+++ b/dune/xt/la/eigen-solver/default.hh
@@ -109,19 +109,19 @@ protected:
     } else
 #endif // HAVE_LAPACKE || HAVE_MKL
       if (type == "shifted_qr") {
-        if (options_->template get<bool>("compute_eigenvalues")
-            || options_->template get<bool>("compute_eigenvectors")) {
-          eigenvalues_ = std::make_unique<std::vector<ComplexType>>(rows);
-          eigenvectors_ = ComplexM::make_unique(rows, cols);
-          std::vector<RealType> real_eigenvalues(rows);
-          auto real_eigenvectors = RealM::make_unique(rows, cols);
-          internal::compute_real_eigenvalues_and_real_right_eigenvectors_using_qr(
-              matrix_, real_eigenvalues, *real_eigenvectors);
-          for (size_t ii = 0; ii < rows; ++ii) {
-            (*eigenvalues_)[ii] = real_eigenvalues[ii];
-            for (size_t jj = 0; jj < cols; ++jj)
-              ComplexM::set_entry(*eigenvectors_, ii, jj, RealM::get_entry(*real_eigenvectors, ii, jj));
-          }
+        if (!(options_->template get<bool>("compute_eigenvalues")
+              || options_->template get<bool>("compute_eigenvectors")))
+          return;
+        eigenvalues_ = std::make_unique<std::vector<ComplexType>>(rows);
+        eigenvectors_ = ComplexM::make_unique(rows, cols);
+        std::vector<RealType> real_eigenvalues(rows);
+        auto real_eigenvectors = RealM::make_unique(rows, cols);
+        internal::compute_real_eigenvalues_and_real_right_eigenvectors_using_qr(
+            matrix_, real_eigenvalues, *real_eigenvectors);
+        for (size_t ii = 0; ii < rows; ++ii) {
+          (*eigenvalues_)[ii] = real_eigenvalues[ii];
+          for (size_t jj = 0; jj < cols; ++jj)
+            ComplexM::set_entry(*eigenvectors_, ii, jj, RealM::get_entry(*real_eigenvectors, ii, jj));
         }
       } else
         DUNE_THROW(Common::Exceptions::internal_error,

--- a/dune/xt/la/eigen-solver/fmatrix.hh
+++ b/dune/xt/la/eigen-solver/fmatrix.hh
@@ -161,19 +161,19 @@ protected:
               matrix_, *eigenvalues_, *eigenvectors_);
         }
       } else if (type == "shifted_qr") {
-        if (options_->template get<bool>("compute_eigenvalues")
-            || options_->template get<bool>("compute_eigenvectors")) {
-          eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<K>>>(SIZE);
-          eigenvectors_ = std::make_unique<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>();
-          std::vector<XT::Common::real_t<K>> real_eigenvalues(SIZE);
-          auto real_eigenvectors = std::make_unique<Dune::FieldMatrix<XT::Common::real_t<K>, SIZE, SIZE>>();
-          internal::compute_real_eigenvalues_and_real_right_eigenvectors_using_qr(
-              matrix_, real_eigenvalues, *real_eigenvectors);
-          for (size_t ii = 0; ii < SIZE; ++ii) {
-            (*eigenvalues_)[ii] = real_eigenvalues[ii];
-            for (size_t jj = 0; jj < SIZE; ++jj)
-              (*eigenvectors_)[ii][jj] = (*real_eigenvectors)[ii][jj];
-          }
+        if (!(options_->template get<bool>("compute_eigenvalues")
+              || options_->template get<bool>("compute_eigenvectors")))
+          return;
+        eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<K>>>(SIZE);
+        eigenvectors_ = std::make_unique<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>();
+        std::vector<XT::Common::real_t<K>> real_eigenvalues(SIZE);
+        auto real_eigenvectors = std::make_unique<Dune::FieldMatrix<XT::Common::real_t<K>, SIZE, SIZE>>();
+        internal::compute_real_eigenvalues_and_real_right_eigenvectors_using_qr(
+            matrix_, real_eigenvalues, *real_eigenvectors);
+        for (size_t ii = 0; ii < SIZE; ++ii) {
+          (*eigenvalues_)[ii] = real_eigenvalues[ii];
+          for (size_t jj = 0; jj < SIZE; ++jj)
+            (*eigenvectors_)[ii][jj] = (*real_eigenvectors)[ii][jj];
         }
       } else
         DUNE_THROW(Common::Exceptions::internal_error,

--- a/dune/xt/test/common/matrix.cc
+++ b/dune/xt/test/common/matrix.cc
@@ -30,6 +30,27 @@ using MatrixTypes =
                      std::tuple<Dune::DynamicMatrix<int>, Int<3>, Int<1>>>;
 
 
+namespace {
+
+
+template <class MatrixType>
+void fill_block_matrix(MatrixType& matrix, const size_t num_blocks, const size_t block_rows, const size_t block_cols)
+{
+  using M = Dune::XT::Common::MatrixAbstraction<MatrixType>;
+  using ScalarType = typename M::ScalarType;
+  for (size_t jj = 0; jj < num_blocks; ++jj)
+    for (size_t ll = 0; ll < block_rows; ++ll)
+      for (size_t mm = 0; mm < block_cols; ++mm) {
+        const size_t row = jj * block_rows + ll;
+        const size_t col = jj * block_cols + mm;
+        M::set_entry(matrix, row, col, static_cast<ScalarType>(100 * row + col));
+      }
+}
+
+
+} // namespace
+
+
 template <class Tuple>
 struct SerializeTest : public ::testing::Test
 {
@@ -51,13 +72,7 @@ struct SerializeTest : public ::testing::Test
     if constexpr (is_block_matrix) {
       constexpr size_t block_rows = rows / num_blocks;
       constexpr size_t block_cols = cols / num_blocks;
-      for (size_t jj = 0; jj < num_blocks; ++jj)
-        for (size_t ll = 0; ll < block_rows; ++ll)
-          for (size_t mm = 0; mm < block_cols; ++mm) {
-            const size_t row = jj * block_rows + ll;
-            const size_t col = jj * block_cols + mm;
-            M::set_entry(matrix_, row, col, static_cast<ScalarType>(100 * row + col));
-          }
+      fill_block_matrix(matrix_, num_blocks, block_rows, block_cols);
     } else {
       for (size_t ii = 0; ii < rows; ++ii)
         for (size_t jj = 0; jj < cols; ++jj)


### PR DESCRIPTION
## Summary

Batch 12 of 12 (final) addressing SonarCloud rule **cpp:S134** ("Refactor this code to not nest more than 3 `if`/`for`/`do`/`while`/`switch` statements"), HIGH maintainability impact.

This batch fixes **4 issues**:
- `dune/xt/la/container/pattern.cc` (line 194)
- `dune/xt/la/eigen-solver/default.hh` (line 121)
- `dune/xt/la/eigen-solver/fmatrix.hh` (line 177)
- `dune/xt/test/common/matrix.cc` (line 56)

## Approach

Behavior-preserving nesting reduction: guard clauses (early `return`) for the eigen-solver `compute()` bodies, and named helper templates where the loop nest was inherent (`internal::multiplication_pattern_has_entry`, `fill_block_matrix`). Sibling files (`generalized-eigen-solver/*`, `matrix-inverter/*`) were checked — the changed blocks are not duplicated there, and the eigen-solver edits use small guard-clause transforms (no large block moved). Logic, values, iteration order and throw messages unchanged. Formatted with clang-format.

## Verification

Not compiled locally (full DUNE stack unavailable) — relying on CI build + SonarCloud analysis.

Final PR in the series of 12.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172svLSMvrsvfVYuXgAmuNR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined matrix pattern multiplication while preserving existing results.
  * Improved shifted QR eigenvalue and eigenvector calculations, including correct complex-valued output handling.
  * Avoided unnecessary eigen-solver work when neither eigenvalues nor eigenvectors are requested.
  * Simplified test matrix initialization without changing test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->