### PR TITLE
fix(wheels): stop shipping CMake build artifacts (8x wheel-size regression)

### DIFF
--- a/python/gdt/pyproject.toml
+++ b/python/gdt/pyproject.toml
@@ -32,9 +32,23 @@ pattern = '__git_revision__ = "(?P<version>[^"]+)"'
 [tool.hatch.build.targets.wheel]
 # The .so modules are compiled build outputs (dropped into the binary dir by CMake); force-include them as artifacts so
 # they always ship, even if a VCS-ignore rule would otherwise exclude them.
-artifacts = ["**/*.so"]
+artifacts = ["dune/**/*.so"]
 # Package the whole `dune` namespace tree (dune/__init__.py declares the namespace so dune.xt and dune.gdt coexist).
 packages = ["dune"]
+# The wheel is assembled in the in-source CMake build dir, so the `dune` tree above is interleaved with build artifacts:
+# CMakeFiles/*.cc.o object files, CMake metadata, the binding .cc/.hh sources and configured templates. packages=["dune"]
+# would otherwise ship all of it -- the unstripped *.cc.o objects alone added ~900 MB and blew the wheel ~8x past Test
+# PyPI's 100 MB per-file limit. Ship only the Python sources and the compiled .so modules, matching the behaviour of the
+# former setuptools find_packages() + package_data={"": ["*.so"]}.
+exclude = [
+  "**/CMakeFiles/**",
+  "**/*.o",
+  "**/*.cc",
+  "**/*.hh",
+  "**/*.cmake",
+  "**/CMakeLists.txt",
+  "**/*.in",
+]
 
 # Force a platform (non-pure) wheel via the build hook in hatch_build.py (CustomBuildHook): hatchling has no declarative
 # option for this, so the hook sets pure_python=False (Root-Is-Purelib: false) and infer_tag=True (stamp the building

--- a/python/xt/pyproject.toml
+++ b/python/xt/pyproject.toml
@@ -68,9 +68,23 @@ pattern = '__git_revision__ = "(?P<version>[^"]+)"'
 [tool.hatch.build.targets.wheel]
 # The .so modules are compiled build outputs (dropped into the binary dir by CMake); force-include them as artifacts so
 # they always ship, even if a VCS-ignore rule would otherwise exclude them.
-artifacts = ["**/*.so"]
+artifacts = ["dune/**/*.so"]
 # Package the whole `dune` namespace tree (dune/__init__.py declares the namespace so dune.xt and dune.gdt coexist).
 packages = ["dune"]
+# The wheel is assembled in the in-source CMake build dir, so the `dune` tree above is interleaved with build artifacts:
+# CMakeFiles/*.cc.o object files, CMake metadata, the binding .cc/.hh sources and configured templates. packages=["dune"]
+# would otherwise ship all of it -- the unstripped *.cc.o objects alone added ~900 MB and blew the wheel ~8x past Test
+# PyPI's 100 MB per-file limit. Ship only the Python sources and the compiled .so modules, matching the behaviour of the
+# former setuptools find_packages() + package_data={"": ["*.so"]}.
+exclude = [
+  "**/CMakeFiles/**",
+  "**/*.o",
+  "**/*.cc",
+  "**/*.hh",
+  "**/*.cmake",
+  "**/CMakeLists.txt",
+  "**/*.in",
+]
 
 # Force a platform (non-pure) wheel via the build hook in hatch_build.py (CustomBuildHook): hatchling has no declarative
 # option for this, so the hook sets pure_python=False (Root-Is-Purelib: false) and infer_tag=True (stamp the building


### PR DESCRIPTION
## What broke

The `test_publish` job fails uploading to Test PyPI:

```
INFO  wheels/dune_gdt-...whl (675.0 MB)
INFO  wheels/dune_xt-...whl  (347.2 MB)
400 File too large. Limit for project 'dune.gdt' is 100 MB.
```

(`pypa/gh-action-pypi-publish` → `https://test.pypi.org/legacy/`). PyPI/Test PyPI enforce a **100 MB per-file** limit.

## When it regressed

CI `wheels_3.13` artifact size (both wheels) was steady ~117–125 MB through 2026-06-14, then jumped **~8×**:

| Build | run | date | artifact |
|---|---|---|---|
| last good (PR #241) | `27509657742` | 2026-06-14 21:02Z | **130,838,192 B (~125 MB)** |
| first big (merge of **PR #229**) | `27527239427` | 2026-06-15 06:03Z | **1,065,897,801 B (~1016 MB)** |

The only build/packaging change between those builds is **PR #229 / `3c94c40` "Migrate dune.xt/dune.gdt to a pyproject.toml-only hatchling build"** (confirmed an ancestor of the first big build, absent from the prior one). The earlier ExprTk swap and the LTO/OOM CI resource bumps only affect *compile-time* memory/disk, not wheel size.

## Why it grew

Each wheel is assembled by `pip wheel` pointed at the **in-source CMake build dir**, whose `dune/` tree is interleaved with build artifacts. The migration's `packages = ["dune"]` ships that *entire* subtree. Inspecting an actual broken wheel:

| type | count | bytes |
|---|---|---|
| `.o` (`CMakeFiles/**/*.cc.o`) | 68 | **972,330,960 (~927 MB)** |
| `.so` (the real modules) | 68 | 332,029,948 |
| `.cc` / `.hh` / `.cmake` / `CMakeLists.txt` / `.in` | ~100 | < 1 MB |

A single object file was 96 MB (`dune/gdt/CMakeFiles/_operators_interfaces_istl_3d.dir/.../interfaces_istl_3d.cc.o`). The pre-regression wheel contained **zero** of these — the old `setup.py` used `find_packages()` + `package_data={"": ["*.so"]}`, which only ever shipped `.py` + `.so`.

## The fix

In both `python/{xt,gdt}/pyproject.toml`, exclude the build artifacts and scope the `.so` force-include to the `dune` tree, restoring the old "Python sources + compiled extensions only" behaviour:

```toml
artifacts = ["dune/**/*.so"]
packages = ["dune"]
exclude = [
  "**/CMakeFiles/**", "**/*.o", "**/*.cc", "**/*.hh",
  "**/*.cmake", "**/CMakeLists.txt", "**/*.in",
]
```

## Verification

Built a minimal reproduction (fixed gdt `pyproject.toml` + hooks) over an assembly tree containing a 90 MB fake `*.cc.o`, `.cc`/`.hh`/CMake metadata, a `.py` and a fake `.so`. Result: a **202 KB** wheel containing only the `.py` files and the `.so` — every build artifact dropped, the `.so` still force-included. Dropping the ~927 MB of `.o` brings each real wheel back to roughly its pre-regression size (≈ `dune_gdt` ~85–90 MB, `dune_xt` ~45 MB), under the 100 MB limit.

Note: `dune_gdt` will sit fairly close to the 100 MB limit (~85–90 MB) — the bindings are genuinely large and the `.so` are already stripped. If it later crosses 100 MB, the next levers are splitting the bindings into more granular distributions or requesting a PyPI per-project file-size-limit increase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuMMN9irrpvKamVYf4tmu7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuMMN9irrpvKamVYf4tmu7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized wheel package configuration to reduce bundle size by restricting compiled artifacts and excluding build outputs, source files, and configuration files from distribution packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->