### PR TITLE
docs: bump clangquill floor to >=0.5.1 to silence 2592 cross-reference warnings

### DIFF
--- a/python/xt/pyproject.toml
+++ b/python/xt/pyproject.toml
@@ -33,7 +33,7 @@ docs = [
     "furo",
     "myst-nb>=0.16",
     "pymor",
-    "clangquill>=0.3.0",
+    "clangquill>=0.5.1",
     "plotly",
     "meshio>=4.4",
 ]


### PR DESCRIPTION
## Problem

The `build_docs` CI job (e.g. [run 27543700504](https://github.com/dune-gdt/dune-gdt/actions/runs/27543700504/job/81428727811)) finishes with **`build succeeded, 2592 warnings.`** — every one an `Unparseable C++ cross-reference`. The same warnings hard-fail the local CMake docs build, which passes `-W` (`docs/CMakeLists.txt`).

## Root cause

The C++ API pages are generated by the **clangquill** Sphinx extension. clangquill ≤ 0.5.0 wrapped the free-form text of Doxygen `@see`/`@sa` commands in `{cpp:any}` roles. When that text is a URL, prose, or an identifier with trailing call syntax (`add_to_entry().`), it is not valid C++, so Sphinx's C++ domain emits a warning — repeated across the whole generated API.

dune-gdt's `default_role = "literal"` (`docs/source/conf.py`) does not help, because these are *explicit* `{cpp:any}` roles, not bare backticks.

## Change

Bump the `docs` extra's floor in `python/xt/pyproject.toml`:

```diff
-    "clangquill>=0.3.0",
+    "clangquill>=0.5.1",
```

clangquill 0.5.1 (renefritze/clangquill#103) classifies `@see`/`@sa` text by shape — URL → autolink, prose → plain text, name → parseable role — eliminating the warnings while keeping genuine cross-references. No `suppress_warnings` stop-gap is added, since that would also mask *real* broken references.

## Sequencing

⚠️ Depends on the **clangquill 0.5.1** release (renefritze/clangquill#103). The docs build here only goes green once that version is on PyPI; current latest is 0.5.0. Land/release clangquill first, then merge this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWn5vgs63Gqd9SDwxoX3Un)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation-related dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->