### PR TITLE
[xt,gdt] fix gcc warnings and add test coverage

### DIFF
--- a/dune/gdt/local/dof-vector.hh
+++ b/dune/gdt/local/dof-vector.hh
@@ -98,6 +98,7 @@ class ConstLocalDofVector
   using BaseType = XT::LA::VectorInterface<Traits>;
 
 public:
+  using typename BaseType::derived_type;
   using typename BaseType::ScalarType;
   using VectorType = Vector;
   using MapperType = MapperInterface<GridView>;
@@ -139,6 +140,25 @@ public:
   void resize(const size_t new_size)
   {
     DUNE_THROW_IF(this->size() != new_size, Exceptions::dof_vector_error, "this does not make sense!");
+  }
+
+  // The following container arithmetic is required by ContainerInterface, but does not make sense for a (local) view
+  // onto a global vector. We provide explicit overrides that throw (in line with add_to_entry/set_entry below): without
+  // them the CRTP forwarding in ContainerInterface would recurse infinitely in release (NDEBUG) builds.
+  derived_type copy() const
+  {
+    DUNE_THROW(Exceptions::dof_vector_error, "a (Const)LocalDofVector cannot be copied as a standalone container!");
+    return this->as_imp(); // unreachable, only here to satisfy the return type
+  }
+
+  void scal(const ScalarType& /*alpha*/)
+  {
+    DUNE_THROW(Exceptions::dof_vector_error, "a (Const)LocalDofVector is not mutable as a standalone container!");
+  }
+
+  void axpy(const ScalarType& /*alpha*/, const derived_type& /*xx*/)
+  {
+    DUNE_THROW(Exceptions::dof_vector_error, "a (Const)LocalDofVector is not mutable as a standalone container!");
   }
 
   void add_to_entry(const size_t /*ii*/, const ScalarType& /*value*/)

--- a/dune/gdt/test/discretefunction/default.cc
+++ b/dune/gdt/test/discretefunction/default.cc
@@ -18,6 +18,7 @@
 #include <dune/xt/la/container/istl.hh>
 
 #include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/exceptions.hh>
 #include <dune/gdt/norms.hh>
 #include <dune/gdt/spaces/h1/continuous-lagrange.hh>
 
@@ -74,6 +75,35 @@ GTEST_TEST(discrete_function, addition_of_dofs)
   u += u;
   for (size_t ii = 0; ii < n; ++ii)
     EXPECT_DOUBLE_EQ(2., u.dofs().vector().get_entry(ii));
+}
+
+
+GTEST_TEST(discrete_function, local_dof_vector_view_arithmetic_throws)
+{
+  auto grid = XT::Grid::make_cube_grid<G>();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_continuous_lagrange_space(grid_view, 1);
+  const auto n = space.mapper().size();
+
+  auto u = make_discrete_function<V>(space);
+  for (size_t ii = 0; ii < n; ++ii)
+    u.dofs().vector().set_entry(ii, 1.);
+
+  auto local_dofs = u.dofs().localize();
+  const auto element = *grid_view.template begin<0>();
+  local_dofs.bind(element);
+
+  // localized read access works as expected
+  ASSERT_GT(local_dofs.size(), 0u);
+  for (size_t ii = 0; ii < local_dofs.size(); ++ii)
+    EXPECT_DOUBLE_EQ(1., local_dofs.get_entry(ii));
+
+  // The container arithmetic required by ContainerInterface does not make sense for a (local) view onto a global
+  // vector: it must throw instead of recursing infinitely (the latter happened in NDEBUG builds before the explicit
+  // copy/scal/axpy overrides were added to ConstLocalDofVector).
+  EXPECT_THROW(local_dofs.copy(), Exceptions::dof_vector_error);
+  EXPECT_THROW(local_dofs.scal(2.), Exceptions::dof_vector_error);
+  EXPECT_THROW(local_dofs.axpy(2., local_dofs), Exceptions::dof_vector_error);
 }
 
 

--- a/dune/xt/functions/base/visualization.hh
+++ b/dune/xt/functions/base/visualization.hh
@@ -46,7 +46,6 @@ public:
   using RangeType = typename RangeTypeSelector<R, r, rC>::type;
 
   virtual ~VisualizerInterface() = default;
-  ;
 
   virtual int ncomps() const = 0;
 

--- a/dune/xt/test/functions/visualizer.cc
+++ b/dune/xt/test/functions/visualizer.cc
@@ -1,0 +1,86 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-xt developers
+
+#include <dune/xt/test/main.hxx> // <- Has to come first, includes the config.h!
+
+#include <cmath>
+
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+
+#include <dune/xt/functions/base/visualization.hh>
+
+using namespace Dune;
+using namespace Dune::XT::Functions;
+
+
+GTEST_TEST(visualizer, default_visualizer_vector_valued)
+{
+  static constexpr size_t r = 3;
+  DefaultVisualizer<r, 1> viz;
+  EXPECT_EQ(int(r), viz.ncomps());
+  FieldVector<double, r> val{1., 2., 3.};
+  for (int comp = 0; comp < int(r); ++comp)
+    EXPECT_DOUBLE_EQ(val[comp], viz.evaluate(comp, val));
+}
+
+GTEST_TEST(visualizer, default_visualizer_matrix_valued)
+{
+  static constexpr size_t r = 2;
+  static constexpr size_t rC = 2;
+  DefaultVisualizer<r, rC> viz;
+  // matrix-valued functions are visualized via their Frobenius norm in a single component
+  EXPECT_EQ(1, viz.ncomps());
+  FieldMatrix<double, r, rC> val{{3., 0.}, {0., 4.}};
+  EXPECT_DOUBLE_EQ(val.frobenius_norm(), viz.evaluate(0, val));
+  EXPECT_DOUBLE_EQ(5., viz.evaluate(0, val));
+}
+
+GTEST_TEST(visualizer, default_visualizer_helper)
+{
+  // the free function returns a usable reference to a static instance
+  static constexpr size_t r = 2;
+  const auto& viz = default_visualizer<r, 1>();
+  EXPECT_EQ(int(r), viz.ncomps());
+  FieldVector<double, r> val{7., 9.};
+  EXPECT_DOUBLE_EQ(7., viz.evaluate(0, val));
+  EXPECT_DOUBLE_EQ(9., viz.evaluate(1, val));
+}
+
+GTEST_TEST(visualizer, sum_visualizer)
+{
+  static constexpr size_t r = 4;
+  SumVisualizer<r> viz;
+  EXPECT_EQ(1, viz.ncomps());
+  FieldVector<double, r> val{1., 2., 3., 4.};
+  EXPECT_DOUBLE_EQ(10., viz.evaluate(0, val));
+}
+
+GTEST_TEST(visualizer, component_visualizer)
+{
+  static constexpr size_t r = 3;
+  const int component = 1;
+  ComponentVisualizer<r> viz(component);
+  EXPECT_EQ(1, viz.ncomps());
+  FieldVector<double, r> val{10., 20., 30.};
+  EXPECT_DOUBLE_EQ(20., viz.evaluate(0, val));
+  // it only ever plots a single component, so anything but comp == 0 is an error
+  EXPECT_THROW(viz.evaluate(1, val), Dune::InvalidStateException);
+}
+
+GTEST_TEST(visualizer, generic_visualizer)
+{
+  static constexpr size_t r = 3;
+  using RangeType = typename VisualizerInterface<r, 1>::RangeType;
+  GenericVisualizer<r> viz(2, [](const int comp, const RangeType& val) { return val[comp] * (comp + 1); });
+  EXPECT_EQ(2, viz.ncomps());
+  RangeType val{5., 6., 7.};
+  EXPECT_DOUBLE_EQ(5., viz.evaluate(0, val));
+  EXPECT_DOUBLE_EQ(12., viz.evaluate(1, val));
+}


### PR DESCRIPTION
## Summary

Addresses two recurring GCC warning classes seen in the `release_coverage` build and adds the test coverage they exposed.

### 1. `-Wpedantic` "extra ';'"
A stray semicolon after the defaulted destructor of `VisualizerInterface` in `dune/xt/functions/base/visualization.hh` was pulled into virtually every `dune/xt/functions/*` translation unit. Removed.

### 2. `-Winfinite-recursion` (genuine latent bug)
Reported for `ContainerInterface::copy()`/`scal()` whose `derived_type` is `Dune::GDT::ConstLocalDofVector`.

`ContainerInterface` (`dune/xt/la/container/container-interface.hh`) is a CRTP base whose `copy`/`scal`/`axpy` forward to `this->as_imp().<method>()`, expecting the derived class to override them. In debug builds `CHECK_CRTP` (see `dune/xt/common/crtp.hh`) catches a missing override at runtime; in `NDEBUG` (release/coverage) builds those macros are no-ops, so the forwarding call resolves back to the interface method itself → unbounded recursion.

`ConstLocalDofVector` (`dune/gdt/local/dof-vector.hh`) is a read-only view that intentionally implements the access methods but never overrode the container arithmetic (`LocalDofVector` inherits the gap). Fixed by adding explicit `copy`/`scal`/`axpy` overrides that throw `Exceptions::dof_vector_error`, matching the existing `add_to_entry`/`set_entry` idiom in the same class. The fix lives in the incomplete view rather than the interface, since the CRTP forwarding is correct for every complete container implementation.

### 3. Test coverage
- **`dune/xt/test/functions/visualizer.cc`** (new, auto-registered): unit tests for the previously untested `DefaultVisualizer`, `SumVisualizer`, `ComponentVisualizer`, and `GenericVisualizer` (`ncomps()` and `evaluate()` across scalar/vector/matrix cases), exercising the just-fixed `VisualizerInterface`.
- **`dune/gdt/test/discretefunction/default.cc`**: regression test confirming that `copy()`, `scal()`, and `axpy()` on a localized DoF view throw `dof_vector_error` (instead of recursing), while ordinary localized reads still work.

## Verification
A full build was not possible in the working environment (dune dependencies absent), so the changes were verified by review against existing patterns. Reviewers should confirm with a `release_coverage` build that the two warnings are gone and that `test_functions_visualizer` and `test_discretefunction_default` pass in a debug build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015hB2ta5qRSJDWsxNSqS8px)_