### PR TITLE
[xt.test.grid] Add focused unit tests to lift dune/xt grid coverage

### DIFF
--- a/dune/xt/test/grid/boundaryinfo.cc
+++ b/dune/xt/test/grid/boundaryinfo.cc
@@ -1,0 +1,132 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include <dune/xt/test/main.hxx>
+
+#include <memory>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/grid/boundaryinfo.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+using namespace Dune::XT;
+using namespace Dune::XT::Grid;
+
+template <class T>
+struct BoundaryInfoTest : public ::testing::Test
+{
+  static constexpr size_t d = T::value;
+  using GridType = Dune::YaspGrid<d, Dune::EquidistantOffsetCoordinates<double, d>>;
+  using GridViewType = typename GridType::LeafGridView;
+  using IntersectionType = extract_intersection_t<GridViewType>;
+
+  const GridProvider<GridType> grid_prv;
+
+  BoundaryInfoTest()
+    : grid_prv(make_cube_grid<GridType>(0., 1., 2))
+  {
+  }
+
+  // For every boundary info, boundary intersections must be classified as the expected boundary type while inner
+  // intersections must be classified as no_boundary.
+  template <class BoundaryInfoType, class BoundaryType>
+  void check_classification(const BoundaryInfoType& info, const BoundaryType& expected_boundary_type)
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    size_t num_boundary = 0;
+    for (auto&& element : Dune::elements(gv)) {
+      for (auto&& intersection : Dune::intersections(gv, element)) {
+        if (intersection.boundary() && !intersection.neighbor()) {
+          EXPECT_EQ(info.type(intersection), expected_boundary_type);
+          ++num_boundary;
+        } else if (intersection.neighbor()) {
+          EXPECT_EQ(info.type(intersection), no_boundary);
+        }
+      }
+    }
+    EXPECT_GT(num_boundary, 0);
+  }
+
+  void check_alldirichlet()
+  {
+    const auto info = make_alldirichlet_boundaryinfo(grid_prv.grid().leafGridView());
+    check_classification(*info, dirichlet_boundary);
+  }
+
+  void check_allneumann()
+  {
+    const auto info = make_allneumann_boundaryinfo<IntersectionType>();
+    check_classification(*info, neumann_boundary);
+  }
+
+  void check_allreflecting()
+  {
+    const auto info = make_allreflecting_boundaryinfo<IntersectionType>();
+    check_classification(*info, reflecting_boundary);
+  }
+
+  // The default normal-based configuration maps every axis-aligned normal to a Dirichlet boundary, so for an
+  // axis-aligned cube grid all boundary intersections must be classified as Dirichlet.
+  void check_normalbased()
+  {
+    const auto info = make_normalbased_boundaryinfo<IntersectionType>(normalbased_boundaryinfo_default_config<d>());
+    check_classification(*info, dirichlet_boundary);
+    // exercise the textual representation
+    EXPECT_FALSE(info->str().empty());
+  }
+};
+
+using GridDims = ::testing::Types<::Int<1>, ::Int<2>, ::Int<3>>;
+TYPED_TEST_SUITE(BoundaryInfoTest, GridDims);
+
+TYPED_TEST(BoundaryInfoTest, alldirichlet)
+{
+  this->check_alldirichlet();
+}
+TYPED_TEST(BoundaryInfoTest, allneumann)
+{
+  this->check_allneumann();
+}
+TYPED_TEST(BoundaryInfoTest, allreflecting)
+{
+  this->check_allreflecting();
+}
+TYPED_TEST(BoundaryInfoTest, normalbased)
+{
+  this->check_normalbased();
+}
+
+
+GTEST_TEST(BoundaryTypes, make_and_compare)
+{
+  // note: make_boundary_type does not support AbsorbingBoundary, so it is intentionally omitted here
+  for (const auto& id : {NoBoundary().id(),
+                         UnknownBoundary().id(),
+                         DirichletBoundary().id(),
+                         NeumannBoundary().id(),
+                         RobinBoundary().id(),
+                         ReflectingBoundary().id(),
+                         InflowBoundary().id(),
+                         OutflowBoundary().id(),
+                         InflowOutflowBoundary().id(),
+                         ImpermeableBoundary().id()}) {
+    std::unique_ptr<BoundaryType> created(make_boundary_type(id));
+    EXPECT_EQ(created->id(), id);
+    // a copy compares equal to its original ...
+    std::unique_ptr<BoundaryType> copied(created->copy());
+    EXPECT_EQ(*created, *copied);
+    EXPECT_FALSE(*created != *copied);
+  }
+  // ... while distinct types compare unequal
+  EXPECT_NE(DirichletBoundary(), NeumannBoundary());
+  EXPECT_THROW(make_boundary_type("not_a_valid_boundary_type"), Exceptions::boundary_type_error);
+}

--- a/dune/xt/test/grid/entity.cc
+++ b/dune/xt/test/grid/entity.cc
@@ -1,0 +1,101 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include <dune/xt/test/main.hxx>
+
+#include <cmath>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/common/float_cmp.hh>
+#include <dune/xt/common/logstreams.hh>
+
+#include <dune/xt/grid/entity.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+using namespace Dune::XT;
+using namespace Dune::XT::Common;
+using namespace Dune::XT::Grid;
+
+template <class T>
+struct EntityTest : public ::testing::Test
+{
+  static constexpr size_t d = T::value;
+  using GridType = Dune::YaspGrid<d, Dune::EquidistantOffsetCoordinates<double, d>>;
+  using GridViewType = typename GridType::LeafGridView;
+  using ElementType = extract_entity_t<GridViewType>;
+
+  static constexpr size_t num_elements_per_dim = 2;
+  const GridProvider<GridType> grid_prv;
+
+  EntityTest()
+    : grid_prv(make_cube_grid<GridType>(0., 1., num_elements_per_dim))
+  {
+  }
+
+  // On a unit cube subdivided into n^d cells, each cell is a cube of edge h = 1/n,
+  // so its diameter (longest corner-to-corner distance) is h * sqrt(d).
+  void check_diameter()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    const double h = 1. / double(num_elements_per_dim);
+    const double expected = h * std::sqrt(double(d));
+    size_t checked = 0;
+    for (auto&& element : Dune::elements(gv)) {
+      EXPECT_TRUE(FloatCmp::eq(diameter(element), expected));
+      EXPECT_DOUBLE_EQ(diameter(element), entity_diameter(element));
+      ++checked;
+    }
+    EXPECT_EQ(checked, gv.size(0));
+  }
+
+  void check_reference_element()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    for (auto&& element : Dune::elements(gv)) {
+      const auto ref_from_entity = reference_element(element);
+      const auto ref_from_geometry = reference_element(element.geometry());
+      // the element itself is the single codim-0 subentity
+      EXPECT_EQ(1, ref_from_entity.size(0));
+      EXPECT_EQ(ref_from_entity.size(0), ref_from_geometry.size(0));
+      // a cube element in d dimensions has 2^d corners (codim-d subentities)
+      EXPECT_EQ(size_t(1) << d, size_t(ref_from_entity.size(int(d))));
+    }
+  }
+
+  void check_print()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    for (auto&& element : Dune::elements(gv)) {
+      print_entity(element, "element", dev_null);
+      dev_null << element; // operator<<
+      // also exercise the empty-name branch
+      print_entity(element, "", dev_null);
+      break; // one element is enough to exercise the output code path
+    }
+  }
+};
+
+using GridDims = ::testing::Types<Int<1>, Int<2>, Int<3>>;
+TYPED_TEST_SUITE(EntityTest, GridDims);
+
+TYPED_TEST(EntityTest, diameter)
+{
+  this->check_diameter();
+}
+TYPED_TEST(EntityTest, reference_element)
+{
+  this->check_reference_element();
+}
+TYPED_TEST(EntityTest, print)
+{
+  this->check_print();
+}

--- a/dune/xt/test/grid/filters.cc
+++ b/dune/xt/test/grid/filters.cc
@@ -95,7 +95,9 @@ struct FilterTest : public ::testing::Test
     const auto gv = grid_prv.grid().leafGridView();
 
     // count expected values by hand
-    size_t total = 0, boundary = 0, inner = 0;
+    size_t total = 0;
+    size_t boundary = 0;
+    size_t inner = 0;
     for (auto&& element : Dune::elements(gv)) {
       for (auto&& intersection : Dune::intersections(gv, element)) {
         ++total;
@@ -121,7 +123,7 @@ struct FilterTest : public ::testing::Test
 
     // CustomBoundaryIntersections combined with an all-Dirichlet boundary info selects every boundary intersection
     const auto info = make_alldirichlet_boundaryinfo(gv);
-    ApplyOn::CustomBoundaryIntersections<GridViewType> custom(*info, new DirichletBoundary());
+    ApplyOn::CustomBoundaryIntersections<GridViewType> custom(*info, std::make_shared<DirichletBoundary>());
     EXPECT_EQ(boundary, count_intersections(custom, gv));
 
     // copy() must yield an equivalent filter

--- a/dune/xt/test/grid/filters.cc
+++ b/dune/xt/test/grid/filters.cc
@@ -1,0 +1,151 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include <dune/xt/test/main.hxx>
+
+#include <memory>
+
+#include <dune/grid/common/partitionset.hh>
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/grid/boundaryinfo.hh>
+#include <dune/xt/grid/filters.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+using namespace Dune::XT;
+using namespace Dune::XT::Grid;
+
+template <class T>
+struct FilterTest : public ::testing::Test
+{
+  static constexpr size_t d = T::value;
+  using GridType = Dune::YaspGrid<d, Dune::EquidistantOffsetCoordinates<double, d>>;
+  using GridViewType = typename GridType::LeafGridView;
+
+  // use four cells per dimension so that (for d >= 2) interior elements without boundary intersections exist
+  static constexpr size_t num_elements_per_dim = 4;
+  const GridProvider<GridType> grid_prv;
+
+  FilterTest()
+    : grid_prv(make_cube_grid<GridType>(0., 1., num_elements_per_dim))
+  {
+  }
+
+  template <class Filter, class Range>
+  size_t count_elements(const Filter& filter, const GridViewType& gv, const Range& range)
+  {
+    size_t count = 0;
+    for (auto&& element : range)
+      if (filter.contains(gv, element))
+        ++count;
+    return count;
+  }
+
+  void check_element_filters()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    const size_t num_elements = gv.size(0);
+
+    // count expected values by hand
+    size_t expected_boundary = 0;
+    for (auto&& element : Dune::elements(gv))
+      if (element.hasBoundaryIntersections())
+        ++expected_boundary;
+
+    EXPECT_EQ(num_elements, count_elements(ApplyOn::AllElements<GridViewType>(), gv, Dune::elements(gv)));
+    EXPECT_EQ(0u, count_elements(ApplyOn::NoElements<GridViewType>(), gv, Dune::elements(gv)));
+    EXPECT_EQ(expected_boundary, count_elements(ApplyOn::BoundaryElements<GridViewType>(), gv, Dune::elements(gv)));
+    EXPECT_GT(expected_boundary, 0);
+    EXPECT_EQ(
+        num_elements,
+        count_elements(ApplyOn::PartitionSetElements<GridViewType, Dune::Partitions::All>(), gv, Dune::elements(gv)));
+
+    // generic filter: select elements with index < num_elements / 2
+    ApplyOn::GenericFilteredElements<GridViewType> half([](const auto& grid_view, const auto& element) {
+      return grid_view.indexSet().index(element) < grid_view.indexSet().size(0) / 2;
+    });
+    EXPECT_EQ(num_elements / 2, count_elements(half, gv, Dune::elements(gv)));
+
+    // copy() must yield an equivalent filter
+    std::unique_ptr<ElementFilter<GridViewType>> copied(ApplyOn::AllElements<GridViewType>().copy());
+    EXPECT_EQ(num_elements, count_elements(*copied, gv, Dune::elements(gv)));
+  }
+
+  template <class Filter>
+  size_t count_intersections(const Filter& filter, const GridViewType& gv)
+  {
+    size_t count = 0;
+    for (auto&& element : Dune::elements(gv))
+      for (auto&& intersection : Dune::intersections(gv, element))
+        if (filter.contains(gv, intersection))
+          ++count;
+    return count;
+  }
+
+  void check_intersection_filters()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+
+    // count expected values by hand
+    size_t total = 0, boundary = 0, inner = 0;
+    for (auto&& element : Dune::elements(gv)) {
+      for (auto&& intersection : Dune::intersections(gv, element)) {
+        ++total;
+        if (intersection.boundary())
+          ++boundary;
+        if (intersection.neighbor() && !intersection.boundary())
+          ++inner;
+      }
+    }
+    EXPECT_EQ(total, num_elements_per_dim_pow_d() * 2 * d);
+    EXPECT_EQ(total, boundary + inner);
+
+    EXPECT_EQ(total, count_intersections(ApplyOn::AllIntersections<GridViewType>(), gv));
+    EXPECT_EQ(0u, count_intersections(ApplyOn::NoIntersections<GridViewType>(), gv));
+    EXPECT_EQ(boundary, count_intersections(ApplyOn::BoundaryIntersections<GridViewType>(), gv));
+    EXPECT_EQ(boundary, count_intersections(ApplyOn::NonPeriodicBoundaryIntersections<GridViewType>(), gv));
+    EXPECT_EQ(inner, count_intersections(ApplyOn::InnerIntersections<GridViewType>(), gv));
+
+    // a generic filter selecting boundary intersections must agree with BoundaryIntersections
+    ApplyOn::GenericFilteredIntersections<GridViewType> generic_boundary(
+        [](const auto&, const auto& intersection) { return intersection.boundary(); });
+    EXPECT_EQ(boundary, count_intersections(generic_boundary, gv));
+
+    // CustomBoundaryIntersections combined with an all-Dirichlet boundary info selects every boundary intersection
+    const auto info = make_alldirichlet_boundaryinfo(gv);
+    ApplyOn::CustomBoundaryIntersections<GridViewType> custom(*info, new DirichletBoundary());
+    EXPECT_EQ(boundary, count_intersections(custom, gv));
+
+    // copy() must yield an equivalent filter
+    std::unique_ptr<IntersectionFilter<GridViewType>> copied(ApplyOn::BoundaryIntersections<GridViewType>().copy());
+    EXPECT_EQ(boundary, count_intersections(*copied, gv));
+  }
+
+  static size_t num_elements_per_dim_pow_d()
+  {
+    size_t result = 1;
+    for (size_t ii = 0; ii < d; ++ii)
+      result *= num_elements_per_dim;
+    return result;
+  }
+};
+
+using GridDims = ::testing::Types<::Int<1>, ::Int<2>, ::Int<3>>;
+TYPED_TEST_SUITE(FilterTest, GridDims);
+
+TYPED_TEST(FilterTest, element_filters)
+{
+  this->check_element_filters();
+}
+TYPED_TEST(FilterTest, intersection_filters)
+{
+  this->check_intersection_filters();
+}

--- a/dune/xt/test/grid/integrals.cc
+++ b/dune/xt/test/grid/integrals.cc
@@ -50,9 +50,9 @@ struct IntegralsTest : public ::testing::Test
     const double c = 2.5;
     for (auto&& element : Dune::elements(gv)) {
       volume += element_integral(
-          element, std::function<double(const FieldVector<double, d>&)>([](const auto&) { return 1.; }), 0);
+          element, std::function<double(const Dune::FieldVector<double, d>&)>([](const auto&) { return 1.; }), 0);
       weighted += element_integral(
-          element, std::function<double(const FieldVector<double, d>&)>([c](const auto&) { return c; }), 0);
+          element, std::function<double(const Dune::FieldVector<double, d>&)>([c](const auto&) { return c; }), 0);
     }
     EXPECT_TRUE(Common::FloatCmp::eq(volume, 1.));
     EXPECT_TRUE(Common::FloatCmp::eq(weighted, c));
@@ -69,7 +69,7 @@ struct IntegralsTest : public ::testing::Test
         if (intersection.boundary() && !intersection.neighbor())
           surface += intersection_integral(
               intersection,
-              std::function<double(const FieldVector<double, int(d) - 1>&)>([](const auto&) { return 1.; }),
+              std::function<double(const Dune::FieldVector<double, int(d) - 1>&)>([](const auto&) { return 1.; }),
               0);
       }
     }

--- a/dune/xt/test/grid/integrals.cc
+++ b/dune/xt/test/grid/integrals.cc
@@ -1,0 +1,90 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include <dune/xt/test/main.hxx>
+
+#include <functional>
+
+#include <dune/common/fvector.hh>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/common/float_cmp.hh>
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/integrals.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+using namespace Dune::XT;
+using namespace Dune::XT::Grid;
+
+template <class T>
+struct IntegralsTest : public ::testing::Test
+{
+  static constexpr size_t d = T::value;
+  using GridType = Dune::YaspGrid<d, Dune::EquidistantOffsetCoordinates<double, d>>;
+  using GridViewType = typename GridType::LeafGridView;
+
+  static constexpr size_t num_elements_per_dim = 3;
+  const GridProvider<GridType> grid_prv;
+
+  IntegralsTest()
+    : grid_prv(make_cube_grid<GridType>(0., 1., num_elements_per_dim))
+  {
+  }
+
+  // The integral of the constant function 1 over all elements equals the volume of the unit cube domain, which is 1.
+  // The integral of a constant c equals c times the same volume.
+  void check_element_integral()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    double volume = 0.;
+    double weighted = 0.;
+    const double c = 2.5;
+    for (auto&& element : Dune::elements(gv)) {
+      volume += element_integral(
+          element, std::function<double(const FieldVector<double, d>&)>([](const auto&) { return 1.; }), 0);
+      weighted += element_integral(
+          element, std::function<double(const FieldVector<double, d>&)>([c](const auto&) { return c; }), 0);
+    }
+    EXPECT_TRUE(Common::FloatCmp::eq(volume, 1.));
+    EXPECT_TRUE(Common::FloatCmp::eq(weighted, c));
+  }
+
+  // The integral of the constant function 1 over all boundary intersections equals the surface area of the unit cube,
+  // which is 2 * d (independent of the refinement level).
+  void check_intersection_integral()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    double surface = 0.;
+    for (auto&& element : Dune::elements(gv)) {
+      for (auto&& intersection : Dune::intersections(gv, element)) {
+        if (intersection.boundary() && !intersection.neighbor())
+          surface += intersection_integral(
+              intersection,
+              std::function<double(const FieldVector<double, int(d) - 1>&)>([](const auto&) { return 1.; }),
+              0);
+      }
+    }
+    EXPECT_TRUE(Common::FloatCmp::eq(surface, 2. * double(d)));
+  }
+};
+
+using GridDims = ::testing::Types<::Int<1>, ::Int<2>, ::Int<3>>;
+TYPED_TEST_SUITE(IntegralsTest, GridDims);
+
+TYPED_TEST(IntegralsTest, element_integral)
+{
+  this->check_element_integral();
+}
+TYPED_TEST(IntegralsTest, intersection_integral)
+{
+  this->check_intersection_integral();
+}

--- a/dune/xt/test/grid/intersection.cc
+++ b/dune/xt/test/grid/intersection.cc
@@ -1,0 +1,122 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include <dune/xt/test/main.hxx>
+
+#include <cmath>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/common/float_cmp.hh>
+#include <dune/xt/common/logstreams.hh>
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/intersection.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+using namespace Dune::XT;
+using namespace Dune::XT::Common;
+using namespace Dune::XT::Grid;
+
+template <class T>
+struct IntersectionTest : public ::testing::Test
+{
+  static constexpr size_t d = T::value;
+  using GridType = Dune::YaspGrid<d, Dune::EquidistantOffsetCoordinates<double, d>>;
+  using GridViewType = typename GridType::LeafGridView;
+
+  static constexpr size_t num_elements_per_dim = 2;
+  const GridProvider<GridType> grid_prv;
+
+  IntersectionTest()
+    : grid_prv(make_cube_grid<GridType>(0., 1., num_elements_per_dim))
+  {
+  }
+
+  // For an axis-aligned cube grid, the center unit outer normal of any intersection has unit length and is
+  // axis-aligned (exactly one component is +-1, all others are 0).
+  void check_normals()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    for (auto&& element : Dune::elements(gv)) {
+      for (auto&& intersection : Dune::intersections(gv, element)) {
+        const auto normal = intersection.centerUnitOuterNormal();
+        EXPECT_TRUE(FloatCmp::eq(normal.two_norm(), 1.));
+        size_t non_zero = 0;
+        for (size_t ii = 0; ii < d; ++ii)
+          if (!FloatCmp::eq(std::abs(normal[ii]), 0.))
+            ++non_zero;
+        EXPECT_EQ(1u, non_zero);
+      }
+    }
+  }
+
+  // The diameter of a codim-1 face of a cube of edge h is h * sqrt(d - 1) (only meaningful for d >= 2, since in 1d
+  // an intersection is a single point).
+  void check_diameter()
+  {
+    if (d < 2)
+      return;
+    const auto gv = grid_prv.grid().leafGridView();
+    const double h = 1. / double(num_elements_per_dim);
+    const double expected = h * std::sqrt(double(d - 1));
+    for (auto&& element : Dune::elements(gv))
+      for (auto&& intersection : Dune::intersections(gv, element))
+        EXPECT_TRUE(FloatCmp::eq(diameter(intersection), expected));
+  }
+
+  // The center of an intersection lies on the intersection; a point translated away from the center along the outer
+  // normal does not.
+  void check_contains()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    for (auto&& element : Dune::elements(gv)) {
+      for (auto&& intersection : Dune::intersections(gv, element)) {
+        const auto center = intersection.geometry().center();
+        EXPECT_TRUE(contains(intersection, center));
+        auto outside = center;
+        outside.axpy(2., intersection.centerUnitOuterNormal());
+        EXPECT_FALSE(contains(intersection, outside));
+      }
+    }
+  }
+
+  void check_print()
+  {
+    const auto gv = grid_prv.grid().leafGridView();
+    for (auto&& element : Dune::elements(gv)) {
+      for (auto&& intersection : Dune::intersections(gv, element)) {
+        print_intersection(intersection, "intersection", dev_null);
+        print_intersection(intersection, "", dev_null);
+        return; // one intersection is enough to exercise the output code path
+      }
+    }
+  }
+};
+
+using GridDims = ::testing::Types<Int<1>, Int<2>, Int<3>>;
+TYPED_TEST_SUITE(IntersectionTest, GridDims);
+
+TYPED_TEST(IntersectionTest, normals)
+{
+  this->check_normals();
+}
+TYPED_TEST(IntersectionTest, diameter)
+{
+  this->check_diameter();
+}
+TYPED_TEST(IntersectionTest, contains)
+{
+  this->check_contains();
+}
+TYPED_TEST(IntersectionTest, print)
+{
+  this->check_print();
+}


### PR DESCRIPTION
## Context

Coverage analysis of `dune/xt` (the Codecov tree for `main`) showed `dune/xt/common`
well covered and `dune/xt/la` / `dune/xt/functions` broadly covered via the `.tpl`
generated test suites, while **`dune/xt/grid` had the largest gap**: several headers
were exercised only indirectly (through the walker) or not at all.

This PR adds focused, **plain GoogleTest** unit tests for that gap. Each is a typed
test over grid dimensions 1/2/3 using `YaspGrid`, modeled on the existing
`dune/xt/test/grid/walker.cc` and `information.cc`. No `.mini`/`.tpl` machinery is
used, and the files are auto-discovered by the existing test CMake globbing
(`_PROCESS_SUBDIR_TESTS`), so **no build configuration changes are required**.

## What's added

| File | Covers | Key assertions |
|------|--------|----------------|
| `entity.cc` | `grid/entity.hh` | `diameter`/`entity_diameter` = `h·√d`, `reference_element` (2ᵈ corners), `print_entity` / `operator<<` |
| `intersection.cc` | `grid/intersection.hh` | `diameter` = `h·√(d-1)`, center unit outer normals are axis-aligned & unit length, `contains`, `print_intersection` |
| `boundaryinfo.cc` | `boundaryinfo/{alldirichlet,allneumann,allreflecting,normalbased}.hh`, `types.hh` | boundary intersections classified as the expected type, inner as `no_boundary`; `make_boundary_type` round-trip and `BoundaryType` equality |
| `filters.cc` | `filters/{element,intersection}.hh` | every `ApplyOn::*` filter (incl. `CustomBoundaryIntersections` + boundary info, generic lambda filters, `copy()`) vs hand-counted expectations |
| `integrals.cc` | `grid/integrals.hh` | `element_integral` of a constant = analytic volume; `intersection_integral` over the boundary = surface area `2·d` |

All expected values are derived from analytic properties of the unit cube
`[0,1]ᵈ`, so they are independent of the refinement level.

## Verification

These require the full DUNE stack to compile, which is not available in the
authoring environment — CI (the same pipeline feeding Codecov) builds and runs
them. After merge, the targeted `grid` headers should move from near-zero toward
full line coverage. This is the first phase of a broader coverage plan (subsequent
phases target small remaining gaps in `functions`, `la`, and `common`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019YzKCz4XtvFNj662VP4Mq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added typed coverage for boundary classification and boundary-type construction/round-trip, including error handling, normal-based configuration checks, and `BoundaryTypes` equality/inequality semantics
  * Added typed tests for grid entity utilities (diameter, reference element consistency, and entity printing)
  * Added typed tests for element and intersection filtering semantics, including boundary-related custom filtering and `copy()` behavior
  * Added typed tests for unit-cube element and boundary intersection integral computations
  * Added typed tests for intersection geometry (unit outer normals, expected face diameter, containment checks, and intersection printing)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->