### PR TITLE
Add uv vcpkg overlay port and drop uv from docs CI

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -207,10 +207,14 @@ jobs:
         fetch-tags: true
         fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+    # uv provides and manages the Python interpreter itself, so there is no
+    # separate actions/setup-python step; all execution below goes through uv.
+    - name: Set up uv
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
-        python-version: ${{ env.PYTHON_VERSION }}
+        # gate the uv cache to trusted runs (pushes/merge queue and same-repo
+        # PRs); disable it for external-fork PRs so a fork cannot poison the cache
+        enable-cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     - name: Download freshly built wheels
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -230,20 +234,20 @@ jobs:
         # parse the C++ API headers (see docs/source/conf.py:_clang_resource_dir)
         sudo apt-get install -y xvfb gmsh clang
 
-    - name: Create the virtualenv
-      # Use the interpreter provisioned by actions/setup-python above.
-      run: python -m venv "${GITHUB_WORKSPACE}/.venv"
+    - name: Create the uv-managed virtualenv
+      # uv downloads the requested CPython itself (no actions/setup-python needed).
+      run: uv venv --python "${PYTHON_VERSION}" "${GITHUB_WORKSPACE}/.venv"
 
     - name: Install bindings and docs/visualisation extras
       run: |
         # install the built dune-xt/dune-gdt wheels (xt is an exact-version dep of gdt)
-        "${GITHUB_WORKSPACE}/.venv/bin/python" -m pip install \
+        uv pip install --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
           --find-links wheelhouse/ wheelhouse/*.whl
         # docs + visualisation extras of the just-installed dune-gdt; the extra
         # contents are the single source of truth in python/xt/pyproject.toml
         # (myst-nb executes the notebook cells; k3d provides visualize_function
         # rendering when the wheels were built with K3D).
-        "${GITHUB_WORKSPACE}/.venv/bin/python" -m pip install \
+        uv pip install --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
           --find-links wheelhouse/ "dune-gdt[docs,visualisation]"
 
     - name: Fetch published benchmark reports
@@ -265,9 +269,10 @@ jobs:
       run: |
         cd "${RUNNER_TEMP}"
         OUT="${GITHUB_WORKSPACE}/build/docs_html"
-        # run in the venv built above (its python sees the installed bindings)
-        xvfb-run -a "${GITHUB_WORKSPACE}/.venv/bin/python" \
-          -m sphinx --keep-going -j 1 -b html \
+        # --no-project: ignore the repo-root pyproject stub; run in the venv built above
+        xvfb-run -a uv run --no-project \
+          --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
+          python -m sphinx --keep-going -j 1 -b html \
           "${GITHUB_WORKSPACE}/docs/source" "${OUT}"
         if compgen -G "${OUT}/reports/*.err.log" > /dev/null; then
           echo "::error::one or more executed documentation notebooks failed (see dumped reports below)"

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -207,14 +207,10 @@ jobs:
         fetch-tags: true
         fetch-depth: 0
 
-    # uv provides and manages the Python interpreter itself, so there is no
-    # separate actions/setup-python step; all execution below goes through uv.
-    - name: Set up uv
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        # gate the uv cache to trusted runs (pushes/merge queue and same-repo
-        # PRs); disable it for external-fork PRs so a fork cannot poison the cache
-        enable-cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Download freshly built wheels
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -234,20 +230,20 @@ jobs:
         # parse the C++ API headers (see docs/source/conf.py:_clang_resource_dir)
         sudo apt-get install -y xvfb gmsh clang
 
-    - name: Create the uv-managed virtualenv
-      # uv downloads the requested CPython itself (no actions/setup-python needed).
-      run: uv venv --python "${PYTHON_VERSION}" "${GITHUB_WORKSPACE}/.venv"
+    - name: Create the virtualenv
+      # Use the interpreter provisioned by actions/setup-python above.
+      run: python -m venv "${GITHUB_WORKSPACE}/.venv"
 
     - name: Install bindings and docs/visualisation extras
       run: |
         # install the built dune-xt/dune-gdt wheels (xt is an exact-version dep of gdt)
-        uv pip install --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
+        "${GITHUB_WORKSPACE}/.venv/bin/python" -m pip install \
           --find-links wheelhouse/ wheelhouse/*.whl
         # docs + visualisation extras of the just-installed dune-gdt; the extra
         # contents are the single source of truth in python/xt/pyproject.toml
         # (myst-nb executes the notebook cells; k3d provides visualize_function
         # rendering when the wheels were built with K3D).
-        uv pip install --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
+        "${GITHUB_WORKSPACE}/.venv/bin/python" -m pip install \
           --find-links wheelhouse/ "dune-gdt[docs,visualisation]"
 
     - name: Fetch published benchmark reports
@@ -269,10 +265,9 @@ jobs:
       run: |
         cd "${RUNNER_TEMP}"
         OUT="${GITHUB_WORKSPACE}/build/docs_html"
-        # --no-project: ignore the repo-root pyproject stub; run in the venv built above
-        xvfb-run -a uv run --no-project \
-          --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
-          python -m sphinx --keep-going -j 1 -b html \
+        # run in the venv built above (its python sees the installed bindings)
+        xvfb-run -a "${GITHUB_WORKSPACE}/.venv/bin/python" \
+          -m sphinx --keep-going -j 1 -b html \
           "${GITHUB_WORKSPACE}/docs/source" "${OUT}"
         if compgen -G "${OUT}/reports/*.err.log" > /dev/null; then
           echo "::error::one or more executed documentation notebooks failed (see dumped reports below)"

--- a/.vcpkg-overlays/ports/uv/README.md
+++ b/.vcpkg-overlays/ports/uv/README.md
@@ -3,18 +3,22 @@
 Local overlay port for [uv](https://github.com/astral-sh/uv), astral-sh's Python
 package and project manager.
 
-There is no `uv` port in upstream vcpkg, so this one is hand-written. It builds
-uv from source with `cargo` (the source is fetched hash-free via
-`vcpkg_from_git`, matching the dune-* overlay ports) and installs the resulting
-`uv` executable as a vcpkg tool under `tools/uv/`.
+There is no `uv` port in upstream vcpkg, so this one is hand-written. Instead of
+building the (large) uv Rust workspace from source, it downloads the official
+prebuilt release archive from GitHub and verifies it against the SHA-256
+published in the release's
+[`sha256.sum`](https://github.com/astral-sh/uv/releases/tag/0.11.21), then
+installs the `uv` and `uvx` executables as vcpkg tools under `tools/uv/`.
 
-Building requires a Rust toolchain (`cargo` + `rustc`) on `PATH`; see uv's
-`rust-version` in its `Cargo.toml` for the minimum supported Rust.
+Prebuilt archives are mapped for `x64`/`arm64` on Linux, macOS and Windows.
 
-To bump the version, change the `version` in `vcpkg.json` and the `REF` (and its
-trailing version comment) in `portfile.cmake` to the matching release tag's
-commit hash:
+To bump the version:
 
-```bash
-git ls-remote --tags https://github.com/astral-sh/uv.git 'refs/tags/<version>'
-```
+1. Pick the new release tag and read its `sha256.sum`:
+
+   ```bash
+   curl -sL https://github.com/astral-sh/uv/releases/download/<version>/sha256.sum
+   ```
+
+2. Update `UV_VERSION` and every `UV_SHA256` in `portfile.cmake`, and the
+   `version` in `vcpkg.json`.

--- a/.vcpkg-overlays/ports/uv/README.md
+++ b/.vcpkg-overlays/ports/uv/README.md
@@ -1,0 +1,20 @@
+# uv
+
+Local overlay port for [uv](https://github.com/astral-sh/uv), astral-sh's Python
+package and project manager.
+
+There is no `uv` port in upstream vcpkg, so this one is hand-written. It builds
+uv from source with `cargo` (the source is fetched hash-free via
+`vcpkg_from_git`, matching the dune-* overlay ports) and installs the resulting
+`uv` executable as a vcpkg tool under `tools/uv/`.
+
+Building requires a Rust toolchain (`cargo` + `rustc`) on `PATH`; see uv's
+`rust-version` in its `Cargo.toml` for the minimum supported Rust.
+
+To bump the version, change the `version` in `vcpkg.json` and the `REF` (and its
+trailing version comment) in `portfile.cmake` to the matching release tag's
+commit hash:
+
+```bash
+git ls-remote --tags https://github.com/astral-sh/uv.git 'refs/tags/<version>'
+```

--- a/.vcpkg-overlays/ports/uv/portfile.cmake
+++ b/.vcpkg-overlays/ports/uv/portfile.cmake
@@ -1,0 +1,53 @@
+# There is no uv port in upstream vcpkg, and astral-sh does not publish SHA-512
+# checksums for the prebuilt release artifacts (only SHA-256), so this overlay
+# builds uv from source with cargo. We fetch the pinned release tag with
+# vcpkg_from_git -- the same hash-free mechanism the dune-* overlay ports use --
+# rather than vcpkg_from_github, which would require a SHA-512 we cannot mint
+# offline. A working Rust toolchain (cargo + rustc, see uv's rust-version in
+# Cargo.toml) must be available on PATH for this port to build.
+
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL "https://github.com/astral-sh/uv.git"
+    REF 5aa65dd7ad0067a6b702bf490c8c2ffe25c50f39 # 0.11.21
+)
+
+find_program(
+    CARGO_EXECUTABLE
+    NAMES cargo
+    PATHS "$ENV{HOME}/.cargo/bin" "$ENV{USERPROFILE}/.cargo/bin"
+)
+if(NOT CARGO_EXECUTABLE)
+    message(
+        FATAL_ERROR
+        "uv: could not find 'cargo'. Install a Rust toolchain (https://rustup.rs) "
+        "before building this port."
+    )
+endif()
+
+# Keep cargo's output out of the (read-only-ish) source tree so AUTO_CLEAN can
+# reclaim it after the tool is copied.
+set(CARGO_TARGET_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rust")
+
+vcpkg_execute_required_process(
+    COMMAND "${CARGO_EXECUTABLE}" build --release --locked --bin uv
+            --target-dir "${CARGO_TARGET_DIR}"
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME "cargo-build-${TARGET_TRIPLET}"
+)
+
+# uv is a standalone CLI: install only the executable as a vcpkg tool.
+vcpkg_copy_tools(
+    TOOL_NAMES uv
+    SEARCH_DIR "${CARGO_TARGET_DIR}/release"
+    AUTO_CLEAN
+)
+
+# It ships no headers or libraries, so the usual include/ tree is absent.
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-MIT"
+)

--- a/.vcpkg-overlays/ports/uv/portfile.cmake
+++ b/.vcpkg-overlays/ports/uv/portfile.cmake
@@ -1,56 +1,78 @@
-# There is no uv port in upstream vcpkg, and astral-sh does not publish SHA-512 checksums for the prebuilt release
-# artifacts (only SHA-256), so this overlay builds uv from source with cargo. We fetch the pinned release tag with
-# vcpkg_from_git -- the same hash-free mechanism the dune-* overlay ports use -- rather than vcpkg_from_github, which
-# would require a SHA-512 we cannot mint offline. A working Rust toolchain (cargo + rustc, see uv's rust-version in
-# Cargo.toml) must be available on PATH for this port to build.
+# There is no uv port in upstream vcpkg. Rather than build the large uv Rust
+# workspace from source, this overlay downloads the official prebuilt release
+# binary from GitHub and verifies it against the SHA-256 published in the
+# release's sha256.sum. uv is a standalone CLI, so only the uv/uvx executables
+# are installed, as vcpkg tools under tools/uv/.
 
 set(VCPKG_BUILD_TYPE release)
 
-vcpkg_from_git(
-  OUT_SOURCE_PATH SOURCE_PATH URL "https://github.com/astral-sh/uv.git" REF
-  5aa65dd7ad0067a6b702bf490c8c2ffe25c50f39 # 0.11.21
-)
+set(UV_VERSION "0.11.21")
 
-find_program(
-  CARGO_EXECUTABLE
-  NAMES cargo
-  PATHS "$ENV{HOME}/.cargo/bin" "$ENV{USERPROFILE}/.cargo/bin")
-if(NOT CARGO_EXECUTABLE)
-  message(FATAL_ERROR "uv: could not find 'cargo'. Install a Rust toolchain (https://rustup.rs) "
-                      "before building this port.")
+# Map the vcpkg triplet to the matching cargo-dist release artifact and its
+# published SHA-256 (see
+# https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/sha256.sum).
+if(VCPKG_TARGET_IS_WINDOWS)
+  if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(UV_ARCHIVE "uv-x86_64-pc-windows-msvc.zip")
+    set(UV_SHA256 "ace861f360c6de2babedc1607d0f454b6b09a820dbc8182dc15af927e4df9589")
+  elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(UV_ARCHIVE "uv-aarch64-pc-windows-msvc.zip")
+    set(UV_SHA256 "74e443f8004022dde57a1bd0d10c097830f9ea8feb4ec927db52cd5d805c2f48")
+  endif()
+elseif(VCPKG_TARGET_IS_OSX)
+  if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(UV_ARCHIVE "uv-x86_64-apple-darwin.tar.gz")
+    set(UV_SHA256 "f3c8e5708a84b920c18b691214d54d2b0da6b984789caae95d47c95120cb7765")
+  elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(UV_ARCHIVE "uv-aarch64-apple-darwin.tar.gz")
+    set(UV_SHA256 "1f921d491ba5ffeea774eb04d6681ecee379101341cbb1500394993b541bf3f4")
+  endif()
+elseif(VCPKG_TARGET_IS_LINUX)
+  if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(UV_ARCHIVE "uv-x86_64-unknown-linux-gnu.tar.gz")
+    set(UV_SHA256 "8c88519b0ef0af9801fcdee419bbb12116bd9e6b18e162ae093c932d8b264050")
+  elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(UV_ARCHIVE "uv-aarch64-unknown-linux-gnu.tar.gz")
+    set(UV_SHA256 "88e800834007cc5efd4675f166eb2a51e7e3ad19876d85fa8805a6fb5c922397")
+  endif()
 endif()
 
-find_program(
-  RUSTC_EXECUTABLE
-  NAMES rustc
-  PATHS "$ENV{HOME}/.cargo/bin" "$ENV{USERPROFILE}/.cargo/bin")
-if(NOT RUSTC_EXECUTABLE)
-  message(FATAL_ERROR "uv: could not find 'rustc'. Install a Rust toolchain (https://rustup.rs) "
-                      "before building this port.")
+if(NOT DEFINED UV_ARCHIVE)
+  message(
+    FATAL_ERROR
+    "uv: no prebuilt release artifact is mapped for triplet '${TARGET_TRIPLET}'.")
 endif()
 
-# Keep cargo's output out of the (read-only-ish) source tree so AUTO_CLEAN can reclaim it after the tool is copied.
-set(CARGO_TARGET_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rust")
+# Download and integrity-check against the official SHA-256. We use file(DOWNLOAD)
+# rather than vcpkg_download_distfile (which mandates a SHA-512 that the release
+# does not publish and that we cannot mint offline) so we can validate with the
+# upstream-provided SHA-256 directly.
+set(UV_ARCHIVE_PATH "${CURRENT_BUILDTREES_DIR}/${UV_ARCHIVE}")
+file(
+  DOWNLOAD
+  "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}"
+  "${UV_ARCHIVE_PATH}"
+  EXPECTED_HASH SHA256=${UV_SHA256}
+  SHOW_PROGRESS)
 
-vcpkg_execute_required_process(
-  COMMAND
-  "${CARGO_EXECUTABLE}"
-  build
-  --release
-  --locked
-  --bin
-  uv
-  --target-dir
-  "${CARGO_TARGET_DIR}"
-  WORKING_DIRECTORY
-  "${SOURCE_PATH}"
-  LOGNAME
-  "cargo-build-${TARGET_TRIPLET}")
+vcpkg_extract_source_archive(
+  UV_TOOL_DIR
+  ARCHIVE "${UV_ARCHIVE_PATH}"
+  SOURCE_BASE "uv-${UV_VERSION}")
 
-# uv is a standalone CLI: install only the executable as a vcpkg tool.
-vcpkg_copy_tools(TOOL_NAMES uv SEARCH_DIR "${CARGO_TARGET_DIR}/release" AUTO_CLEAN)
+# cargo-dist archives wrap the binaries in a single top-level directory, which
+# vcpkg_extract_source_archive strips, leaving uv/uvx directly in UV_TOOL_DIR.
+vcpkg_copy_tools(
+  TOOL_NAMES uv uvx
+  SEARCH_DIR "${UV_TOOL_DIR}"
+  AUTO_CLEAN)
 
-# It ships no headers or libraries, so the usual include/ tree is absent.
+# uv ships no headers/libraries, and the release archive carries no license
+# files, so record the dual license by hand.
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
-
-vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-MIT")
+file(
+  WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
+  "uv is distributed under the terms of either the Apache License 2.0 or the MIT "
+  "license, at your option. See "
+  "https://github.com/astral-sh/uv/blob/${UV_VERSION}/LICENSE-APACHE and "
+  "LICENSE-MIT for the full texts.\n")

--- a/.vcpkg-overlays/ports/uv/portfile.cmake
+++ b/.vcpkg-overlays/ports/uv/portfile.cmake
@@ -1,53 +1,47 @@
-# There is no uv port in upstream vcpkg, and astral-sh does not publish SHA-512
-# checksums for the prebuilt release artifacts (only SHA-256), so this overlay
-# builds uv from source with cargo. We fetch the pinned release tag with
-# vcpkg_from_git -- the same hash-free mechanism the dune-* overlay ports use --
-# rather than vcpkg_from_github, which would require a SHA-512 we cannot mint
-# offline. A working Rust toolchain (cargo + rustc, see uv's rust-version in
+# There is no uv port in upstream vcpkg, and astral-sh does not publish SHA-512 checksums for the prebuilt release
+# artifacts (only SHA-256), so this overlay builds uv from source with cargo. We fetch the pinned release tag with
+# vcpkg_from_git -- the same hash-free mechanism the dune-* overlay ports use -- rather than vcpkg_from_github, which
+# would require a SHA-512 we cannot mint offline. A working Rust toolchain (cargo + rustc, see uv's rust-version in
 # Cargo.toml) must be available on PATH for this port to build.
 
 set(VCPKG_BUILD_TYPE release)
 
 vcpkg_from_git(
-    OUT_SOURCE_PATH SOURCE_PATH
-    URL "https://github.com/astral-sh/uv.git"
-    REF 5aa65dd7ad0067a6b702bf490c8c2ffe25c50f39 # 0.11.21
+  OUT_SOURCE_PATH SOURCE_PATH URL "https://github.com/astral-sh/uv.git" REF
+  5aa65dd7ad0067a6b702bf490c8c2ffe25c50f39 # 0.11.21
 )
 
 find_program(
-    CARGO_EXECUTABLE
-    NAMES cargo
-    PATHS "$ENV{HOME}/.cargo/bin" "$ENV{USERPROFILE}/.cargo/bin"
-)
+  CARGO_EXECUTABLE
+  NAMES cargo
+  PATHS "$ENV{HOME}/.cargo/bin" "$ENV{USERPROFILE}/.cargo/bin")
 if(NOT CARGO_EXECUTABLE)
-    message(
-        FATAL_ERROR
-        "uv: could not find 'cargo'. Install a Rust toolchain (https://rustup.rs) "
-        "before building this port."
-    )
+  message(FATAL_ERROR "uv: could not find 'cargo'. Install a Rust toolchain (https://rustup.rs) "
+                      "before building this port.")
 endif()
 
-# Keep cargo's output out of the (read-only-ish) source tree so AUTO_CLEAN can
-# reclaim it after the tool is copied.
+# Keep cargo's output out of the (read-only-ish) source tree so AUTO_CLEAN can reclaim it after the tool is copied.
 set(CARGO_TARGET_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rust")
 
 vcpkg_execute_required_process(
-    COMMAND "${CARGO_EXECUTABLE}" build --release --locked --bin uv
-            --target-dir "${CARGO_TARGET_DIR}"
-    WORKING_DIRECTORY "${SOURCE_PATH}"
-    LOGNAME "cargo-build-${TARGET_TRIPLET}"
-)
+  COMMAND
+  "${CARGO_EXECUTABLE}"
+  build
+  --release
+  --locked
+  --bin
+  uv
+  --target-dir
+  "${CARGO_TARGET_DIR}"
+  WORKING_DIRECTORY
+  "${SOURCE_PATH}"
+  LOGNAME
+  "cargo-build-${TARGET_TRIPLET}")
 
 # uv is a standalone CLI: install only the executable as a vcpkg tool.
-vcpkg_copy_tools(
-    TOOL_NAMES uv
-    SEARCH_DIR "${CARGO_TARGET_DIR}/release"
-    AUTO_CLEAN
-)
+vcpkg_copy_tools(TOOL_NAMES uv SEARCH_DIR "${CARGO_TARGET_DIR}/release" AUTO_CLEAN)
 
 # It ships no headers or libraries, so the usual include/ tree is absent.
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
-vcpkg_install_copyright(
-    FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-MIT"
-)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE" "${SOURCE_PATH}/LICENSE-MIT")

--- a/.vcpkg-overlays/ports/uv/portfile.cmake
+++ b/.vcpkg-overlays/ports/uv/portfile.cmake
@@ -1,15 +1,13 @@
-# There is no uv port in upstream vcpkg. Rather than build the large uv Rust
-# workspace from source, this overlay downloads the official prebuilt release
-# binary from GitHub and verifies it against the SHA-256 published in the
-# release's sha256.sum. uv is a standalone CLI, so only the uv/uvx executables
-# are installed, as vcpkg tools under tools/uv/.
+# There is no uv port in upstream vcpkg. Rather than build the large uv Rust workspace from source, this overlay
+# downloads the official prebuilt release binary from GitHub and verifies it against the SHA-256 published in the
+# release's sha256.sum. uv is a standalone CLI, so only the uv/uvx executables are installed, as vcpkg tools under
+# tools/uv/.
 
 set(VCPKG_BUILD_TYPE release)
 
 set(UV_VERSION "0.11.21")
 
-# Map the vcpkg triplet to the matching cargo-dist release artifact and its
-# published SHA-256 (see
+# Map the vcpkg triplet to the matching cargo-dist release artifact and its published SHA-256 (see
 # https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/sha256.sum).
 if(VCPKG_TARGET_IS_WINDOWS)
   if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
@@ -38,41 +36,26 @@ elseif(VCPKG_TARGET_IS_LINUX)
 endif()
 
 if(NOT DEFINED UV_ARCHIVE)
-  message(
-    FATAL_ERROR
-    "uv: no prebuilt release artifact is mapped for triplet '${TARGET_TRIPLET}'.")
+  message(FATAL_ERROR "uv: no prebuilt release artifact is mapped for triplet '${TARGET_TRIPLET}'.")
 endif()
 
-# Download and integrity-check against the official SHA-256. We use file(DOWNLOAD)
-# rather than vcpkg_download_distfile (which mandates a SHA-512 that the release
-# does not publish and that we cannot mint offline) so we can validate with the
-# upstream-provided SHA-256 directly.
+# Download and integrity-check against the official SHA-256. We use file(DOWNLOAD) rather than vcpkg_download_distfile
+# (which mandates a SHA-512 that the release does not publish and that we cannot mint offline) so we can validate with
+# the upstream-provided SHA-256 directly.
 set(UV_ARCHIVE_PATH "${CURRENT_BUILDTREES_DIR}/${UV_ARCHIVE}")
 file(
-  DOWNLOAD
-  "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}"
-  "${UV_ARCHIVE_PATH}"
+  DOWNLOAD "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}" "${UV_ARCHIVE_PATH}"
   EXPECTED_HASH SHA256=${UV_SHA256}
   SHOW_PROGRESS)
 
-vcpkg_extract_source_archive(
-  UV_TOOL_DIR
-  ARCHIVE "${UV_ARCHIVE_PATH}"
-  SOURCE_BASE "uv-${UV_VERSION}")
+vcpkg_extract_source_archive(UV_TOOL_DIR ARCHIVE "${UV_ARCHIVE_PATH}" SOURCE_BASE "uv-${UV_VERSION}")
 
-# cargo-dist archives wrap the binaries in a single top-level directory, which
-# vcpkg_extract_source_archive strips, leaving uv/uvx directly in UV_TOOL_DIR.
-vcpkg_copy_tools(
-  TOOL_NAMES uv uvx
-  SEARCH_DIR "${UV_TOOL_DIR}"
-  AUTO_CLEAN)
+# cargo-dist archives wrap the binaries in a single top-level directory, which vcpkg_extract_source_archive strips,
+# leaving uv/uvx directly in UV_TOOL_DIR.
+vcpkg_copy_tools(TOOL_NAMES uv uvx SEARCH_DIR "${UV_TOOL_DIR}" AUTO_CLEAN)
 
-# uv ships no headers/libraries, and the release archive carries no license
-# files, so record the dual license by hand.
+# uv ships no headers/libraries, and the release archive carries no license files, so record the dual license by hand.
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
-file(
-  WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
-  "uv is distributed under the terms of either the Apache License 2.0 or the MIT "
-  "license, at your option. See "
-  "https://github.com/astral-sh/uv/blob/${UV_VERSION}/LICENSE-APACHE and "
-  "LICENSE-MIT for the full texts.\n")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright"
+     "uv is distributed under the terms of either the Apache License 2.0 or the MIT " "license, at your option. See "
+     "https://github.com/astral-sh/uv/blob/${UV_VERSION}/LICENSE-APACHE and " "LICENSE-MIT for the full texts.\n")

--- a/.vcpkg-overlays/ports/uv/portfile.cmake
+++ b/.vcpkg-overlays/ports/uv/portfile.cmake
@@ -43,10 +43,20 @@ endif()
 # (which mandates a SHA-512 that the release does not publish and that we cannot mint offline) so we can validate with
 # the upstream-provided SHA-256 directly.
 set(UV_ARCHIVE_PATH "${CURRENT_BUILDTREES_DIR}/${UV_ARCHIVE}")
+# INACTIVITY_TIMEOUT aborts a stalled connection so a network hiccup cannot hang
+# the build indefinitely; EXPECTED_HASH already rejects a truncated/corrupt
+# archive, and STATUS lets us surface any other transport failure clearly.
 file(
   DOWNLOAD "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}" "${UV_ARCHIVE_PATH}"
   EXPECTED_HASH SHA256=${UV_SHA256}
+  INACTIVITY_TIMEOUT 60
+  STATUS UV_DOWNLOAD_STATUS
   SHOW_PROGRESS)
+list(GET UV_DOWNLOAD_STATUS 0 UV_DOWNLOAD_CODE)
+if(NOT UV_DOWNLOAD_CODE EQUAL 0)
+  list(GET UV_DOWNLOAD_STATUS 1 UV_DOWNLOAD_ERROR)
+  message(FATAL_ERROR "uv: failed to download ${UV_ARCHIVE}: ${UV_DOWNLOAD_ERROR}")
+endif()
 
 vcpkg_extract_source_archive(UV_TOOL_DIR ARCHIVE "${UV_ARCHIVE_PATH}" SOURCE_BASE "uv-${UV_VERSION}")
 

--- a/.vcpkg-overlays/ports/uv/portfile.cmake
+++ b/.vcpkg-overlays/ports/uv/portfile.cmake
@@ -20,6 +20,15 @@ if(NOT CARGO_EXECUTABLE)
                       "before building this port.")
 endif()
 
+find_program(
+  RUSTC_EXECUTABLE
+  NAMES rustc
+  PATHS "$ENV{HOME}/.cargo/bin" "$ENV{USERPROFILE}/.cargo/bin")
+if(NOT RUSTC_EXECUTABLE)
+  message(FATAL_ERROR "uv: could not find 'rustc'. Install a Rust toolchain (https://rustup.rs) "
+                      "before building this port.")
+endif()
+
 # Keep cargo's output out of the (read-only-ish) source tree so AUTO_CLEAN can reclaim it after the tool is copied.
 set(CARGO_TARGET_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rust")
 

--- a/.vcpkg-overlays/ports/uv/portfile.cmake
+++ b/.vcpkg-overlays/ports/uv/portfile.cmake
@@ -43,9 +43,8 @@ endif()
 # (which mandates a SHA-512 that the release does not publish and that we cannot mint offline) so we can validate with
 # the upstream-provided SHA-256 directly.
 set(UV_ARCHIVE_PATH "${CURRENT_BUILDTREES_DIR}/${UV_ARCHIVE}")
-# INACTIVITY_TIMEOUT aborts a stalled connection so a network hiccup cannot hang
-# the build indefinitely; EXPECTED_HASH already rejects a truncated/corrupt
-# archive, and STATUS lets us surface any other transport failure clearly.
+# INACTIVITY_TIMEOUT aborts a stalled connection so a network hiccup cannot hang the build indefinitely; EXPECTED_HASH
+# already rejects a truncated/corrupt archive, and STATUS lets us surface any other transport failure clearly.
 file(
   DOWNLOAD "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}" "${UV_ARCHIVE_PATH}"
   EXPECTED_HASH SHA256=${UV_SHA256}

--- a/.vcpkg-overlays/ports/uv/vcpkg.json
+++ b/.vcpkg-overlays/ports/uv/vcpkg.json
@@ -5,5 +5,5 @@
     "An extremely fast Python package and project manager, written in Rust",
   "homepage": "https://github.com/astral-sh/uv",
   "license": "Apache-2.0 OR MIT",
-  "supports": "!uwp & !xbox"
+  "supports": "(windows | linux | osx) & (x64 | arm64)"
 }

--- a/.vcpkg-overlays/ports/uv/vcpkg.json
+++ b/.vcpkg-overlays/ports/uv/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "uv",
+  "version": "0.11.21",
+  "description":
+    "An extremely fast Python package and project manager, written in Rust",
+  "homepage": "https://github.com/astral-sh/uv",
+  "license": "Apache-2.0 OR MIT",
+  "supports": "!uwp & !xbox"
+}


### PR DESCRIPTION
## Summary

- **New `uv` vcpkg overlay port** under `.vcpkg-overlays/ports/uv/`. Upstream vcpkg has no `uv` port, and astral-sh publishes only SHA-256 checksums for the prebuilt release artifacts (vcpkg needs SHA-512), so the port builds uv from source with `cargo`, fetching the pinned release tag (`0.11.21`, commit `5aa65dd`) hash-free via `vcpkg_from_git` — the same mechanism the `dune-*` overlay ports already use. The `uv` executable is installed as a vcpkg tool under `tools/uv/`. A Rust toolchain (`cargo` + `rustc`) is required at build time; the portfile fails fast with a clear message if `cargo` is missing.
- **Removed the uv setup from the docs workflow.** The `build_docs` job in `.github/workflows/non_docker_build.yml` no longer uses `astral-sh/setup-uv` / `uv venv` / `uv pip` / `uv run`. It now provisions Python via `actions/setup-python` and uses a plain `python -m venv` + `pip install` + direct `python -m sphinx` invocation (still under `xvfb-run`).
- **pybind11 overlay** — the existing `.vcpkg-overlays/ports/pybind11` port is already "the upstream port minus the `python3` dependency", so no change was needed there.

## Notes

- The uv port is not wired into the top-level `vcpkg.json` dependencies — adding it there would force every build to compile uv from source (and require Rust on every runner). It is provided as an available overlay port to be referenced when needed.
- Switching the docs job off uv drops uv's package cache; `actions/setup-python` is used without pip caching (matching the prior behaviour, which only cached uv's own store).

## Test plan

- [ ] CI: `Build docs` job runs with `actions/setup-python` + venv/pip/sphinx.
- [ ] `uv` overlay port builds where a Rust toolchain is available.

https://claude.ai/code/session_016pwXniTiUXxJAL4bwLda3r

---
_Generated by [Claude Code](https://claude.ai/code/session_016pwXniTiUXxJAL4bwLda3r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `uv` as a vcpkg overlay port, enabling installation of `uv` and `uvx` prebuilt tools across Linux, macOS, and Windows with x64 and arm64 support.
* **Documentation**
  * Added port documentation describing supported platforms, download/verification approach, and the manual process to bump versions.
* **Improvements**
  * Updated the port to fetch the official prebuilt release archive and verify it with a release-provided SHA-256, plus added licensing information for the installed tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->