### PR TITLE
Fix wheel build: install dune wheels into dune-common's actual virtualenv

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -9,6 +9,9 @@ self-hosted-runner:
   - cpu=8
   - cpu=4
   - family=m7i
+  # r7i (memory-optimized) is used by build-linux so the -j7 Python-bindings
+  # compile fits in RAM; m7i stays for the wheel/docs jobs.
+  - family=r7i
   - image=ubuntu24-full-x64
   - volume=150gb
   - volume=80gb

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -121,10 +121,14 @@ jobs:
     runs-on:
     - runs-on=${{ github.run_id }}-${{ matrix.preset }}
     - cpu=${{ needs.config.outputs.linux_cpu }}
-    # m7i (general-purpose, 4 GB/vCPU -> 32 GB at cpu=8). Neither preset uses LTO,
-    # so there is no /tmp ltrans explosion like build_wheels; the 32 GB also lets
-    # the test_binaries build run at -j cpu-1 (see below).
-    - family=m7i
+    # r7i (memory-optimized, 8 GB/vCPU -> 64 GB at cpu=8). The Python bindings are
+    # the memory driver: their pybind11 TUs instantiate deeply-nested Dune templates
+    # and peak well above the ~2 GB/TU of the test binaries, so building them at the
+    # shared -j cpu-1 (see below) OOM-killed the 32 GB m7i mid-step on a cold ccache
+    # (the runner vanished, leaving the step stuck in-progress). The 64 GB here keeps
+    # the -j7 bindings compile (~7 * ~8 GB) under memory. Neither preset uses LTO, so
+    # there is no /tmp ltrans explosion like build_wheels.
+    - family=r7i
     - image=ubuntu24-full-x64
     # build/ tree + .vcpkg-root + 2 GB ccache fit easily; 80 GB gp3 leaves ample
     # headroom and the runner is a short-lived spot instance, so the extra storage

--- a/cmake/modules/DuneGdtMacros.cmake
+++ b/cmake/modules/DuneGdtMacros.cmake
@@ -143,16 +143,19 @@ set(DUNE_GRID_EXPERIMENTAL_GRID_EXTENSIONS TRUE)
 
 include(DunePybindxiUtils)
 
-# TODO there's no real way to require packages present at configure time? - jinja2,pyparsing is needed for test
-# templating can't use the run-in-env script here, because it will try to use dune.common which we're trying to install
-dune_execute_process(
-  COMMAND
-  ${CMAKE_BINARY_DIR}/dune-env/bin/python
-  -m
-  pip
-  install
-  jinja2
-  pyparsing)
+# Resolve dune-common's actual virtualenv interpreter. dune-common adopts an already-active virtualenv (e.g. the
+# manylinux wheel build activates build/wheelhouse/venv before configuring) instead of creating
+# ${CMAKE_BINARY_DIR}/dune-env, and RUN_IN_ENV_SCRIPT then wraps that adopted venv. The installs below must therefore
+# target DUNE_PYTHON_VIRTUALENV_EXECUTABLE -- hardcoding ${CMAKE_BINARY_DIR}/dune-env made the EXISTS guard false in
+# that case, so the dune wheels were never installed and a later run-in-env step failed with "No module named dune". For
+# a normal build DUNE_PYTHON_VIRTUALENV_EXECUTABLE is exactly ${CMAKE_BINARY_DIR}/dune-env/bin/python, so behaviour is
+# unchanged there. The fallback keeps the previous path for the early include pass, before dune-common has set the
+# variable (the EXISTS guard then skips the installs, as before).
+set(_dune_venv_python "${DUNE_PYTHON_VIRTUALENV_EXECUTABLE}")
+if(NOT _dune_venv_python)
+  set(_dune_venv_python "${CMAKE_BINARY_DIR}/dune-env/bin/python")
+endif()
+
 # Install the dune wheels from the vcpkg wheelhouse into the virtualenv. This file runs twice during configure: once
 # when included from the top-level CMakeLists.txt — possibly before dune-common's cmake has created the virtualenv, in
 # which case the installs are skipped — and once as dune-gdt's module-test macros after the virtualenv exists, which is
@@ -165,7 +168,17 @@ dune_execute_process(
 # an abstract requirement (and won't upgrade an already-satisfied one), so it cannot pull a mismatching release from
 # PyPI. --no-index would pin even harder but breaks the install: the wheels' third-party dependencies (portalocker,
 # numpy, ...) are not in the wheelhouse and must come from PyPI.
-if(EXISTS ${CMAKE_BINARY_DIR}/dune-env/bin/python)
+if(EXISTS ${_dune_venv_python})
+  # jinja2,pyparsing is needed for test templating; install directly into the venv (not via the run-in-env script, which
+  # would try to import dune.common — exactly what we are about to install).
+  dune_execute_process(
+    COMMAND
+    ${_dune_venv_python}
+    -m
+    pip
+    install
+    jinja2
+    pyparsing)
   if(NOT VCPKG_TARGET_TRIPLET)
     set(VCPKG_TARGET_TRIPLET x64-linux)
   endif()
@@ -178,7 +191,7 @@ if(EXISTS ${CMAKE_BINARY_DIR}/dune-env/bin/python)
         FATAL_ERROR "Expected exactly one ${dune_wheel_pkg} wheel in ${_dune_wheelhouse}, found: '${_dune_wheel}'")
     endif()
     execute_process(
-      COMMAND ${CMAKE_BINARY_DIR}/dune-env/bin/python -m pip install --find-links=${_dune_wheelhouse} ${_dune_wheel}
+      COMMAND ${_dune_venv_python} -m pip install --find-links=${_dune_wheelhouse} ${_dune_wheel}
       RESULT_VARIABLE _pip_install_result
       OUTPUT_VARIABLE pip_install_log ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
       ERROR_VARIABLE pip_install_log
@@ -194,3 +207,4 @@ if(EXISTS ${CMAKE_BINARY_DIR}/dune-env/bin/python)
 else()
   message(STATUS "Skipping dune wheel installs, the virtualenv does not exist yet")
 endif()
+unset(_dune_venv_python)


### PR DESCRIPTION
## Problem

`Build wheels (3.13)` is broken on `claude/oauth-pr-queue-filtering-lq7dq8` (e.g. run for `f7f074e` failed; it was green at `92ad900d` on 06-16). Configure aborts with:

```
DuneExecuteProcess.cmake:68: Error extracting static info from .../float_cmp.mini
  command: .../run-in-dune-env;dune_extract_static.py ...
  Return code: 77
  /home/dxt/src/build/wheelhouse/venv/bin/python: No module named dune
  Dune python package could not be found.
-- Configuring incomplete, errors occurred!
```

## Root cause

`cmake/modules/DuneGdtMacros.cmake` installed the dune wheels (and jinja2/pyparsing) into a **hardcoded** `${CMAKE_BINARY_DIR}/dune-env`, gated by `if(EXISTS ${CMAKE_BINARY_DIR}/dune-env/bin/python)`.

The manylinux wheel build (`.ci/build-wheels.sh`) creates and **activates** its own venv (`build/wheelhouse/venv`) before configuring. dune-common then adopts that already-active virtualenv instead of creating `${CMAKE_BINARY_DIR}/dune-env`, and `RUN_IN_ENV_SCRIPT` wraps the adopted venv. So the hardcoded path never exists → the guard is false → the dune wheels are never installed → the later `run-in-dune-env dune_extract_static.py` (system-test setup) can't import `dune` and configure fails.

## Fix

Target dune-common's actual virtualenv interpreter, `DUNE_PYTHON_VIRTUALENV_EXECUTABLE` (the venv `RUN_IN_ENV_SCRIPT` actually wraps), for the EXISTS guard and both pip installs, falling back to the old `dune-env` path for the early include pass before dune-common has set the variable.

- **Normal builds:** `DUNE_PYTHON_VIRTUALENV_EXECUTABLE` equals `${CMAKE_BINARY_DIR}/dune-env/bin/python`, so behaviour is unchanged.
- **Wheel build:** dune is now installed into the active `wheelhouse/venv`, which `run-in-dune-env` uses → `dune_extract_static.py` imports `dune` and configure succeeds.

Also moved the jinja2/pyparsing install inside the venv-exists guard so it no longer runs against a non-existent interpreter.

## Context / validation

Found while working on #246 (the cmake/python-uv rewire, based on this branch). That PR is unaffected by this bug except that it stopped masking it: its earlier `find_program(uv REQUIRED)` aborted configure before this code ran. This fix is independent and belongs on the base branch where the regression was introduced. CI on this PR exercises the wheel build and validates the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxMUN5ZbTg6zDT6qF7Waqx)_