### PR TITLE
ci(wheels): make ccache effective and cache vcpkg build tree

### DIFF
--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -43,24 +43,36 @@ cd "${DUNE_SRC_DIR}"
 # vcpkg pulls several dune-* deps via `git fetch` from github.com during configure.
 # On the RunsOn/AWS fleet these fail (exit 128) on the first real network fetch
 # while succeeding from developer machines -- consistent with GitHub throttling
-# unauthenticated git from cloud IPs. First a non-fatal probe so the real
-# reachability/error is visible in the job log (vcpkg cleans its buildtrees on
-# failure, hiding git-fetch-*-err.log otherwise):
-echo "=== github fetch probe (unauthenticated): dune-mirrors/dune-geometry ==="
-git ls-remote https://github.com/dune-mirrors/dune-geometry.git 2>&1 | head -3 || true
-curl -sS -o /dev/null -w 'info/refs http=%{http_code}\n' \
-  "https://github.com/dune-mirrors/dune-geometry.git/info/refs?service=git-upload-pack" || true
-echo "======================================================================="
-# Then authenticate github fetches when a token is available, so vcpkg uses the
-# (much higher) authenticated rate limit. set +x so the token is never echoed.
+# unauthenticated git from cloud IPs. Probe reachability before vcpkg runs. The
+# output is tee'd to a host-visible file because the job log is only retrievable
+# as a tail, and vcpkg's verbose bootstrap pushes this early output out of that
+# window; the workflow "Dump" step cats this file on failure.
+PROBE_LOG="${WHEEL_DIR}/github-probe.log"
+{
+  echo "=== github fetch probe: dune-mirrors/dune-geometry (in-container) ==="
+  echo "git: $(git --version 2>&1)"
+  echo "GITHUB_TOKEN present: $([ -n "${GITHUB_TOKEN:-}" ] && echo yes || echo no)"
+  echo "--- unauthenticated git ls-remote (first refs) ---"
+  git ls-remote https://github.com/dune-mirrors/dune-geometry.git 2>&1 | head -3 || true
+  curl -sS -o /dev/null -w 'curl info/refs http=%{http_code}\n' \
+    "https://github.com/dune-mirrors/dune-geometry.git/info/refs?service=git-upload-pack" 2>&1 || true
+  echo "===================================================================="
+} 2>&1 | tee "${PROBE_LOG}"
+# Authenticate github fetches when a token is available so vcpkg uses the (much
+# higher) authenticated rate limit. set +x so the token is never echoed; then
+# re-probe through the authenticated path to confirm it took effect.
 set +x
 if [ -n "${GITHUB_TOKEN:-}" ]; then
   git config --global \
     url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
     "https://github.com/"
-  echo "Configured authenticated github.com fetches for vcpkg."
+  set -x
+  { echo "--- authenticated git ls-remote (first refs) ---"
+    git ls-remote https://github.com/dune-mirrors/dune-geometry.git 2>&1 | head -3 || true
+    echo "====================================================================" ; } 2>&1 | tee -a "${PROBE_LOG}"
+else
+  set -x
 fi
-set -x
 
 # Route every compile through ccache via the compiler launcher rather than
 # PATH symlinks: the manylinux container puts gcc-toolset ahead of /usr/local/bin

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -42,11 +42,9 @@ pipx install --force "cmake<4"
 "${PYTHON_BIN}" -m venv "${WHEEL_DIR}/venv"
 # shellcheck disable=SC1091
 . "${WHEEL_DIR}/venv/bin/activate"
-# ninja is installed explicitly: CMake records CMAKE_MAKE_PROGRAM as this venv's
-# bin/ninja, and that path is baked into the cached build/wheelbuilder-release
-# CMakeCache.txt. The venv is recreated fresh every run, so without an explicit
-# install a warm cache hit reconfigures against a missing ninja and fails the
-# project() call ("venv/bin/ninja --version ... no such file or directory").
+# ninja is installed explicitly so CMake's Ninja generator has a make program in
+# this (freshly recreated) venv; without it the project() call fails with
+# "ninja --version ... no such file or directory".
 "${PYTHON_BIN}" -m pip install auditwheel wheel build ninja
 cd "${DUNE_SRC_DIR}"
 

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -26,6 +26,12 @@ trap cleanup EXIT
 
 # otherwise versioneer fails on mounted source directories in CI
 git config --global --add safe.directory "${DUNE_SRC_DIR}"
+# vcpkg runs `git fetch` as root inside .vcpkg-root/downloads/git-tmp, but when
+# .vcpkg-root is restored from the actions/cache build-tree cache it is owned by
+# the runner user -> git aborts with "fatal: detected dubious ownership" (exit
+# 128) on the first dependency fetch. Trust all repo dirs; the container is
+# ephemeral and single-purpose, so disabling the owner check here is safe.
+git config --global --add safe.directory '*'
 
 yum install -y curl zip unzip tar ccache
 

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -6,6 +6,13 @@ WHEEL_DIR="${DUNE_SRC_DIR}/${WHEELDIR_RELATIVE}"
 PYTHON_BIN="python${PYTHON_VERSION//\"/}"
 
 export CCACHE_DIR="${WHEEL_DIR}/cache"
+# Hash compiler contents rather than mtime/path so the cache stays valid even
+# when the pinned manylinux image is refreshed (a fresh pull changes file
+# timestamps but not the compiler binary).
+export CCACHE_COMPILERCHECK=content
+# The release bindings are template- and LTO-heavy; their object cache outgrows
+# ccache's 5 GB default. The runner volume has ample headroom (volume=150gb).
+export CCACHE_MAXSIZE=10G
 # Create final wheel dir, but not tmp here
 mkdir -p "${WHEEL_DIR}/final" || true
 
@@ -21,9 +28,6 @@ trap cleanup EXIT
 git config --global --add safe.directory "${DUNE_SRC_DIR}"
 
 yum install -y curl zip unzip tar ccache
-pushd /usr/local/bin/
-for ii in cc c++ cpp g++ gcc mpicc mpic++ mpicxx ; do ln -s "$(which ccache)" "$ii"; done
-popd
 
 # some of our vcpkg deps don't build with cmake 4 yet
 # the container's cmake is managed with pipx already
@@ -35,7 +39,13 @@ pipx install --force "cmake<4"
 "${PYTHON_BIN}" -m pip install auditwheel wheel build
 cd "${DUNE_SRC_DIR}"
 
-cmake --preset wheelbuilder-release -DDXT_DONT_LINK_PYTHON_LIB=1
+# Route every compile through ccache via the compiler launcher rather than
+# PATH symlinks: the manylinux container puts gcc-toolset ahead of /usr/local/bin
+# in PATH, so ccache symlinks there are never reached. Passing the launcher as a
+# cache variable (-D) also forces CMake to regenerate the Ninja rules when a
+# cached build/wheelbuilder-release tree is restored. Mirrors the build-linux job.
+cmake --preset wheelbuilder-release -DDXT_DONT_LINK_PYTHON_LIB=1 \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 cmake --build --preset wheelbuilder-release --target bindings -- -j "$(nproc --ignore 1)" -l "$(nproc --ignore 1)"
 
 DUNE_BUILD_DIR="${DUNE_SRC_DIR}/build/wheelbuilder-release"

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -45,41 +45,6 @@ pipx install --force "cmake<4"
 "${PYTHON_BIN}" -m pip install auditwheel wheel build
 cd "${DUNE_SRC_DIR}"
 
-# --- vcpkg github fetch: diagnose + authenticate -----------------------------
-# vcpkg pulls several dune-* deps via `git fetch` from github.com during configure.
-# On the RunsOn/AWS fleet these fail (exit 128) on the first real network fetch
-# while succeeding from developer machines -- consistent with GitHub throttling
-# unauthenticated git from cloud IPs. Probe reachability before vcpkg runs. The
-# output is tee'd to a host-visible file because the job log is only retrievable
-# as a tail, and vcpkg's verbose bootstrap pushes this early output out of that
-# window; the workflow "Dump" step cats this file on failure.
-PROBE_LOG="${WHEEL_DIR}/github-probe.log"
-{
-  echo "=== github fetch probe: dune-mirrors/dune-geometry (in-container) ==="
-  echo "git: $(git --version 2>&1)"
-  echo "GITHUB_TOKEN present: $([ -n "${GITHUB_TOKEN:-}" ] && echo yes || echo no)"
-  echo "--- unauthenticated git ls-remote (first refs) ---"
-  git ls-remote https://github.com/dune-mirrors/dune-geometry.git 2>&1 | head -3 || true
-  curl -sS -o /dev/null -w 'curl info/refs http=%{http_code}\n' \
-    "https://github.com/dune-mirrors/dune-geometry.git/info/refs?service=git-upload-pack" 2>&1 || true
-  echo "===================================================================="
-} 2>&1 | tee "${PROBE_LOG}"
-# Authenticate github fetches when a token is available so vcpkg uses the (much
-# higher) authenticated rate limit. set +x so the token is never echoed; then
-# re-probe through the authenticated path to confirm it took effect.
-set +x
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-  git config --global \
-    url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
-    "https://github.com/"
-  set -x
-  { echo "--- authenticated git ls-remote (first refs) ---"
-    git ls-remote https://github.com/dune-mirrors/dune-geometry.git 2>&1 | head -3 || true
-    echo "====================================================================" ; } 2>&1 | tee -a "${PROBE_LOG}"
-else
-  set -x
-fi
-
 # Route every compile through ccache via the compiler launcher rather than
 # PATH symlinks: the manylinux container puts gcc-toolset ahead of /usr/local/bin
 # in PATH, so ccache symlinks there are never reached. Passing the launcher as a

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -42,7 +42,12 @@ pipx install --force "cmake<4"
 "${PYTHON_BIN}" -m venv "${WHEEL_DIR}/venv"
 # shellcheck disable=SC1091
 . "${WHEEL_DIR}/venv/bin/activate"
-"${PYTHON_BIN}" -m pip install auditwheel wheel build
+# ninja is installed explicitly: CMake records CMAKE_MAKE_PROGRAM as this venv's
+# bin/ninja, and that path is baked into the cached build/wheelbuilder-release
+# CMakeCache.txt. The venv is recreated fresh every run, so without an explicit
+# install a warm cache hit reconfigures against a missing ninja and fails the
+# project() call ("venv/bin/ninja --version ... no such file or directory").
+"${PYTHON_BIN}" -m pip install auditwheel wheel build ninja
 cd "${DUNE_SRC_DIR}"
 
 # Route every compile through ccache via the compiler launcher rather than

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -85,8 +85,15 @@ fi
 # in PATH, so ccache symlinks there are never reached. Passing the launcher as a
 # cache variable (-D) also forces CMake to regenerate the Ninja rules when a
 # cached build/wheelbuilder-release tree is restored. Mirrors the build-linux job.
+# CMAKE_CXX_SCAN_FOR_MODULES=OFF: the manylinux image only ships ccache 3.7.7
+# (EPEL), which predates C++20 module scanning and corrupts the P1689 scan
+# command (-fmodules-ts -fdeps-format=p1689r5 -MD) -> "cc1plus: error: to
+# generate dependencies you must specify either '-M' or '-MM'". dune-gdt does
+# not use C++20 modules, so disabling the scan is safe and also drops a
+# redundant build step. (build-linux keeps scanning on; its apt ccache is 4.x.)
 cmake --preset wheelbuilder-release -DDXT_DONT_LINK_PYTHON_LIB=1 \
-  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_SCAN_FOR_MODULES=OFF
 cmake --build --preset wheelbuilder-release --target bindings -- -j "$(nproc --ignore 1)" -l "$(nproc --ignore 1)"
 
 DUNE_BUILD_DIR="${DUNE_SRC_DIR}/build/wheelbuilder-release"

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -39,6 +39,29 @@ pipx install --force "cmake<4"
 "${PYTHON_BIN}" -m pip install auditwheel wheel build
 cd "${DUNE_SRC_DIR}"
 
+# --- vcpkg github fetch: diagnose + authenticate -----------------------------
+# vcpkg pulls several dune-* deps via `git fetch` from github.com during configure.
+# On the RunsOn/AWS fleet these fail (exit 128) on the first real network fetch
+# while succeeding from developer machines -- consistent with GitHub throttling
+# unauthenticated git from cloud IPs. First a non-fatal probe so the real
+# reachability/error is visible in the job log (vcpkg cleans its buildtrees on
+# failure, hiding git-fetch-*-err.log otherwise):
+echo "=== github fetch probe (unauthenticated): dune-mirrors/dune-geometry ==="
+git ls-remote https://github.com/dune-mirrors/dune-geometry.git 2>&1 | head -3 || true
+curl -sS -o /dev/null -w 'info/refs http=%{http_code}\n' \
+  "https://github.com/dune-mirrors/dune-geometry.git/info/refs?service=git-upload-pack" || true
+echo "======================================================================="
+# Then authenticate github fetches when a token is available, so vcpkg uses the
+# (much higher) authenticated rate limit. set +x so the token is never echoed.
+set +x
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  git config --global \
+    url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf \
+    "https://github.com/"
+  echo "Configured authenticated github.com fetches for vcpkg."
+fi
+set -x
+
 # Route every compile through ccache via the compiler launcher rather than
 # PATH symlinks: the manylinux container puts gcc-toolset ahead of /usr/local/bin
 # in PATH, so ccache symlinks there are never reached. Passing the launcher as a

--- a/.ci/make_docker_wheels.bash
+++ b/.ci/make_docker_wheels.bash
@@ -55,7 +55,7 @@ done
 DOCKER_RUN="docker run ${DT} --env-file=${ENV_FILE} -e DUNE_SRC_DIR=/home/dxt/src -v ${THISDIR}/../:/home/dxt/src \
   -e LOCAL_USER=${LOCAL_USER} -e LOCAL_GID=${LOCAL_GID} -e LOCAL_UID=${LOCAL_UID} \
   -e WHEELDIR_RELATIVE=${WHEELDIR_RELATIVE} -e PYTHON_VERSION=${PYTHON_VERSION} -e PLATFORM=${PLATFORM} \
-  -e CI -e GITHUB_RUN_NUMBER \
+  -e CI -e GITHUB_RUN_NUMBER -e GITHUB_TOKEN \
   -i ${IMAGE}"
 
 ${DOCKER_RUN} /home/dxt/src/.ci/build-wheels.sh

--- a/.ci/make_docker_wheels.bash
+++ b/.ci/make_docker_wheels.bash
@@ -55,7 +55,7 @@ done
 DOCKER_RUN="docker run ${DT} --env-file=${ENV_FILE} -e DUNE_SRC_DIR=/home/dxt/src -v ${THISDIR}/../:/home/dxt/src \
   -e LOCAL_USER=${LOCAL_USER} -e LOCAL_GID=${LOCAL_GID} -e LOCAL_UID=${LOCAL_UID} \
   -e WHEELDIR_RELATIVE=${WHEELDIR_RELATIVE} -e PYTHON_VERSION=${PYTHON_VERSION} -e PLATFORM=${PLATFORM} \
-  -e CI -e GITHUB_RUN_NUMBER -e GITHUB_TOKEN \
+  -e CI -e GITHUB_RUN_NUMBER \
   -i ${IMAGE}"
 
 ${DOCKER_RUN} /home/dxt/src/.ci/build-wheels.sh

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -241,35 +241,37 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-
 
-    - name: Restore wheel build tree (vcpkg toolchain + deps)
+    - name: Restore vcpkg deps (toolchain + installed packages)
       # ccache only covers the dune-xt/dune-gdt translation units; the vcpkg
       # dependency ports build with vcpkg's own toolchain and are not cached by
-      # ccache. Persisting .vcpkg-root (the toolchain VcpkgBootStrap.cmake bakes
-      # into the CMake config) together with build/wheelbuilder-release skips the
-      # from-scratch rebuild of boost/dune-*/suitesparse/etc on every run. Both
-      # paths live under the source dir that make_docker_wheels.bash bind-mounts
-      # into the container, so the container's writes land on the host. Keyed on
-      # the inputs that determine the toolchain/manifest, mirroring build-linux.
+      # ccache. Cache ONLY the relocatable, expensive artifacts -- the vcpkg
+      # toolchain (.vcpkg-root) and the installed packages (vcpkg_installed) -- not
+      # the whole configured build/wheelbuilder-release tree: its CMakeCache and
+      # generated rules embed state tied to the per-run venv (ninja path, the dune
+      # python package), so reusing it makes a warm reconfigure skip the dune
+      # install and then fail ("No module named dune"). Reconfiguring fresh each
+      # run (vcpkg sees vcpkg_installed and skips the dep rebuild) avoids that whole
+      # class of staleness while still skipping the ~35 min dependency build. Both
+      # paths live under the source dir bind-mounted into the container. Keyed on
+      # the inputs that determine the toolchain/manifest.
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
-          build/wheelbuilder-release
+          build/wheelbuilder-release/vcpkg_installed
           .vcpkg-root
-        key: ${{ runner.os }}-wheels-build-${{ matrix.python-version }}-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+        key: ${{ runner.os }}-wheels-vcpkg-${{ matrix.python-version }}-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
         restore-keys: |
-          ${{ runner.os }}-wheels-build-${{ matrix.python-version }}-
+          ${{ runner.os }}-wheels-vcpkg-${{ matrix.python-version }}-
 
-    - name: Drop stale wheel build tree if vcpkg toolchain is missing
-      # If build/wheelbuilder-release was restored but the .vcpkg-root toolchain it
-      # references is absent (a restore-key matched an older, differently-keyed
-      # cache), the baked toolchain path no longer exists and configure fails
-      # immediately. Clear the stale tree so CMake re-bootstraps vcpkg. Mirrors the
-      # build-linux guard.
+    - name: Drop stale vcpkg_installed if toolchain is missing
+      # If vcpkg_installed was restored (via the trailing-dash restore-key) but the
+      # .vcpkg-root toolchain it was built against is absent, clear it so vcpkg
+      # reinstalls cleanly instead of configure failing on a missing toolchain.
       run: |
-        if [ -d build/wheelbuilder-release ] && [ ! -f .vcpkg-root/scripts/buildsystems/vcpkg.cmake ]; then
-          echo "Restored build/wheelbuilder-release but .vcpkg-root toolchain is" \
-               "missing; clearing stale build tree so CMake re-bootstraps vcpkg."
-          rm -rf build/wheelbuilder-release
+        if [ -d build/wheelbuilder-release/vcpkg_installed ] && [ ! -f .vcpkg-root/scripts/buildsystems/vcpkg.cmake ]; then
+          echo "Restored vcpkg_installed but .vcpkg-root toolchain is missing;" \
+               "clearing it so vcpkg reinstalls from scratch."
+          rm -rf build/wheelbuilder-release/vcpkg_installed
         fi
 
     - run: |
@@ -322,21 +324,21 @@ jobs:
         path: build/wheelhouse/cache
         key: ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-${{ github.run_id }}
 
-    - name: Save wheel build tree (vcpkg toolchain + deps)
-      # Persist the vcpkg toolchain + dependency build keyed on the manifest hash
+    - name: Save vcpkg deps (toolchain + installed packages)
+      # Persist the vcpkg toolchain + installed packages keyed on the manifest hash
       # so the next run with an unchanged vcpkg.json/preset/bootstrap skips the
       # dependency rebuild. Gated on success() (unlike the ccache save above):
       # the key is deterministic and actions/cache keys are immutable, so saving a
-      # partial/corrupt tree from a failed run would poison the cache permanently
-      # (a later good run could not overwrite the same key). Matches build-linux's
-      # "Save build cache". The repeated fork-trust gate is defence-in-depth.
+      # partial/corrupt set from a failed run would poison the cache permanently
+      # (a later good run could not overwrite the same key). The repeated fork-trust
+      # gate is defence-in-depth.
       if: success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
-          build/wheelbuilder-release
+          build/wheelbuilder-release/vcpkg_installed
           .vcpkg-root
-        key: ${{ runner.os }}-wheels-build-${{ matrix.python-version }}-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+        key: ${{ runner.os }}-wheels-vcpkg-${{ matrix.python-version }}-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
 
     - name: Upload wheels
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -294,6 +294,13 @@ jobs:
       # none are missed.
       if: failure()
       run: |
+        # The in-container github-fetch probe (build-wheels.sh) tee's here; print
+        # it first since it carries the real reachability/auth result.
+        if [ -f build/wheelhouse/github-probe.log ]; then
+          echo "::group::github-probe.log"
+          sudo cat build/wheelhouse/github-probe.log || true
+          echo "::endgroup::"
+        fi
         sudo find .vcpkg-root/buildtrees build/wheelbuilder-release \
           -name '*.log' -type f 2>/dev/null | sort | while read -r f; do
           echo "::group::${f}"

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -280,6 +280,10 @@ jobs:
         # provide a unique build number so every upload gets a distinct version
         CI: "true"
         GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        # forwarded into the manylinux container so vcpkg's `git fetch` of the
+        # dune-* deps is authenticated (avoids GitHub's unauthenticated rate
+        # limit, which throttles git from the RunsOn/AWS fleet -> fetch exit 128)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Dump vcpkg build error logs
       # On failure, surface vcpkg's per-port logs (e.g. dune-geometry's

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -281,6 +281,34 @@ jobs:
         CI: "true"
         GITHUB_RUN_NUMBER: ${{ github.run_number }}
 
+    - name: Dump vcpkg build error logs
+      # On failure, surface vcpkg's per-port logs (e.g. dune-geometry's
+      # git-fetch-*-err.log) directly in the job log so the actual error is
+      # visible without downloading an artifact. They live under .vcpkg-root and
+      # build/wheelbuilder-release on the bind-mounted source tree: written by the
+      # container as root but world-readable, so this host-side step can cat them.
+      if: failure()
+      run: |
+        shopt -s nullglob
+        for f in .vcpkg-root/buildtrees/*/*.log \
+                 build/wheelbuilder-release/vcpkg-*.log; do
+          echo "::group::${f}"
+          cat "${f}"
+          echo "::endgroup::"
+        done
+
+    - name: Upload vcpkg error logs (in case of failure)
+      # Companion downloadable artifact, mirroring the build-linux job's
+      # "Upload error logs" step.
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: wheels_vcpkg_error-log_${{ matrix.python-version }}
+        path: |
+          .vcpkg-root/buildtrees/*/*.log
+          build/wheelbuilder-release/vcpkg-*.log
+        if-no-files-found: warn
+
     - name: Save wheel-build ccache
       # Persist the compiler cache even when the build fails so the next run stays
       # warm. The job-level `if` already blocks fork PRs; the same trust gate is

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -284,16 +284,16 @@ jobs:
     - name: Dump vcpkg build error logs
       # On failure, surface vcpkg's per-port logs (e.g. dune-geometry's
       # git-fetch-*-err.log) directly in the job log so the actual error is
-      # visible without downloading an artifact. They live under .vcpkg-root and
-      # build/wheelbuilder-release on the bind-mounted source tree: written by the
-      # container as root but world-readable, so this host-side step can cat them.
+      # visible without downloading an artifact. The container writes these as
+      # root, so buildtree dirs created this run are not traversable by the
+      # unprivileged runner user -> read them via sudo and a recursive find so
+      # none are missed.
       if: failure()
       run: |
-        shopt -s nullglob
-        for f in .vcpkg-root/buildtrees/*/*.log \
-                 build/wheelbuilder-release/vcpkg-*.log; do
+        sudo find .vcpkg-root/buildtrees build/wheelbuilder-release \
+          -name '*.log' -type f 2>/dev/null | sort | while read -r f; do
           echo "::group::${f}"
-          cat "${f}"
+          sudo cat "${f}" || true
           echo "::endgroup::"
         done
 

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -241,6 +241,37 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-
 
+    - name: Restore wheel build tree (vcpkg toolchain + deps)
+      # ccache only covers the dune-xt/dune-gdt translation units; the vcpkg
+      # dependency ports build with vcpkg's own toolchain and are not cached by
+      # ccache. Persisting .vcpkg-root (the toolchain VcpkgBootStrap.cmake bakes
+      # into the CMake config) together with build/wheelbuilder-release skips the
+      # from-scratch rebuild of boost/dune-*/suitesparse/etc on every run. Both
+      # paths live under the source dir that make_docker_wheels.bash bind-mounts
+      # into the container, so the container's writes land on the host. Keyed on
+      # the inputs that determine the toolchain/manifest, mirroring build-linux.
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          build/wheelbuilder-release
+          .vcpkg-root
+        key: ${{ runner.os }}-wheels-build-${{ matrix.python-version }}-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
+        restore-keys: |
+          ${{ runner.os }}-wheels-build-${{ matrix.python-version }}-
+
+    - name: Drop stale wheel build tree if vcpkg toolchain is missing
+      # If build/wheelbuilder-release was restored but the .vcpkg-root toolchain it
+      # references is absent (a restore-key matched an older, differently-keyed
+      # cache), the baked toolchain path no longer exists and configure fails
+      # immediately. Clear the stale tree so CMake re-bootstraps vcpkg. Mirrors the
+      # build-linux guard.
+      run: |
+        if [ -d build/wheelbuilder-release ] && [ ! -f .vcpkg-root/scripts/buildsystems/vcpkg.cmake ]; then
+          echo "Restored build/wheelbuilder-release but .vcpkg-root toolchain is" \
+               "missing; clearing stale build tree so CMake re-bootstraps vcpkg."
+          rm -rf build/wheelbuilder-release
+        fi
+
     - run: |
         ./.ci/make_docker_wheels.bash
       env:
@@ -260,6 +291,19 @@ jobs:
       with:
         path: build/wheelhouse/cache
         key: ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-${{ github.run_id }}
+
+    - name: Save wheel build tree (vcpkg toolchain + deps)
+      # Persist the vcpkg toolchain + dependency build keyed on the manifest hash
+      # so the next run with an unchanged vcpkg.json/preset/bootstrap skips the
+      # dependency rebuild. Same fork-trust gate as the ccache save above
+      # (defence-in-depth + cache-poisoning lint on a standalone save step).
+      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          build/wheelbuilder-release
+          .vcpkg-root
+        key: ${{ runner.os }}-wheels-build-${{ matrix.python-version }}-${{ hashFiles('vcpkg.json', 'CMakePresets.json', 'cmake/VcpkgBootStrap.cmake') }}
 
     - name: Upload wheels
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -280,31 +280,17 @@ jobs:
         # provide a unique build number so every upload gets a distinct version
         CI: "true"
         GITHUB_RUN_NUMBER: ${{ github.run_number }}
-        # forwarded into the manylinux container so vcpkg's `git fetch` of the
-        # dune-* deps is authenticated (avoids GitHub's unauthenticated rate
-        # limit, which throttles git from the RunsOn/AWS fleet -> fetch exit 128)
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Dump vcpkg build error logs
-      # On failure, surface vcpkg's per-port logs (e.g. dune-geometry's
-      # git-fetch-*-err.log) directly in the job log so the actual error is
-      # visible without downloading an artifact. The container writes these as
-      # root, so buildtree dirs created this run are not traversable by the
-      # unprivileged runner user -> read them via sudo and a recursive find so
-      # none are missed.
+      # On failure, surface vcpkg's per-port error logs directly in the job log
+      # so the cause is visible without downloading the artifact below. vcpkg
+      # writes these inside the container as root, so freshly created buildtree
+      # dirs are not traversable by the unprivileged runner -> read them via sudo.
       if: failure()
       run: |
-        # Keep this dump small so it stays within the retrievable log tail: only
-        # the github-fetch probe (the real reachability/auth result) and the
-        # failing ports' git-fetch logs -- NOT the 900+ restored-cache buildtree
-        # logs, which are irrelevant noise that pushes everything else off-tail.
-        if [ -f build/wheelhouse/github-probe.log ]; then
-          echo "::group::github-probe.log"
-          sudo cat build/wheelhouse/github-probe.log || true
-          echo "::endgroup::"
-        fi
-        sudo find .vcpkg-root/buildtrees -name 'git-fetch-*' -type f 2>/dev/null \
-          | sort | while read -r f; do
+        sudo find .vcpkg-root/buildtrees build/wheelbuilder-release -type f \
+          \( -name '*-err.log' -o -name 'git-fetch-*' -o -name 'vcpkg-*.log' \) \
+          2>/dev/null | sort | while read -r f; do
           echo "::group::${f}"
           sudo cat "${f}" || true
           echo "::endgroup::"

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -294,15 +294,17 @@ jobs:
       # none are missed.
       if: failure()
       run: |
-        # The in-container github-fetch probe (build-wheels.sh) tee's here; print
-        # it first since it carries the real reachability/auth result.
+        # Keep this dump small so it stays within the retrievable log tail: only
+        # the github-fetch probe (the real reachability/auth result) and the
+        # failing ports' git-fetch logs -- NOT the 900+ restored-cache buildtree
+        # logs, which are irrelevant noise that pushes everything else off-tail.
         if [ -f build/wheelhouse/github-probe.log ]; then
           echo "::group::github-probe.log"
           sudo cat build/wheelhouse/github-probe.log || true
           echo "::endgroup::"
         fi
-        sudo find .vcpkg-root/buildtrees build/wheelbuilder-release \
-          -name '*.log' -type f 2>/dev/null | sort | while read -r f; do
+        sudo find .vcpkg-root/buildtrees -name 'git-fetch-*' -type f 2>/dev/null \
+          | sort | while read -r f; do
           echo "::group::${f}"
           sudo cat "${f}" || true
           echo "::endgroup::"

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -288,8 +288,11 @@ jobs:
       # dirs are not traversable by the unprivileged runner -> read them via sudo.
       if: failure()
       run: |
-        sudo find .vcpkg-root/buildtrees build/wheelbuilder-release -type f \
-          \( -name '*-err.log' -o -name 'git-fetch-*' -o -name 'vcpkg-*.log' \) \
+        # Only the per-port error logs (not the multi-MB vcpkg-manifest-install.log,
+        # which would bury the real error in the retrievable log tail); the full
+        # set is still captured by the artifact upload below.
+        sudo find .vcpkg-root/buildtrees -type f \
+          \( -name '*-err.log' -o -name 'git-fetch-*' \) \
           2>/dev/null | sort | while read -r f; do
           echo "::group::${f}"
           sudo cat "${f}" || true

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -295,9 +295,12 @@ jobs:
     - name: Save wheel build tree (vcpkg toolchain + deps)
       # Persist the vcpkg toolchain + dependency build keyed on the manifest hash
       # so the next run with an unchanged vcpkg.json/preset/bootstrap skips the
-      # dependency rebuild. Same fork-trust gate as the ccache save above
-      # (defence-in-depth + cache-poisoning lint on a standalone save step).
-      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      # dependency rebuild. Gated on success() (unlike the ccache save above):
+      # the key is deterministic and actions/cache keys are immutable, so saving a
+      # partial/corrupt tree from a failed run would poison the cache permanently
+      # (a later good run could not overwrite the same key). Matches build-linux's
+      # "Save build cache". The repeated fork-trust gate is defence-in-depth.
+      if: success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |


### PR DESCRIPTION
## Problem

The `build_wheels` job takes ~53 min on **every** run, even on the RunsOn fleet. Inspecting a recent run on `main` ([run 27632142248, job 81709682013](https://github.com/dune-gdt/dune-gdt/actions/runs/27632142248/job/81709682013)) shows that **neither caching layer was doing anything**:

- **ccache was 100% ineffective.** The job's own `ccache -s` reported:
  ```
  cache hit (direct)        0
  cache hit (preprocessed)  0
  cache miss                0
  files in cache            0
  cache size              0.0 kB
  ```
  Both the *Restore* and *Save* ccache steps completed in **0 seconds** — they save/restore an empty directory. The RunsOn S3 / Magic Cache and the `actions/cache` key scheme are fine; the cache is empty because nothing ever wrote to it.
  - **Root cause:** `build-wheels.sh` symlinked the compilers to ccache in `/usr/local/bin`, but the manylinux container's PATH is `/opt/rh/gcc-toolset-14/root/usr/bin:/usr/local/...`. gcc-toolset-14 precedes `/usr/local/bin`, so the real compilers are always invoked directly and the ccache symlinks are never reached.
- **vcpkg dependencies were rebuilt from source every run.** Nothing persisted `.vcpkg-root` or `build/wheelbuilder-release` between runs, so the ephemeral container recompiled boost / dune-* / suitesparse / openblas / eigen / tbb (`vcpkg.json`) from scratch each time — this dominates the ~35 min that precedes the bindings compile.

The sibling **`build-linux`** job in the same workflow already solves both problems correctly; this PR brings `build_wheels` in line with it.

## Changes

**`.ci/build-wheels.sh`**
- Route every compile through ccache via `-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache` (PATH-independent, works regardless of gcc-toolset). Passing them as `-D` cache vars also forces Ninja-rule regeneration when a cached build tree is restored.
- Remove the dead `/usr/local/bin` ccache symlink hack.
- Set `CCACHE_COMPILERCHECK=content` (cache survives manylinux image refreshes) and `CCACHE_MAXSIZE=10G` (LTO/template-heavy objects exceed the 5 GB default).

**`.github/workflows/non_docker_build.yml`** (`build_wheels` job)
- Add `actions/cache` restore + save for `build/wheelbuilder-release` and `.vcpkg-root`, keyed on `hashFiles('vcpkg.json','CMakePresets.json','cmake/VcpkgBootStrap.cmake')`, so vcpkg deps aren't rebuilt when the manifest is unchanged.
- Add the "drop stale build tree if vcpkg toolchain is missing" guard and reuse the existing fork-trust gate on the save step — both mirroring `build-linux`.

These paths live under the source dir that `make_docker_wheels.bash` bind-mounts into the container, so the container's writes land on the host and are visible to `actions/cache`.

## Expected impact
- **Cold run:** ~same runtime, but `ccache -s` now shows non-zero cache population and the save steps take real time.
- **Warm run:** vcpkg dependency rebuild skipped + bindings recompile served from ccache (as in `build-linux`, whose Build step is ~49 s). Target total ≈ 12–15 min (remaining cost: auditwheel repair ~5 min + pip wheel + cache restore).

## Verification
- After merge/first run, confirm via the job log that `ccache -s` reports non-zero `cache miss`/`files in cache`, and that the two *Save* cache steps no longer finish in 0 s.
- On a second run, confirm the *Restore* steps pull real data, there is no `Building package …` vcpkg output, `ccache -s` shows a high hit ratio, and total job time drops substantially.
- The `make_docker_wheels.bash` import smoke-test (one `dune_xt*` + one `dune_gdt*` wheel) must still pass.

https://claude.ai/code/session_01Mj5meKRuSdRoj8ctLN5hrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mj5meKRuSdRoj8ctLN5hrJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved wheel build performance by strengthening compiler cache validity (content-based checking) and increasing the maximum cache size.
  * Updated wheel building to route both C and C++ compilation through the compiler cache for more consistent builds.
  * Enhanced non-Docker wheel workflow with deterministic vcpkg build caching, safeguards against stale/incorrect cache matches, and improved failure diagnostics (job log + per-version artifacts).
  * Forwarded the GitHub token into the Docker build environment to help avoid network-related configure failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->