### PR TITLE
docs(readme): add RunsOn CI acknowledgement badge (free-license link-back)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ dune-gdt is a [DUNE](http://www.dune-project.org/) module which provides a gener
 discretization toolbox for grid-based numerical methods. It contains building blocks - like
 local operators, local evaluations, local assemblers - for discretization methods and suitable
 discrete function spaces.
+
+---
+
+## Continuous integration
+
+CI for this project (Linux build & test, Python wheels, and documentation) runs on
+self-hosted GitHub Actions runners provided by [RunsOn](https://runs-on.com).
+
+[![CI powered by RunsOn](https://img.shields.io/badge/CI%20powered%20by-RunsOn-7B68EE?logo=githubactions&logoColor=white)](https://runs-on.com)


### PR DESCRIPTION
## What

Adds a short **Continuous integration** section at the bottom of `README.md` with a "CI powered by RunsOn" badge linking back to [runs-on.com](https://runs-on.com).

## Why

PR #247 migrated all heavy CI jobs (Linux build & test, Python wheels, docs) to self-hosted [RunsOn](https://runs-on.com) runners. RunsOn's free non-commercial license (covering open-source projects) asks for *"a public acknowledgement linking back to runs-on.com."* This adds that link-back to satisfy the license.

This is a follow-up to #247: the badge was meant to go into that PR, but it was already in the merge queue, so the acknowledgement lands here as a small standalone change to `main`.

## Notes

- README-only change (9 lines added); no workflow or code changes.

https://claude.ai/code/session_01MdcQ1CHzqXuaCSdUp5Mpd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdcQ1CHzqXuaCSdUp5Mpd8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new Continuous Integration section describing the project's comprehensive CI scope, including Linux build and test execution, Python wheel package generation, and automated documentation building processes. A CI status badge from RunsOn has been integrated to provide quick visibility into the current build status and project health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->