### PR TITLE
fix(mpfr): fix linker flag typo -W1 -> -Wl in dll.patch

### DIFF
--- a/.vcpkg-overlays/ports/mpfr/dll.patch
+++ b/.vcpkg-overlays/ports/mpfr/dll.patch
@@ -7,7 +7,7 @@ index fdee5978d..0791b2528 100644
     if test "$enable_shared" = yes; then
       MPFR_LDFLAGS="$MPFR_LDFLAGS -no-undefined"
 -     LIBMPFR_LDFLAGS="$LIBMPFR_LDFLAGS -Wl,--output-def,.libs/libmpfr-6.dll.def"
-+     LIBMPFR_LDFLAGS="$LIBMPFR_LDFLAGS -W1,--no-undefined"
++     LIBMPFR_LDFLAGS="$LIBMPFR_LDFLAGS -Wl,--no-undefined"
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
  #include "gmp.h"
  #if !__GMP_LIBGMP_DLL


### PR DESCRIPTION
Fix typo in `.vcpkg-overlays/ports/mpfr/dll.patch` line 10: `-W1,--no-undefined` (digit `1`) → `-Wl,--no-undefined` (letter `l`). The malformed flag was not being passed to the linker correctly.

Addresses review comment https://github.com/dune-gdt/dune-gdt/pull/268#discussion_r3448928448

---
_Generated by [Claude Code](https://claude.ai/code/session_0195iQBHbKgix6MnKHi1LeLv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration for the MPFR library to adjust how linker options are applied for DLL/static builds, improving compatibility and ensuring consistent “no undefined symbols” behavior during linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->