### PR TITLE
cmake: silence configure-time warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ add_pylicense()
 dxt_exclude_from_headercheck(${CMAKE_SOURCE_DIR}/.vcpkg-root)
 dxt_exclude_from_headercheck(${CMAKE_BINARY_DIR}/vcpkg_installed)
 
-finalize_dune_project(GENERATE_CONFIG_H_CMAKE)
+finalize_dune_project()
 # patch config.h to remove warnings about unused HAVE_GRIDTYPE
 execute_process(
   COMMAND sed -i -e "s,^\\([ ]*\\)\#if HAVE_GRIDTYPE$,\\1\#if defined(HAVE_GRIDTYPE) \\&\\& HAVE_GRIDTYPE,g"

--- a/cmake/modules/XtTooling.cmake
+++ b/cmake/modules/XtTooling.cmake
@@ -106,7 +106,7 @@ macro(ADD_TIDY)
       COMMENT "Running clang-tidy -fix for all files, this will take a very long time..."
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
   else()
-    message(WARNING "not adding tidy target because clang-tidy is missing or"
+    message(WARNING "not adding tidy target because clang-tidy is missing or "
                     "wrong version: ${ClangTidy_EXECUTABLE} ${ClangTidy_VERSION}")
   endif(ClangTidy_FOUND)
 endmacro()

--- a/dune/gdt/test/CMakeLists.txt
+++ b/dune/gdt/test/CMakeLists.txt
@@ -11,20 +11,20 @@
 #   Tobias Leibner  (2016 - 2018
 # ~~~
 
+# Only subdirs that contain test sources (*.cc/*.tpl) are listed here. The header-only eocstudies directories
+# (instationary-eocstudies, stationary-eocstudies) provide base.hh helpers included by tests in other subdirs, and
+# projections/prolongations currently hold no tests; listing any of them would trigger add_subdir_tests author warnings
+# about missing sources.
 set(GDT_TEST_SUBDIRS
     burgers
     discretefunction
-    instationary-eocstudies
     integrands
     interpolations
     inviscid-compressible-flow
     linear-transport
     misc
     operators
-    projections
-    prolongations
     spaces
-    stationary-eocstudies
     stationary-heat-equation
     stokes)
 


### PR DESCRIPTION
## Summary

Cleans up CMake configure-time warnings observed during `cmake` setup.

### `add_subdir_test(...), but no sources were found` (×4)

`GDT_TEST_SUBDIRS` listed four directories that contain no test sources (`*.cc`/`*.tpl`), so `add_subdir_tests` emitted an author warning for each:

- `instationary-eocstudies` / `stationary-eocstudies` — header-only; their `base.hh` (and `diffusion-ipdg.hh` / `hyperbolic-nonconforming.hh`) helpers are `#include`d by tests in other subdirs (`burgers`, `linear-transport`, `inviscid-compressible-flow`, `stationary-heat-equation`). The headers stay in the source tree and remain available; only the no-op test registration is removed.
- `projections` / `prolongations` — empty directories with no tracked files.

These are dropped from `GDT_TEST_SUBDIRS` (with an explanatory comment). No tests are lost since none of these directories produced any.

### `Passing arguments to finalize_dune_project is no longer needed`

Dropped the deprecated `GENERATE_CONFIG_H_CMAKE` argument from `finalize_dune_project()` — `config.h` generation is now automatic in current Dune, and passing the argument triggered a deprecation warning. The subsequent `config.h` patching step is unaffected.

### Minor

Fixed a missing space in the clang-tidy "missing or wrong version" warning text (`missing orwrong` → `missing or wrong`).

## Note

The `Could NOT find ClangTidy` / "not adding tidy target" warning is environmental (no `clang-tidy >= 12` installed in the configure environment) and is handled gracefully — nothing to change in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkDQfqkc7rGip3azLpEQpp)_