### PR TITLE
docs: use -j auto for parallel Sphinx build

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -272,7 +272,7 @@ jobs:
         # --no-project: ignore the repo-root pyproject stub; run in the venv built above
         xvfb-run -a uv run --no-project \
           --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
-          python -m sphinx --keep-going -j 1 -b html \
+          python -m sphinx --keep-going -j auto -b html \
           "${GITHUB_WORKSPACE}/docs/source" "${OUT}"
         if compgen -G "${OUT}/reports/*.err.log" > /dev/null; then
           echo "::error::one or more executed documentation notebooks failed (see dumped reports below)"


### PR DESCRIPTION
## Summary

- Changes `-j 1` to `-j auto` in the `non_docker_build.yml` docs build step so Sphinx uses all available CPU cores instead of being hard-coded to a single process.

## Notebook execution parallelism

myst-nb declares `parallel_read_safe: True`, which means Sphinx can execute notebooks in parallel during the read phase when `-j > 1`. The actual parallelism achieved depends on whether all loaded extensions declare `parallel_read_safe: True`. `sphinxcontrib-bibtex` has historically set this to `False` (global bibliography state), which would limit read-phase parallelism — but `-j auto` still parallelises the **write phase** unconditionally (all custom extensions already declare `parallel_write_safe: True`).

## Test plan

- [ ] Docs CI job passes with `-j auto`
- [ ] No regression in notebook error reporting (`.err.log` check is unaffected by the `-j` change)

https://claude.ai/code/session_01NKkDNgk2UugRUFBo6wgDQx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKkDNgk2UugRUFBo6wgDQx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->