### PR TITLE
Wire coverage/pytest through CMake (CTest + coverage targets)

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -189,19 +189,13 @@ jobs:
       run: |
         sudo apt-get update
         # xvfb gives the Python binding tests a headless display; both legs run
-        # those tests. gcovr is pulled separately (coverage leg only) via pipx.
+        # those tests. gcovr/coverage.py are pulled on the fly by uv inside the
+        # CMake coverage_cpp / coverage_python targets (coverage leg only).
         sudo apt-get install -y ninja-build ccache xvfb
 
-    - name: Install coverage tooling
-      # gcovr turns the gcov .gcda/.gcno files produced by the instrumented build
-      # into a Cobertura XML report codecov understands. Only needed on the
-      # coverage leg, which alone compiles with instrumentation.
-      if: ${{ matrix.coverage }}
-      run: pipx install gcovr
-
     - name: Set up uv
-      # Both legs run the Python test suite, which the CMake xt_test_python /
-      # gdt_test_python targets execute via `uv run` (no manually-managed venv).
+      # Both legs run the Python test suite, which the ctest xt_test_python /
+      # gdt_test_python tests execute via `uv run` (no manually-managed venv).
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         # gate the uv cache to trusted runs (pushes/merge queue and same-repo
@@ -243,50 +237,34 @@ jobs:
         cmake --build --preset=${{ matrix.preset }} --target test_binaries --parallel -- -j ${{ needs.config.outputs.linux_build_jobs }}
         ccache --show-stats
 
-    - name: Test with CTest
-      run: |
-        # Run the ~400 test executables concurrently. ctest_parallel (2x vCPU,
-        # from the config job) oversubscribes since the tests are short/IO-light.
-        ctest --preset=${{ matrix.preset }} --parallel ${{ needs.config.outputs.ctest_parallel }}
-
     - name: Build Python bindings
-      # Both legs run the Python test suite, so both build the .so bindings.
+      # Both legs run the Python test suite (now part of ctest), so both build the
+      # .so bindings first — CTest does not build dependencies, and the
+      # xt_test_python / gdt_test_python tests need the compiled modules present.
       run: cmake --build --preset=${{ matrix.preset }} --target bindings --parallel -- -j ${{ needs.config.outputs.linux_build_jobs }}
 
-    - name: Run Python tests (with coverage)
-      # The xt_test_python / gdt_test_python targets run pytest with --cov and
-      # write coverage.py data files (coverage-xt, coverage-gdt) into the build
-      # dir. xvfb-run wraps the whole invocation so any visualisation-backed test
-      # has a display. We intentionally skip the test_docs target (notebook
-      # execution) here — that is covered by the build_docs job. The coverage.py
-      # data is only converted and uploaded on the coverage leg below.
+    - name: Test with CTest
+      # Runs both the C++ suite and the Python (pytest) suite — the latter is now
+      # registered as ctest tests (xt_test_python / gdt_test_python) rather than a
+      # standalone build target. xvfb-run wraps the whole invocation so any
+      # visualisation-backed binding test has a headless display. The pytest tests
+      # write coverage.py data files (coverage-xt, coverage-gdt) into the build dir
+      # for the coverage_python target below. ctest_parallel (2x vCPU, from the
+      # config job) oversubscribes the ~400 short/IO-light C++ executables.
       run: |
-        xvfb-run -a cmake --build --preset=${{ matrix.preset }} \
-          --target xt_test_python gdt_test_python
+        xvfb-run -a ctest --preset=${{ matrix.preset }} --parallel ${{ needs.config.outputs.ctest_parallel }}
 
-    - name: Collect C++ coverage (gcovr -> Cobertura XML)
+    - name: Collect C++ coverage (coverage_cpp target -> Cobertura XML)
+      # gcovr is run by the CMake coverage_cpp target (pulled on the fly via uv);
+      # it writes build/<preset>/coverage-cpp.xml.
       if: ${{ matrix.coverage }}
-      run: |
-        gcovr \
-          --root "${GITHUB_WORKSPACE}" \
-          --filter "${GITHUB_WORKSPACE}/dune/" \
-          --gcov-ignore-parse-errors \
-          --exclude-unreachable-branches \
-          --exclude-throw-branches \
-          --print-summary \
-          --xml-pretty -o "${GITHUB_WORKSPACE}/coverage-cpp.xml" \
-          "${GITHUB_WORKSPACE}/build/${{ matrix.preset }}"
+      run: cmake --build --preset=${{ matrix.preset }} --target coverage_cpp
 
-    - name: Collect Python coverage (coverage.py -> XML)
+    - name: Collect Python coverage (coverage_python target -> XML)
+      # the CMake coverage_python target combines the two coverage.py data files
+      # written by the pytest ctest runs and writes build/<preset>/coverage-python.xml.
       if: ${{ matrix.coverage }}
-      run: |
-        # the pytest run wrote two coverage.py data files (coverage-xt,
-        # coverage-gdt) into the build dir; combine them into one XML. coverage is
-        # pulled on the fly by uv (no manually-managed venv), matching the rest of
-        # the Python tooling in this job.
-        cd "${GITHUB_WORKSPACE}/build/${{ matrix.preset }}"
-        uv run --no-project --with coverage python -m coverage combine coverage-xt coverage-gdt
-        uv run --no-project --with coverage python -m coverage xml -o "${GITHUB_WORKSPACE}/coverage-python.xml"
+      run: cmake --build --preset=${{ matrix.preset }} --target coverage_python
 
     - name: Upload C++ coverage to Codecov
       if: ${{ matrix.coverage }}
@@ -294,7 +272,7 @@ jobs:
       with:
         # OIDC (id-token) auth instead of an upload token; see job permissions.
         use_oidc: true
-        files: ${{ github.workspace }}/coverage-cpp.xml
+        files: ${{ github.workspace }}/build/${{ matrix.preset }}/coverage-cpp.xml
         flags: cpp
         # We already produced the Cobertura XML with gcovr above; stop the action
         # from searching the tree and from running its own coverage plugins (the
@@ -310,7 +288,7 @@ jobs:
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         use_oidc: true
-        files: ${{ github.workspace }}/coverage-python.xml
+        files: ${{ github.workspace }}/build/${{ matrix.preset }}/coverage-python.xml
         flags: python
         disable_search: true
         plugins: noop

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -285,36 +285,65 @@ macro(DXT_EXCLUDE_FROM_HEADERCHECK)
 endmacro(DXT_EXCLUDE_FROM_HEADERCHECK)
 
 macro(DXT_ADD_PYTHON_TESTS)
-  # The Python test suites run through `uv run`: uv assembles an ephemeral environment (no manually-created/activated
-  # virtualenv) pinned to the very interpreter the bindings were compiled against (${Python_EXECUTABLE}, so the cpython
-  # ABI of the built .so modules matches), installs the freshly built packages editable from the build tree plus the
-  # pytest tooling, and runs pytest. dune.gdt depends on the exact-version dune.xt, so the gdt suite installs both
-  # editable packages.
-  add_custom_target(
-    xt_test_python
+  # The Python test suites are registered as CTest tests (run by `ctest`, never as standalone build targets) so a single
+  # `ctest --preset ...` exercises both the C++ and the Python suites. Each test runs through `uv run`: uv assembles an
+  # ephemeral environment (no manually-created/activated virtualenv) pinned to the very interpreter the bindings were
+  # compiled against (${Python_EXECUTABLE}, so the cpython ABI of the built .so modules matches), installs the freshly
+  # built packages editable from the build tree plus the pytest tooling, and runs pytest. dune.gdt depends on the
+  # exact-version dune.xt, so the gdt suite installs both editable packages. The bindings .so modules must be built
+  # before `ctest` runs (CTest does not build dependencies): build the `bindings` target first.
+  add_test(
+    NAME xt_test_python
     COMMAND
-      ${CMAKE_COMMAND} -E env COVERAGE_FILE=${CMAKE_BINARY_DIR}/coverage-xt "uv" "run" "--no-project" "--python"
-      "${Python_EXECUTABLE}" "--with-editable" "${CMAKE_BINARY_DIR}/python/xt" "--with" "pytest" "--with" "pytest-cov"
-      "--with" "pytest-regressions" "--with" "hypothesis" "python" "-m" "pytest" "${CMAKE_BINARY_DIR}/python/xt" "--cov"
-      "${CMAKE_CURRENT_SOURCE_DIR}/" "--junitxml=${CMAKE_BINARY_DIR}/pytest_results_xt.xml"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/python/xt"
-    DEPENDS bindings
-    VERBATIM USES_TERMINAL)
-  add_custom_target(
-    gdt_test_python
+      uv run --no-project --python ${Python_EXECUTABLE} --with-editable ${CMAKE_BINARY_DIR}/python/xt --with pytest
+      --with pytest-cov --with pytest-regressions --with hypothesis python -m pytest ${CMAKE_BINARY_DIR}/python/xt
+      --cov ${CMAKE_CURRENT_SOURCE_DIR}/ --junitxml=${CMAKE_BINARY_DIR}/pytest_results_xt.xml)
+  set_tests_properties(
+    xt_test_python PROPERTIES WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/python/xt ENVIRONMENT
+                              COVERAGE_FILE=${CMAKE_BINARY_DIR}/coverage-xt LABELS "dune-gdt-test;python_test")
+  add_test(
+    NAME gdt_test_python
     COMMAND
-      ${CMAKE_COMMAND} -E env COVERAGE_FILE=${CMAKE_BINARY_DIR}/coverage-gdt "uv" "run" "--no-project" "--python"
-      "${Python_EXECUTABLE}" "--with-editable" "${CMAKE_BINARY_DIR}/python/xt" "--with-editable"
-      "${CMAKE_BINARY_DIR}/python/gdt" "--with" "pytest" "--with" "pytest-cov" "--with" "pytest-regressions" "--with"
-      "hypothesis" "python" "-m" "pytest" "${CMAKE_BINARY_DIR}/python/gdt" "--cov" "${CMAKE_CURRENT_SOURCE_DIR}/"
-      "--junitxml=${CMAKE_BINARY_DIR}/pytest_results_gdt.xml"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/python/gdt"
-    DEPENDS bindings
-    VERBATIM USES_TERMINAL)
+      uv run --no-project --python ${Python_EXECUTABLE} --with-editable ${CMAKE_BINARY_DIR}/python/xt --with-editable
+      ${CMAKE_BINARY_DIR}/python/gdt --with pytest --with pytest-cov --with pytest-regressions --with hypothesis python
+      -m pytest ${CMAKE_BINARY_DIR}/python/gdt --cov ${CMAKE_CURRENT_SOURCE_DIR}/
+      --junitxml=${CMAKE_BINARY_DIR}/pytest_results_gdt.xml)
+  set_tests_properties(
+    gdt_test_python PROPERTIES WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/python/gdt ENVIRONMENT
+                               COVERAGE_FILE=${CMAKE_BINARY_DIR}/coverage-gdt LABELS "dune-gdt-test;python_test")
 
+  # Coverage-processing targets (moved here from the CI workflow). Run them after `ctest`: the pytest tests above write
+  # the coverage.py data files (coverage-xt, coverage-gdt) into the build dir, and the instrumented C++ tests (the
+  # release_coverage preset) write the gcov .gcda/.gcno files under the build tree. Both gcovr and coverage.py are
+  # pulled on the fly by uv (no manually-managed venv); they are also listed in the `infrastructure` dev group in
+  # python/xt/pyproject.toml.
+  if(NOT TARGET coverage_cpp)
+    # gcov data under the build tree -> Cobertura XML codecov understands, filtered to our own dune/ sources.
+    add_custom_target(
+      coverage_cpp
+      COMMAND
+        uv run --no-project --with gcovr gcovr --root ${CMAKE_SOURCE_DIR} --filter ${CMAKE_SOURCE_DIR}/dune/
+        --gcov-ignore-parse-errors --exclude-unreachable-branches --exclude-throw-branches --print-summary --xml-pretty
+        -o ${CMAKE_BINARY_DIR}/coverage-cpp.xml ${CMAKE_BINARY_DIR}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      VERBATIM USES_TERMINAL)
+  endif()
+  if(NOT TARGET coverage_python)
+    # combine the two coverage.py data files written by the pytest CTest runs and emit one XML.
+    add_custom_target(
+      coverage_python
+      COMMAND uv run --no-project --with coverage python -m coverage combine coverage-xt coverage-gdt
+      COMMAND uv run --no-project --with coverage python -m coverage xml -o ${CMAKE_BINARY_DIR}/coverage-python.xml
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      VERBATIM USES_TERMINAL)
+  endif()
+  if(NOT TARGET coverage)
+    add_custom_target(coverage DEPENDS coverage_cpp coverage_python)
+  endif()
+
+  # test_python is kept as a (now empty) aggregate build target for backwards compatibility: the xt/gdt Python suites it
+  # used to drive are registered as CTest tests above and are run via `ctest`, not as standalone build targets.
   if(NOT TARGET test_python)
     add_custom_target(test_python)
   endif(NOT TARGET test_python)
-
-  add_dependencies(test_python xt_test_python gdt_test_python)
 endmacro(DXT_ADD_PYTHON_TESTS)

--- a/python/xt/pyproject.toml
+++ b/python/xt/pyproject.toml
@@ -43,6 +43,11 @@ infrastructure = [
     "pytest",
     "pytest-cov",
     "pytest-regressions",
+    # coverage processors driven by the CMake coverage_python / coverage_cpp targets:
+    # coverage.py combines the per-suite pytest data files into one XML, gcovr turns the
+    # C++ gcov data into Cobertura XML (see cmake/modules/DuneXTTesting.cmake).
+    "coverage",
+    "gcovr",
     "cmake_format==0.4.1",
     "codecov",
     "yapf==0.32",


### PR DESCRIPTION
Recreates the **"wire coverage/pytest through CMake"** half of #246, deliberately **leaving out the uv-interpreter (venv) handling** (the `.python-version` pin, the `DXT_USE_UV_PYTHON` / `uv python find|install` block in `CMakeLists.txt`, and the `-DDXT_USE_UV_PYTHON=OFF` opt-out in `.ci/build-wheels.sh`). The r7i runner changes from #246 are already on `main` (merged via #251) and are not touched here.

## What & why

Make `ctest` the single entry point for both the C++ and the Python test suites, and move the coverage post-processing (gcovr + coverage.py) out of the CI workflow into CMake targets so it is reproducible locally.

## Changes

- **`cmake/modules/DuneXTTesting.cmake`** — `DXT_ADD_PYTHON_TESTS` now registers `xt_test_python` / `gdt_test_python` as **CTest tests** (label `dune-gdt-test`, picked up by the existing test presets) instead of standalone build targets, so `ctest` runs the Python suites. Adds `coverage_cpp`, `coverage_python` and an aggregate `coverage` target that port the gcovr + coverage.py processing out of CI (tooling pulled on the fly via `uv run --with`). `test_python` is kept as an empty backwards-compat aggregate.
  - Unlike #246 these stay on the bare `uv` command and the default `find_package(Python)` interpreter (no `${UV_EXECUTABLE}` / forced `Python_EXECUTABLE`), since the uv-interpreter sourcing is intentionally omitted — matching how `main` already invokes the suites.
- **`.github/workflows/non_docker_build.yml`** — build `bindings` before `ctest` (CTest doesn't build deps), run pytest via `xvfb-run -a ctest … --parallel ${ctest_parallel}` (drops the standalone pytest build-target step), remove the `pipx install gcovr` step, and collect coverage via `cmake --build --target coverage_cpp|coverage_python` (uploading `build/<preset>/coverage-*.xml`).
- **`python/xt/pyproject.toml`** — add `coverage` and `gcovr` to the `infrastructure` dev-tooling group.

## Verification

- `cmake-format` (v0.6.13, repo `.cmake_format.py`) and `cmake-lint` pass on `DuneXTTesting.cmake`; workflow YAML parses cleanly.
- No leftover `pipx install gcovr`, standalone `xt_test_python gdt_test_python` build-target invocation, or stale gcovr/coverage shell steps; Codecov `files:` point at `build/<preset>/coverage-*.xml`.
- CI exercises both matrix legs (`debug`, `release_coverage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMBikVzLjPjMbKGcnwgpY1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized the test execution flow to build Python bindings first, then run both C++ and Python (pytest) suites via the unified test runner.
  * Standardized Python test registration under the testing framework and improved coverage-aware execution.

* **Chores**
  * Integrated coverage collection/reporting into the build system with dedicated C++ and Python coverage outputs and combined reporting.
  * Added coverage tooling to the project’s infrastructure extras to support the new coverage workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->