### PR TITLE
Add vcpkg overlay ports for current GNU autotools (autoconf, automake, libtool, autoconf-archive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ dependencies.m4
 *Doxyfile.in
 install-sh
 libtool
+# but keep the libtool vcpkg overlay port (the bare "libtool" rule above is for the
+# autotools-generated script, not this hand-maintained port directory)
+!/.vcpkg-overlays/ports/libtool/
 ltmain.sh
 missing
 stamp-h1

--- a/.vcpkg-overlays/README.md
+++ b/.vcpkg-overlays/README.md
@@ -31,6 +31,43 @@ the pinned commit. To refresh a pin, edit `deps/module_list.bash` and rerun:
 > case edit `deps/module_list.bash` and the affected `portfile.cmake` together by
 > hand, keeping them in sync.
 
+## Hand-maintained ports (not generated)
+
+A handful of ports in `ports/` are **not** produced by `update_ports.bash` and
+are edited by hand: `pybind11`, `uv`, `libtirpc`, `alberta`, and the GNU
+autotools host tools below. `update_ports.bash` only touches the DUNE modules
+listed in `deps/module_list.bash`, so it leaves these alone.
+
+### GNU autotools host tools
+
+`libtirpc` and `alberta` build with `vcpkg_configure_make`, which needs the GNU
+autotools. To avoid depending on whatever happens to be installed on the build
+machine, the following ports pin current upstream releases (downloaded from
+`ftp.gnu.org` and verified by SHA-512):
+
+| Port | Version | Notes |
+|------|---------|-------|
+| autoconf | 2.73 | `autoconf`, `autoreconf`, `autom4te`, ... under `tools/autoconf/bin` |
+| automake | 1.18.1 | `automake`/`aclocal`; depends on `autoconf` (host) |
+| libtool | 2.5.4 | `libtool`/`libtoolize` plus the `libltdl` loader library + `ltdl.h` |
+| autoconf-archive | 2024.10.16 | data-only: ~580 reusable m4 macros under `share/autoconf-archive/aclocal` |
+
+`vcpkg_configure_make` bakes the persistent `CURRENT_INSTALLED_DIR` into the
+installed scripts as their prefix and installs the executables under
+`tools/<port>/bin`, so the tools remain usable after the temporary build trees
+are gone. The aclocal macros for each port live in `share/<port>/aclocal`; a
+consumer that wires these tools onto `PATH` should also add those directories to
+`ACLOCAL_PATH` (for example `share/libtool/aclocal` and
+`share/autoconf-archive/aclocal`).
+
+To bump a version: update `version` in the port's `vcpkg.json`, the URL/SHA-512
+in its `portfile.cmake` (`sha512sum` of the new `.tar.xz`), and rebuild.
+
+> Note: the bare `libtool` entry in the repo's top-level `.gitignore` (an
+> autotools-generated script name) also matches `ports/libtool/`, so that path is
+> re-included there with a `!` negation. Keep that negation when editing
+> `.gitignore`.
+
 ## Current pins (DUNE 2.10)
 
 All core/staging modules currently track the **`releases/2.10` maintenance

--- a/.vcpkg-overlays/ports/autoconf-archive/portfile.cmake
+++ b/.vcpkg-overlays/ports/autoconf-archive/portfile.cmake
@@ -1,0 +1,26 @@
+# cmake-lint: disable=C0301
+
+# autoconf-archive is data-only: it installs a large collection of reusable m4 macros (consumed by aclocal/autoconf at
+# configure time) under share/${PORT}/aclocal and ships no binaries or headers, hence EMPTY_INCLUDE_FOLDER.
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_download_distfile(
+  ARCHIVE
+  URLS
+  "https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-${VERSION}.tar.xz"
+  FILENAME
+  "autoconf-archive-${VERSION}.tar.xz"
+  SHA512
+  91140cb666447f12a1d39d7d42f5fe6ea3601bb586f466381c9e949087aafa06aed8d061a4f5d020a3d234eb710e4bb47cd25380bcffd8c423fa1a7af05e988b
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+
+vcpkg_configure_make(SOURCE_PATH "${SOURCE_PATH}" DETERMINE_BUILD_TRIPLET)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/.vcpkg-overlays/ports/autoconf-archive/vcpkg.json
+++ b/.vcpkg-overlays/ports/autoconf-archive/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "autoconf-archive",
+  "version": "2024.10.16",
+  "description":
+    "GNU Autoconf Archive, a collection of more than 500 reusable autoconf macros",
+  "homepage": "https://www.gnu.org/software/autoconf-archive/",
+  "license": "GPL-3.0-or-later",
+  "supports": "!windows",
+  "dependencies": []
+}

--- a/.vcpkg-overlays/ports/autoconf/portfile.cmake
+++ b/.vcpkg-overlays/ports/autoconf/portfile.cmake
@@ -1,0 +1,29 @@
+# cmake-lint: disable=C0301
+
+# autoconf is a host build tool (perl/m4 scripts plus a tree of m4 macros). vcpkg_configure_make bakes the persistent
+# CURRENT_INSTALLED_DIR into the installed scripts as their prefix and places the executables under tools/${PORT}/bin,
+# so the tool keeps working after the temporary build/package trees are gone. The baked absolute paths are expected,
+# hence SKIP_ABSOLUTE_PATHS_CHECK; autoconf ships no headers, hence EMPTY_INCLUDE_FOLDER.
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
+
+vcpkg_download_distfile(
+  ARCHIVE
+  URLS
+  "https://ftp.gnu.org/gnu/autoconf/autoconf-${VERSION}.tar.xz"
+  FILENAME
+  "autoconf-${VERSION}.tar.xz"
+  SHA512
+  be051d542f9bd93752eccbdc9b1f3cf1fa4069a153ef34edd5303bfdf162e24d56e33e70df1b978cebb8d1139a82417bb8299cfe6c38cff8613040a829cc624f
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+
+vcpkg_configure_make(SOURCE_PATH "${SOURCE_PATH}" DETERMINE_BUILD_TRIPLET)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/.vcpkg-overlays/ports/autoconf/vcpkg.json
+++ b/.vcpkg-overlays/ports/autoconf/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "autoconf",
+  "version": "2.73",
+  "description":
+    "GNU Autoconf, a tool for producing configure scripts for building, installing and packaging software",
+  "homepage": "https://www.gnu.org/software/autoconf/",
+  "license": "GPL-3.0-or-later",
+  "supports": "!windows",
+  "dependencies": []
+}

--- a/.vcpkg-overlays/ports/automake/portfile.cmake
+++ b/.vcpkg-overlays/ports/automake/portfile.cmake
@@ -1,0 +1,29 @@
+# cmake-lint: disable=C0301
+
+# automake is a host build tool whose aclocal/automake scripts drive autoconf at runtime (hence the autoconf host
+# dependency). As with autoconf, vcpkg_configure_make bakes the persistent CURRENT_INSTALLED_DIR as the prefix and
+# installs the executables under tools/${PORT}/bin, so the baked absolute paths are expected (SKIP_ABSOLUTE_PATHS_CHECK)
+# and there are no headers (EMPTY_INCLUDE_FOLDER).
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
+
+vcpkg_download_distfile(
+  ARCHIVE
+  URLS
+  "https://ftp.gnu.org/gnu/automake/automake-${VERSION}.tar.xz"
+  FILENAME
+  "automake-${VERSION}.tar.xz"
+  SHA512
+  8baa16831416a953a743f4e3c0f55cea5ebefe0f5a7a0e390581981d4461d02dc9038415124e974b2ec390c40daaa241802cd7d42c6fafb793f87cf355db2a61
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+
+vcpkg_configure_make(SOURCE_PATH "${SOURCE_PATH}" DETERMINE_BUILD_TRIPLET)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/.vcpkg-overlays/ports/automake/vcpkg.json
+++ b/.vcpkg-overlays/ports/automake/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "automake",
+  "version": "1.18.1",
+  "description":
+    "GNU Automake, a tool for automatically generating Makefile.in files compliant with the GNU Coding Standards",
+  "homepage": "https://www.gnu.org/software/automake/",
+  "license": "GPL-2.0-or-later",
+  "supports": "!windows",
+  "dependencies": [
+    {
+      "name": "autoconf",
+      "host": true
+    }
+  ]
+}

--- a/.vcpkg-overlays/ports/libtool/portfile.cmake
+++ b/.vcpkg-overlays/ports/libtool/portfile.cmake
@@ -1,0 +1,31 @@
+# cmake-lint: disable=C0301
+
+# libtool provides the libtool/libtoolize host scripts (used together with autoconf/automake, hence the host
+# dependencies) plus the libltdl dynamic-module-loader library and its ltdl.h header. vcpkg_configure_make bakes the
+# persistent CURRENT_INSTALLED_DIR as the prefix and installs the scripts under tools/${PORT}/bin, so the baked absolute
+# paths in those scripts are expected (SKIP_ABSOLUTE_PATHS_CHECK).
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_POLICY_SKIP_ABSOLUTE_PATHS_CHECK enabled)
+
+vcpkg_download_distfile(
+  ARCHIVE
+  URLS
+  "https://ftp.gnu.org/gnu/libtool/libtool-${VERSION}.tar.xz"
+  FILENAME
+  "libtool-${VERSION}.tar.xz"
+  SHA512
+  eed207094bcc444f4bfbb13710e395e062e3f1d312ca8b186ab0cbd22dc92ddef176a0b3ecd43e02676e37bd9e328791c59a38ef15846d4eae15da4f20315724
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+
+# --enable-ltdl-install installs the libltdl loader library and ltdl.h alongside the libtool scripts.
+vcpkg_configure_make(SOURCE_PATH "${SOURCE_PATH}" DETERMINE_BUILD_TRIPLET OPTIONS --enable-ltdl-install)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/.vcpkg-overlays/ports/libtool/vcpkg.json
+++ b/.vcpkg-overlays/ports/libtool/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libtool",
+  "version": "2.5.4",
+  "description":
+    "GNU Libtool, a generic library support script that hides the complexity of using shared libraries behind a consistent interface; also provides the libltdl dynamic module loader",
+  "homepage": "https://www.gnu.org/software/libtool/",
+  "license": "GPL-2.0-or-later",
+  "supports": "!windows",
+  "dependencies": [
+    {
+      "name": "autoconf",
+      "host": true
+    },
+    {
+      "name": "automake",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds hand-maintained vcpkg overlay ports pinning **current** upstream releases of the GNU autotools that the make-based ports (`libtirpc`, `alberta`) rely on through `vcpkg_configure_make`. This removes the dependency on whatever autotools happen to be installed on the build machine.

| Port | Version (released) | Notes |
|------|--------------------|-------|
| `autoconf` | 2.73 (2026-03-20) | `autoconf`, `autoreconf`, `autom4te`, … under `tools/autoconf/bin` |
| `automake` | 1.18.1 (2025-06-26) | `automake`/`aclocal`; depends on `autoconf` (host) |
| `libtool` | 2.5.4 (2024-11-20) | `libtool`/`libtoolize` plus the `libltdl` loader library + `ltdl.h` |
| `autoconf-archive` | 2024.10.16 | data-only: ~580 reusable m4 macros under `share/autoconf-archive/aclocal` |

Each is built with `vcpkg_configure_make`/`vcpkg_install_make`, which bakes the persistent `CURRENT_INSTALLED_DIR` as the prefix and installs the executables under `tools/<port>/bin`, so the tools remain usable after the temporary build trees are gone. Sources are fetched from `ftp.gnu.org` and verified by SHA-512.

## Notes

- The top-level `.gitignore` has a bare `libtool` rule (for the autotools-*generated* script). It also matched `ports/libtool/`, so that path is re-included with a `!` negation.
- `.vcpkg-overlays/README.md` gains a section documenting these ports (and the other non-generated overlay ports), since `update_ports.bash` only manages the DUNE modules in `deps/module_list.bash`.

## Testing (local)

Built the pinned vcpkg (`2025.04.09`) and installed all four ports via the overlay (`vcpkg install autoconf autoconf-archive automake libtool --triplet=x64-linux`) — all build and install cleanly, including a from-scratch rebuild with binary caching disabled.

Verified the installed, relocatable tools run and locate their data from the install tree:

```
autoconf (GNU Autoconf) 2.73
automake (GNU automake) 1.18.1
aclocal (GNU automake) 1.18.1
libtool (GNU libtool) 2.5.4
libtoolize (GNU libtool) 2.5.4
```

End-to-end checks:
- A `LT_INIT`-based project ran through `autoreconf -fi` + `./configure` + `make` and produced a real `libdemo.so`/`.a` via the pinned libtool.
- An `AX_CXX_COMPILE_STDCXX([17])`-based project ran through `autoreconf -fi` + `./configure` cleanly, confirming `aclocal` picks up the autoconf-archive macros.

Formatting/lint: `cmake-format` (idempotent) and `cmake-lint` pass on all portfiles with `.cmake_format.py`; manifests follow the existing overlay-port style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UW5v9KGNHeketGfBySFKSQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UW5v9KGNHeketGfBySFKSQ)_