### PR TITLE
docs: use clangquill hierarchical namespace layout for the C++ API

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -586,6 +586,11 @@ jobs:
       # writes <out>/reports/<name>.err.log instead of aborting, and we fail the job
       # on those below. We intentionally do NOT pass sphinx -W, because intersphinx
       # inventory fetches emit network-dependent warnings unrelated to the docs build.
+      # Sphinx runs single-threaded (-j 1) on purpose: this job's runner is sized for
+      # it (4 vCPU / 16 GB, see runs-on labels above), and the clangquill C++ API now
+      # emits one page per class/function (group_by="namespace"), a far larger document
+      # set whose per-worker environment copies under "-j auto" OOM-killed the 16 GB box
+      # mid-write. Single-threaded keeps peak RAM bounded; the 60 min timeout is ample.
       env:
         DUNE_GDT_BENCHMARK_DATA: ${{ github.workspace }}/build/benchmark_data
       run: |
@@ -594,7 +599,7 @@ jobs:
         # --no-project: ignore the repo-root pyproject stub; run in the venv built above
         xvfb-run -a uv run --no-project \
           --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
-          python -m sphinx --keep-going -j auto -b html \
+          python -m sphinx --keep-going -j 1 -b html \
           "${GITHUB_WORKSPACE}/docs/source" "${OUT}"
         if compgen -G "${OUT}/reports/*.err.log" > /dev/null; then
           echo "::error::one or more executed documentation notebooks failed (see dumped reports below)"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,10 +149,12 @@ clangquill_include_dirs = ["../.."]
 clangquill_std = "c++17"
 clangquill_clang_resource_dir = _clang_resource_dir()
 clangquill_output_dir = "cpp_api"
-# Group at class granularity (clangquill >= 0.3.0): descend through namespaces so
-# a single huge dune::{gdt,xt} namespace becomes one page per member class. This
-# keeps Sphinx's C++ domain resolver fast and gives each class its own URL.
-clangquill_group_by = "class"
+# Build a browsable namespace hierarchy (clangquill >= 0.6.0): the index lists
+# only the top namespaces, each namespace hub links its sub-namespaces, classes,
+# per-name function pages, a lumped operators page, and grouped types/constants
+# pages. This replaces the single colossal flat index (one entry per class) with
+# a drill-down: all namespaces -> everything in a namespace -> per-symbol pages.
+clangquill_group_by = "namespace"
 # Emit every symbol clangquill extracts, including the (largely templated)
 # undocumented internals, so the C++ API pages cover all in-tree headers rather
 # than only those carrying a documentation comment.

--- a/python/xt/pyproject.toml
+++ b/python/xt/pyproject.toml
@@ -36,7 +36,8 @@ docs = [
     # clangquill only supports Python >=3.13. Mark it so that resolving the project's extras (which `uv run --group test`
     # does in project mode, see cmake/modules/DuneXTTesting.cmake) stays satisfiable on the Python 3.12 test builds; the
     # docs themselves are built on 3.13. Without the marker the test resolution fails with an unsatisfiable requirement.
-    'clangquill>=0.5.1; python_version >= "3.13"',
+    # >=0.6.0 for the hierarchical group_by="namespace" page layout (docs/source/conf.py).
+    'clangquill>=0.6.0; python_version >= "3.13"',
     "plotly",
     "meshio>=4.4",
 ]


### PR DESCRIPTION
## Why

The generated C++ API reference (https://staging.dune-gdt.org/cpp_api/index.html) is currently a **single flat index listing every class and namespace** — hundreds of fully-qualified entries on one page, which is unreadable and slow to navigate.

## What

Switch `clangquill_group_by` from `"class"` to the new **`"namespace"`** mode, which builds a browsable drill-down hierarchy instead:

- the root `cpp_api/index` lists only the **top namespaces** (`Dune`);
- each namespace gets a navigational **hub** page whose toctree links its sub-namespaces (`Dune::XT`, `Dune::GDT`, `Dune::XT::Common`, …), one page per **class**, one page per **free-function name** (overloads together), a single lumped **operators** page, and grouped **types** / **constants** pages.

So instead of one giant list you get *all namespaces → everything in a namespace → individual class/function pages*.

Also bumps the `clangquill` docs dependency to `>=0.6.0` (the release introducing the mode).

## Depends on

- renefritze/clangquill#108 — adds `group_by="namespace"`. This PR needs a clangquill **0.6.0** release before the docs build will pick up the new mode; until then the `>=0.6.0` constraint will not resolve.

## Notes

- Only the docs/API layout changes — no library/runtime code is touched.
- `clangquill_include_undocumented`, the cache dir, and all other settings are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvkHoZzrUQgfp1NLSFGkUW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference structure to organize items by namespace for improved drill-down navigation.
  * Adjusted the documentation build configuration to run single-threaded to help prevent out-of-memory issues during larger builds.
* **Chores**
  * Raised the documentation-related dependency requirement for newer Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->