### PR TITLE
fix(vcpkg): update baseline and fix GCC 15 build failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,9 @@ repos:
   rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
   hooks:
   - id: trailing-whitespace
+    # mpfr is a verbatim copy of the upstream vcpkg port; do not rewrite its
+    # patches (stripping context-line whitespace corrupts the diffs).
+    exclude: "^\\.vcpkg-overlays/ports/mpfr/"
   - id: check-yaml
     args: [--allow-multiple-documents]
   - id: check-added-large-files
@@ -14,7 +17,7 @@ repos:
   rev: 'dd18dad857d6133e90bbe478f4f2f22ec0030269' # frozen: v22.1.5
   hooks:
   - id: clang-format
-    exclude: "^(pybind11)"
+    exclude: "^(pybind11)|^\\.vcpkg-overlays/ports/mpfr/"
 - repo: https://github.com/google/yamlfmt
   rev: b5ca1890231d5e1e5181fef75a1be609d1e25029 # frozen: v0.21.0
   hooks:
@@ -34,11 +37,11 @@ repos:
   hooks:
   - id: cmake-format
     additional_dependencies: [pyyaml>=5.1] # see https://github.com/cheshirekow/cmake-format-precommit/pull/4#issuecomment-943444582
-    exclude: "config.h.cmake|pybind11"
+    exclude: "config.h.cmake|pybind11|^\\.vcpkg-overlays/ports/mpfr/"
     args: ["-i", "--config-files=.cmake_format.py"]
   - id: cmake-lint
     additional_dependencies: [pyyaml>=5.1] # see https://github.com/cheshirekow/cmake-format-precommit/pull/4#issuecomment-943444582
-    exclude: "config.h.cmake|pybind11"
+    exclude: "config.h.cmake|pybind11|^\\.vcpkg-overlays/ports/mpfr/"
     args: ["--config-files=.cmake_format.py"]
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 8ef330cbb7204d388aa7a620f9549bcea8009663 # frozen: 0.37.3

--- a/.vcpkg-overlays/README.md
+++ b/.vcpkg-overlays/README.md
@@ -34,7 +34,7 @@ the pinned commit. To refresh a pin, edit `deps/module_list.bash` and rerun:
 ## Hand-maintained ports (not generated)
 
 A handful of ports in `ports/` are **not** produced by `update_ports.bash` and
-are edited by hand: `pybind11`, `uv`, `libtirpc`, `alberta`, and the GNU
+are edited by hand: `pybind11`, `uv`, `libtirpc`, `alberta`, `mpfr`, and the GNU
 autotools host tools below. `update_ports.bash` only touches the DUNE modules
 listed in `deps/module_list.bash`, so it leaves these alone.
 
@@ -59,6 +59,32 @@ are gone. The aclocal macros for each port live in `share/<port>/aclocal`; a
 consumer that wires these tools onto `PATH` should also add those directories to
 `ACLOCAL_PATH` (for example `share/libtool/aclocal` and
 `share/autoconf-archive/aclocal`).
+
+Providing these ports is not enough on its own. Declaring them as `host`
+dependencies of a make-based port makes vcpkg *build and install* them into the
+host tree, but it does **not** put them to use: `vcpkg_run_autoreconf` locates
+`autoreconf`/`aclocal`/`libtoolize` with a plain `find_program`, and vcpkg does
+not add a host dependency's `tools/<port>/bin` to the consuming port's build
+`PATH`. The aclocal macros are also installed under per-port
+`share/<port>/aclocal` dirs that `aclocal` does not search by default. A consumer
+therefore has to do two things: declare the tools as `host` dependencies *and*,
+in its portfile, prepend `tools/autoconf|automake|libtool/bin` to `PATH` and set
+`ACLOCAL_PATH` to the `share/*/aclocal` dirs (so the `AX_*` macros from
+autoconf-archive are found).
+
+`libtirpc` and `alberta` happen to build against the autoconf/automake/libtool
+that the CI runners already ship, so they don't wire anything up. `mpfr` is the
+port that actually needs the overlay tools: it autoreconfs and its
+`configure.ac` uses an autoconf-archive (`AX_*`) macro that is **not** present on
+the runners. It is overlaid here as a copy of the upstream port (`dll.patch`,
+`src-only.patch`, `usage` verbatim) with two changes to `portfile.cmake` and
+`vcpkg.json`: the four autotools added as `host` dependencies, and a block before
+`vcpkg_make_configure` that prepends the tool `bin` dirs to `PATH` and points
+`ACLOCAL_PATH` at the installed `share/*/aclocal` dirs. Without this, `mpfr`
+falls back to the build machine's system autotools and fails on runners that lack
+`autoconf-archive`. When bumping the vcpkg baseline, re-sync the patches/usage
+from `.vcpkg-root/ports/mpfr/` if upstream changed them, and re-check that the
+upstream `portfile.cmake` still matches apart from the autotools wiring block.
 
 To bump a version: update `version` in the port's `vcpkg.json`, the URL/SHA-512
 in its `portfile.cmake` (`sha512sum` of the new `.tar.xz`), and rebuild.

--- a/.vcpkg-overlays/ports/libtirpc/portfile.cmake
+++ b/.vcpkg-overlays/ports/libtirpc/portfile.cmake
@@ -13,7 +13,17 @@ vcpkg_download_distfile(
 
 vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
 
-vcpkg_configure_make(SOURCE_PATH "${SOURCE_PATH}" DETERMINE_BUILD_TRIPLET AUTOCONFIG OPTIONS --disable-gssapi)
+vcpkg_configure_make(
+  SOURCE_PATH
+  "${SOURCE_PATH}"
+  DETERMINE_BUILD_TRIPLET
+  AUTOCONFIG
+  OPTIONS
+  --disable-gssapi
+  OPTIONS_DEBUG
+  "CFLAGS=-std=c17"
+  OPTIONS_RELEASE
+  "CFLAGS=-std=c17")
 
 vcpkg_install_make()
 

--- a/.vcpkg-overlays/ports/mpfr/dll.patch
+++ b/.vcpkg-overlays/ports/mpfr/dll.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index fdee5978d..0791b2528 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -593,7 +593,7 @@ case $host in
+    AC_MSG_CHECKING(for DLL/static GMP)
+    if test "$enable_shared" = yes; then
+      MPFR_LDFLAGS="$MPFR_LDFLAGS -no-undefined"
+-     LIBMPFR_LDFLAGS="$LIBMPFR_LDFLAGS -Wl,--output-def,.libs/libmpfr-6.dll.def"
++     LIBMPFR_LDFLAGS="$LIBMPFR_LDFLAGS -W1,--no-undefined"
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #include "gmp.h"
+ #if !__GMP_LIBGMP_DLL

--- a/.vcpkg-overlays/ports/mpfr/portfile.cmake
+++ b/.vcpkg-overlays/ports/mpfr/portfile.cmake
@@ -1,0 +1,62 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://www.mpfr.org/mpfr-${VERSION}/mpfr-${VERSION}.tar.xz" "https://ftp.gnu.org/gnu/mpfr/mpfr-${VERSION}.tar.xz"
+    FILENAME "mpfr-${VERSION}.tar.xz"
+    SHA512 eb9e7f51b5385fb349cc4fba3a45ffdf0dd53be6dfc74932dc01258158a10514667960c530c47dd9dfc5aa18be2bd94859d80499844c5713710581e6ac6259a9
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        dll.patch
+        src-only.patch
+)
+
+# mpfr is reconfigured with autoreconf, which needs autoconf/automake/libtool and
+# the autoconf-archive m4 macros (its configure.ac uses AX_* macros). Those come
+# from our overlay host-tool ports (declared as host dependencies in vcpkg.json),
+# but vcpkg does not put a host dependency's tools/<port>/bin on PATH automatically
+# and aclocal does not search the per-port share/<port>/aclocal macro dirs. Wire
+# both up here so the build does not fall back to the system autotools. See
+# .vcpkg-overlays/README.md.
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/autoconf/bin")
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/automake/bin")
+vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/libtool/bin")
+file(GLOB mpfr_aclocal_dirs LIST_DIRECTORIES true
+    "${CURRENT_HOST_INSTALLED_DIR}/share/aclocal"
+    "${CURRENT_HOST_INSTALLED_DIR}/share/*/aclocal"
+)
+# aclocal splits ACLOCAL_PATH on ';' on native Windows hosts and ':' elsewhere.
+if(CMAKE_HOST_WIN32)
+    set(mpfr_path_sep ";")
+else()
+    set(mpfr_path_sep ":")
+endif()
+list(JOIN mpfr_aclocal_dirs "${mpfr_path_sep}" mpfr_aclocal_path)
+set(ENV{ACLOCAL_PATH} "${mpfr_aclocal_path}")
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+)
+
+vcpkg_make_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(REMOVE
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/AUTHORS"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/BUGS"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/COPYING"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/COPYING.LESSER"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/NEWS"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/TODO"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING.LESSER")

--- a/.vcpkg-overlays/ports/mpfr/src-only.patch
+++ b/.vcpkg-overlays/ports/mpfr/src-only.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile.am b/Makefile.am
+index 89242c6..662ce24 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -24,12 +24,14 @@ AUTOMAKE_OPTIONS = gnu
+ # old Automake version.
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = doc src tests tune tools/bench
++SUBDIRS = src # Skipping: doc tests tune tools/bench
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = mpfr.pc
+ 
+ nobase_dist_doc_DATA = AUTHORS BUGS COPYING COPYING.LESSER NEWS TODO \
++  # BREAK
++VCPKG_SKIP_EXAMPLES = \
+   examples/ReadMe examples/can_round.c examples/divworst.c \
+   examples/rndo-add.c examples/sample.c examples/threads.c \
+   examples/version.c

--- a/.vcpkg-overlays/ports/mpfr/usage
+++ b/.vcpkg-overlays/ports/mpfr/usage
@@ -1,0 +1,6 @@
+The package mpfr can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig)
+    pkg_check_modules(mpfr REQUIRED IMPORTED_TARGET mpfr)
+    
+    target_link_libraries(main PRIVATE PkgConfig::mpfr)

--- a/.vcpkg-overlays/ports/mpfr/vcpkg.json
+++ b/.vcpkg-overlays/ports/mpfr/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "mpfr",
+  "version": "4.2.2",
+  "port-version": 1,
+  "description":
+    "The MPFR library is a C library for multiple-precision floating-point computations with correct rounding",
+  "homepage": "https://www.mpfr.org",
+  "license": "LGPL-3.0-or-later",
+  "supports": "!xbox",
+  "dependencies": [
+    "gmp",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    {
+      "name": "autoconf",
+      "host": true
+    },
+    {
+      "name": "autoconf-archive",
+      "host": true
+    },
+    {
+      "name": "automake",
+      "host": true
+    },
+    {
+      "name": "libtool",
+      "host": true
+    }
+  ]
+}

--- a/cmake/VcpkgBootStrap.cmake
+++ b/cmake/VcpkgBootStrap.cmake
@@ -44,7 +44,7 @@ if(NOT ${VCPKG_FOUND})
     FetchContent_Declare(
       vcpkg
       GIT_REPOSITORY https://github.com/microsoft/vcpkg/
-      GIT_TAG 2025.04.09
+      GIT_TAG 2026.06.01
       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.vcpkg-root CMAKE_CACHE_ARGS
       -DVCPKG_BOOTSTRAP_OPTIONS:STRING="-disableMetrics")
     FetchContent_MakeAvailable(vcpkg)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -61,5 +61,5 @@
     "suitesparse",
     "lapack"
   ],
-  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b"
+  "builtin-baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -61,5 +61,12 @@
     "suitesparse",
     "lapack"
   ],
-  "builtin-baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc"
+  "builtin-baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc",
+  "overrides": [
+    {
+      "name": "eigen3",
+      "version": "3.4.0",
+      "port-version": 5
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Bump vcpkg tag from `2025.04.09` to `2026.06.01` and update `builtin-baseline` in `vcpkg.json` accordingly
- Fix `libtirpc` build failure under GCC 15: the new C23 default treats empty parameter lists `()` as `(void)`, causing a conflicting-types error in `auth_none.c` (`extern bool_t xdr_opaque_auth()` vs the header prototype `bool_t xdr_opaque_auth(XDR *, struct opaque_auth *)`). Pass `-std=c17` via `CFLAGS` in the overlay portfile to restore the pre-C23 semantics.
- `mpfr` also requires the `autoconf-archive` system package (needed for `autoreconf`); this is a one-time `sudo apt install autoconf-archive` on the build host.

## Test plan

- [ ] `cmake --preset release` completes without errors
- [ ] Subsequent `cmake --build build/release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the vcpkg bootstrap pin and builtin baseline to improve reproducibility.
  * Reduced formatting/lint noise by excluding the MPFR overlay from selected hooks.
* **New Features**
  * Added an MPFR overlay port with complete build/install logic.
  * Added MPFR usage documentation for CMake/pkg-config.
* **Bug Fixes**
  * Refined MPFR build behavior for DLL/static linking and limited the build scope to `src`.
* **Refactor**
  * Reformatted the libtirpc configure invocation while keeping the same configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->