### PR TITLE
ci: move all workflows back to GitHub-hosted ubuntu-24.04 runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,18 +1,5 @@
 ---
-# Register the custom runner labels used by the build_wheels job so actionlint
-# does not flag them as unknown. These are RunsOn (https://runs-on.com) labels
-# that select the EC2 instance shape, image and cache extras at job-launch time;
-# the runs-on=<id> routing label carries a ${{ }} expression and is skipped by
-# actionlint automatically.
-self-hosted-runner:
-  labels:
-  - cpu=8
-  - cpu=4
-  - family=m7i
-  # r7i (memory-optimized) is used by build-linux so the -j7 Python-bindings
-  # compile fits in RAM; m7i stays for the wheel/docs jobs.
-  - family=r7i
-  - image=ubuntu24-full-x64
-  - volume=150gb
-  - volume=80gb
-  - extras=s3-cache
+# actionlint configuration.
+#
+# All jobs run on GitHub-hosted runners (ubuntu-26.04), so there are no custom
+# self-hosted runner labels to register here.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,10 @@
 ---
 # actionlint configuration.
 #
-# All jobs run on GitHub-hosted runners (ubuntu-26.04), so there are no custom
-# self-hosted runner labels to register here.
+# All jobs run on GitHub-hosted runners. ubuntu-26.04 is newer than the runner
+# label set baked into the pinned actionlint release, so register it here as a
+# known label; otherwise actionlint reports it as an unknown runner label on
+# every job. (This is the labels list actionlint suggests for exactly this case.)
+self-hosted-runner:
+  labels:
+  - ubuntu-26.04

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,10 +1,5 @@
 ---
 # actionlint configuration.
 #
-# All jobs run on GitHub-hosted runners. ubuntu-26.04 is newer than the runner
-# label set baked into the pinned actionlint release, so register it here as a
-# known label; otherwise actionlint reports it as an unknown runner label on
-# every job. (This is the labels list actionlint suggests for exactly this case.)
-self-hosted-runner:
-  labels:
-  - ubuntu-26.04
+# All jobs run on GitHub-hosted runners (ubuntu-24.04), so there are no custom
+# self-hosted runner labels to register here.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   benchmarks:
     name: Build and run benchmarks (Release)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   benchmarks:
     name: Build and run benchmarks (Release)
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/check_markdown_links.yml
+++ b/.github/workflows/check_markdown_links.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   markdown-link-check:
     name: Markdown
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
     - name: Checkout reposotiry
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/check_markdown_links.yml
+++ b/.github/workflows/check_markdown_links.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   markdown-link-check:
     name: Markdown
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout reposotiry
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
     - name: Fetch dependabot metadata

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
     - name: Fetch dependabot metadata

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -27,7 +27,7 @@ jobs:
   # pipeline. `push`/`workflow_dispatch` ignore the outputs and always run full.
   changes:
     name: Detect changed paths
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       # paths-filter reads the PR file list via the API on pull_request events
@@ -60,45 +60,34 @@ jobs:
             - '!**/*.md'
 
   config:
-    # Single source of truth for instance sizing. Everything downstream (the
-    # runs-on cpu labels, the build -j, the ctest --parallel level) derives from
-    # the vCPU counts set here, so changing instance size is a one-line edit and
-    # the rest auto-adjusts. This indirection exists because GitHub Actions does
-    # not expose the env: context inside runs-on:; job outputs (needs.*) are the
-    # only workflow-local values usable there.
+    # Single source of truth for build parallelism. The test_binaries/bindings
+    # build -j and the ctest --parallel level both derive from the vCPU count set
+    # here, so the sizing lives in one place. This indirection exists because
+    # GitHub Actions does not expose the env: context inside run: steps as a
+    # workflow-wide constant; a job output (needs.config.outputs.*) is the
+    # simplest shared value.
     name: CI sizing constants
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     outputs:
-      linux_cpu: ${{ steps.sizing.outputs.linux_cpu }}
       linux_build_jobs: ${{ steps.sizing.outputs.linux_build_jobs }}
       ctest_parallel: ${{ steps.sizing.outputs.ctest_parallel }}
-      wheels_cpu: ${{ steps.sizing.outputs.wheels_cpu }}
-      docs_cpu: ${{ steps.sizing.outputs.docs_cpu }}
     steps:
     - id: sizing
       run: |
-        # ---- change instance size here ----
-        linux_cpu=8
-        wheels_cpu=8
-        docs_cpu=4
-        # -----------------------------------
-        # Fail fast on nonsensical sizes so a bad edit surfaces here (a cheap
-        # GitHub-hosted job) instead of as a confusing "-j 0"/"--parallel 0" or an
-        # invalid RunsOn cpu label deep in a self-hosted build. linux_cpu must be
-        # >= 2 so linux_build_jobs (cpu-1) stays >= 1.
-        for v in "$linux_cpu" "$wheels_cpu" "$docs_cpu"; do
-          [[ "$v" =~ ^[0-9]+$ ]] || { echo "::error::cpu values must be positive integers (got '$v')"; exit 1; }
-        done
+        # ---- GitHub-hosted runner vCPU count (ubuntu-26.04 standard = 4) ----
+        linux_cpu=4
+        # --------------------------------------------------------------------
+        # Fail fast on a nonsensical size so a bad edit surfaces here (a cheap
+        # job) instead of as a confusing "-j 0"/"--parallel 0" deep in a build.
+        # linux_cpu must be >= 2 so linux_build_jobs (cpu-1) stays >= 1.
+        [[ "$linux_cpu" =~ ^[0-9]+$ ]] || { echo "::error::linux_cpu must be a positive integer (got '$linux_cpu')"; exit 1; }
         (( linux_cpu >= 2 )) || { echo "::error::linux_cpu must be >= 2 (got $linux_cpu)"; exit 1; }
-        (( wheels_cpu >= 1 && docs_cpu >= 1 )) || { echo "::error::wheels_cpu/docs_cpu must be >= 1"; exit 1; }
         {
-          echo "linux_cpu=$linux_cpu"
-          echo "wheels_cpu=$wheels_cpu"
-          echo "docs_cpu=$docs_cpu"
-          # Cap compile concurrency by RAM: m7i = 4 GB/vCPU, template-heavy TUs
-          # peak ~2 GB each, so cpu-1 keeps peak RAM well under the box.
+          # Cap compile concurrency by RAM: the GitHub-hosted runner has 16 GB and
+          # template-heavy TUs peak ~2 GB each, so cpu-1 keeps peak RAM well under
+          # the box while using all but one vCPU.
           echo "linux_build_jobs=$((linux_cpu - 1))"
           # Tests are ~400 short, IO-light executables: oversubscribe at 2x vCPU.
           echo "ctest_parallel=$((linux_cpu * 2))"
@@ -107,38 +96,23 @@ jobs:
   build-linux:
     name: Build on Linux (${{ matrix.preset }})
     needs: [config, changes]
-    # Two ANDed gates: (1) fork-trust — only run on the self-hosted RunsOn/AWS
-    # fleet for trusted contexts (pushes/tags, the merge queue, same-repo PRs);
-    # external fork PRs are skipped because fork code must never execute on the
-    # fleet (arbitrary code execution risk; a GitHub-hosted fallback is a
-    # follow-up). (2) path filter — skip the C++ matrix on docs-only/markdown-only
-    # changes (push/dispatch always run full).
+    # Two ANDed gates: (1) fork-trust — skip the heavy build for external fork PRs
+    # (pushes/tags, the merge queue and same-repo PRs still run); this also keeps a
+    # fork from writing the shared Actions cache. (2) path filter — skip the C++
+    # matrix on docs-only/markdown-only changes (push/dispatch always run full).
     if: >-
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.non_docs == 'true')
-    # Trial running on RunsOn self-hosted runners (https://runs-on.com). The
-    # run_id routing label is suffixed with the matrix preset so each leg
-    # provisions its own ephemeral instance instead of competing for one.
-    runs-on:
-    - runs-on=${{ github.run_id }}-${{ matrix.preset }}
-    - cpu=${{ needs.config.outputs.linux_cpu }}
-    # r7i (memory-optimized, 8 GB/vCPU -> 64 GB at cpu=8). The Python bindings are
-    # the memory driver: their pybind11 TUs instantiate deeply-nested Dune templates
-    # and peak well above the ~2 GB/TU of the test binaries, so building them at the
-    # shared -j cpu-1 (see below) OOM-killed the 32 GB m7i mid-step on a cold ccache
-    # (the runner vanished, leaving the step stuck in-progress). The 64 GB here keeps
-    # the -j7 bindings compile (~7 * ~8 GB) under memory. Neither preset uses LTO, so
-    # there is no /tmp ltrans explosion like build_wheels.
-    - family=r7i
-    - image=ubuntu24-full-x64
-    # build/ tree + .vcpkg-root + 2 GB ccache fit easily; 80 GB gp3 leaves ample
-    # headroom and the runner is a short-lived spot instance, so the extra storage
-    # is negligible.
-    - volume=80gb
-    - extras=s3-cache
+    # GitHub-hosted standard runner (4 vCPU / 16 GB). The bindings compile is the
+    # memory driver: its pybind11 TUs instantiate deeply-nested Dune templates and
+    # peak well above the ~2 GB/TU of the test binaries, so it is built at the
+    # shared -j cpu-1 (linux_build_jobs from the config job, = 3 here) to keep peak
+    # RAM well under 16 GB. Neither preset uses LTO, so there is no /tmp ltrans
+    # explosion like build_wheels.
+    runs-on: ubuntu-26.04
     # A fully cold leg (no build cache) compiles every vcpkg dependency as a shared
     # library, the project, the ~400 test binaries and the Python bindings from
-    # scratch; on the m7i fleet that fits well under 3h. Warm runs restore the
-    # build/ + ccache and finish in well under an hour.
+    # scratch; the 180 min timeout leaves ample headroom. Warm runs restore the
+    # ccache and finish much faster.
     timeout-minutes: 180
     permissions:
       contents: read
@@ -168,11 +142,6 @@ jobs:
       CCACHE_MAXSIZE: "2G"
 
     steps:
-    # Configures the RunsOn Magic Cache sidecar so the actions/cache steps below
-    # transparently use S3 (extras=s3-cache). No-op on GitHub-hosted runners, so it
-    # stays safe if this job ever falls back to ubuntu-24.04.
-    - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2
-
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         # this checkout's token is not used for any later git push/API call
@@ -232,8 +201,8 @@ jobs:
         # test_binaries is ~400 separate executables, several of which are
         # template-heavy TUs that peak around ~2 GB RAM each. Cap concurrency by
         # memory: -j cpu-1 (linux_build_jobs from the config job) keeps peak RAM
-        # (~2 GB * (cpu-1)) well under the m7i runner (4 GB/vCPU) while using all
-        # but one of its vCPUs. With a warm ccache most of these are cache hits.
+        # (~2 GB * (cpu-1)) well under the GitHub-hosted runner (16 GB) while using
+        # all but one of its vCPUs. With a warm ccache most of these are cache hits.
         cmake --build --preset=${{ matrix.preset }} --target test_binaries --parallel -- -j ${{ needs.config.outputs.linux_build_jobs }}
         ccache --show-stats
 
@@ -317,35 +286,20 @@ jobs:
 
   build_wheels:
     name: Build wheels
-    needs: [config, changes]
-    # Two ANDed gates: (1) fork-trust — only run on trusted contexts (pushes/tags,
-    # the merge queue, same-repo PRs); fork PRs must never execute on the
-    # self-hosted RunsOn/AWS fleet (arbitrary code execution risk). (2) path
-    # filter — skip on docs-only/markdown-only changes; build_docs then sources the
-    # wheels from the last successful main build instead of rebuilding them here.
+    needs: [changes]
+    # Two ANDed gates: (1) fork-trust — skip the wheel build for external fork PRs
+    # (pushes/tags, the merge queue and same-repo PRs still run); this also keeps a
+    # fork from writing the shared Actions cache. (2) path filter — skip on
+    # docs-only/markdown-only changes; build_docs then sources the wheels from the
+    # last successful main build instead of rebuilding them here.
     if: >-
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.non_docs == 'true')
-    # Trial running on RunsOn self-hosted runners (https://runs-on.com). The label
-    # list selects an 8-vCPU c7i EC2 instance with the ubuntu24-full image; the
-    # extras=s3-cache label enables the RunsOn S3-backed Magic Cache, which the
-    # runs-on/action step below wires into actions/cache.
-    runs-on:
-    - runs-on=${{ github.run_id }}
-    - cpu=${{ needs.config.outputs.wheels_cpu }}
-    # m7i (general-purpose, 4 GB/vCPU -> 32 GB at cpu=8). c7i is compute-optimized
-    # at 2 GB/vCPU = only 16 GB, which OOMs the -j7 compile in build-wheels.sh.
-    # build-wheels.sh builds at -j "$(nproc --ignore 1)", so its compile
-    # parallelism auto-scales with whatever cpu the config job provisions.
-    - family=m7i
-    - image=ubuntu24-full-x64
-    # Enlarge the root EBS volume. The release build links with LTO, and at -j7 it
-    # runs several LTO links in parallel, each spilling many large *.ltrans.o
-    # intermediates into /tmp. On the default disk this overruns the volume and the
-    # link dies with "No space left on device"; 150 GB gp3 leaves ample headroom
-    # for the LTO scratch plus the manylinux image, ccache, and build tree. The
-    # volume is on a short-lived spot runner, so the extra storage is negligible.
-    - volume=150gb
-    - extras=s3-cache
+    # GitHub-hosted standard runner (4 vCPU / 16 GB). build-wheels.sh builds at
+    # -j "$(nproc --ignore 1)" (= 3 here), so its compile parallelism auto-scales
+    # with the runner; at -j3 the parallel LTO links keep their *.ltrans.o scratch
+    # within /tmp and the build stays within memory (the much wider -j on the old
+    # self-hosted box needed an enlarged volume for the spill — moot at -j3).
+    runs-on: ubuntu-26.04
     timeout-minutes: 120
     permissions:
       contents: read
@@ -354,11 +308,6 @@ jobs:
         python-version: ["3.13"] #, "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    # Configures the RunsOn Magic Cache sidecar so the actions/cache step below
-    # transparently uses S3. No-op on GitHub-hosted runners, so it stays safe if
-    # this job ever falls back to ubuntu-24.04.
-    - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2
-
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         # this checkout's token is not used for any later git push/API call
@@ -369,8 +318,7 @@ jobs:
 
     - name: Restore wheel-build ccache
       # build-wheels.sh sets CCACHE_DIR to build/wheelhouse/cache (on the host
-      # bind-mount), so the compiler cache survives between runs. Routed to RunsOn
-      # S3 via extras=s3-cache + the runs-on/action step above. Split into
+      # bind-mount), so the compiler cache survives between runs. Split into
       # restore/save (rather than the unified action) so the write can be gated to
       # trusted contexts, matching build-linux and avoiding cache poisoning.
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -447,7 +395,7 @@ jobs:
 
   build_docs:
     name: Build docs (executes notebooks via myst-nb)
-    needs: [config, build_wheels, changes]
+    needs: [build_wheels, changes]
     # Gates (all ANDed): (1) fork-trust, same as build_wheels (also satisfies the
     # cache-poisoning lint on the uv cache below). (2) build_wheels reached a valid
     # terminal state — success (use its artifact) or skipped/docs-only (pull the
@@ -458,16 +406,10 @@ jobs:
     if: >-
       !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (needs.build_wheels.result == 'success' || needs.build_wheels.result == 'skipped') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' ||
        needs.changes.outputs.non_docs == 'true' || needs.changes.outputs.docs == 'true')
-    # Trial running on RunsOn self-hosted runners (https://runs-on.com). The docs
-    # build is single-threaded (sphinx -j 1), so 4 vCPU / 16 GB (m7i) is plenty and
-    # no volume bump is needed (it only downloads the wheels artifact and renders
-    # HTML). extras=s3-cache + the runs-on/action step route setup-uv's cache to S3.
-    runs-on:
-    - runs-on=${{ github.run_id }}
-    - cpu=${{ needs.config.outputs.docs_cpu }}
-    - family=m7i
-    - image=ubuntu24-full-x64
-    - extras=s3-cache
+    # GitHub-hosted standard runner (4 vCPU / 16 GB). The docs build is
+    # single-threaded (sphinx -j 1), so the standard runner is plenty (it only
+    # downloads the wheels artifact and renders HTML).
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     permissions:
       contents: read
@@ -480,10 +422,6 @@ jobs:
       PYTHON_VERSION: "3.13"
 
     steps:
-    # Configures the RunsOn Magic Cache sidecar so setup-uv's cache (gated below)
-    # transparently uses S3 (extras=s3-cache). No-op on GitHub-hosted runners.
-    - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60 # v2.1.2
-
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         # this checkout's token is not used for any later git push/API call
@@ -587,7 +525,7 @@ jobs:
       # on those below. We intentionally do NOT pass sphinx -W, because intersphinx
       # inventory fetches emit network-dependent warnings unrelated to the docs build.
       # Sphinx runs single-threaded (-j 1) on purpose: this job's runner is sized for
-      # it (4 vCPU / 16 GB, see runs-on labels above), and the clangquill C++ API now
+      # it (4 vCPU / 16 GB GitHub-hosted runner), and the clangquill C++ API now
       # emits one page per class/function (group_by="namespace"), a far larger document
       # set whose per-worker environment copies under "-j auto" OOM-killed the 16 GB box
       # mid-write. Single-threaded keeps peak RAM bounded; the 60 min timeout is ample.
@@ -629,7 +567,7 @@ jobs:
 
   deploy_docs:
     name: Deploy docs to GitHub Pages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: build_docs
     # publish only on pushes to main; PRs and the merge queue build (above) but
     # never deploy. build_docs must have succeeded, so broken docs are not
@@ -666,7 +604,7 @@ jobs:
 
   test_publish:
     name: Publish to Test PyPI
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: build_wheels
     # only publish to Test PyPI on pushes to main, never on PRs, the merge
     # queue, or manual runs
@@ -697,7 +635,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: build_wheels
     if: startsWith(github.ref, 'refs/tags/')
     timeout-minutes: 120
@@ -730,7 +668,7 @@ jobs:
   # check pending forever. Matrix job results aggregate (any failed leg => failure).
   ci-gate:
     name: CI gate
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions: {}
     if: always()
     needs: [changes, config, build-linux, build_wheels, build_docs]

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -76,10 +76,14 @@ jobs:
     steps:
     - id: sizing
       run: |
-        # ---- GitHub-hosted runner vCPU count (ubuntu-26.04 standard = 4) ----
-        linux_cpu=4
-        # --------------------------------------------------------------------
-        # Fail fast on a nonsensical size so a bad edit surfaces here (a cheap
+        # ---- GitHub-hosted runner vCPU count ----
+        # Detect the runner's core count instead of hard-coding it, so the derived
+        # -j / --parallel levels stay correct if the runner class ever changes. The
+        # config job shares build-linux's ubuntu-26.04 label, so its nproc matches
+        # that job's core count; standard GitHub-hosted runners report 4.
+        linux_cpu="$(nproc)"
+        # -----------------------------------------
+        # Fail fast on a nonsensical size so a bad value surfaces here (a cheap
         # job) instead of as a confusing "-j 0"/"--parallel 0" deep in a build.
         # linux_cpu must be >= 2 so linux_build_jobs (cpu-1) stays >= 1.
         [[ "$linux_cpu" =~ ^[0-9]+$ ]] || { echo "::error::linux_cpu must be a positive integer (got '$linux_cpu')"; exit 1; }
@@ -105,9 +109,9 @@ jobs:
     # GitHub-hosted standard runner (4 vCPU / 16 GB). The bindings compile is the
     # memory driver: its pybind11 TUs instantiate deeply-nested Dune templates and
     # peak well above the ~2 GB/TU of the test binaries, so it is built at the
-    # shared -j cpu-1 (linux_build_jobs from the config job, = 3 here) to keep peak
-    # RAM well under 16 GB. Neither preset uses LTO, so there is no /tmp ltrans
-    # explosion like build_wheels.
+    # shared -j cpu-1 (linux_build_jobs from the config job, = 3 on the standard
+    # 4-vCPU runner) to keep peak RAM well under 16 GB. Neither preset uses LTO, so
+    # there is no /tmp ltrans explosion like build_wheels.
     runs-on: ubuntu-26.04
     # A fully cold leg (no build cache) compiles every vcpkg dependency as a shared
     # library, the project, the ~400 test binaries and the Python bindings from
@@ -295,7 +299,7 @@ jobs:
     if: >-
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.non_docs == 'true')
     # GitHub-hosted standard runner (4 vCPU / 16 GB). build-wheels.sh builds at
-    # -j "$(nproc --ignore 1)" (= 3 here), so its compile parallelism auto-scales
+    # -j "$(nproc --ignore 1)" (= 3 on a standard 4-vCPU runner), so its compile parallelism auto-scales
     # with the runner; at -j3 the parallel LTO links keep their *.ltrans.o scratch
     # within /tmp and the build stays within memory (the much wider -j on the old
     # self-hosted box needed an enlarged volume for the spill — moot at -j3).

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -72,6 +72,7 @@ jobs:
       contents: read
     outputs:
       linux_build_jobs: ${{ steps.sizing.outputs.linux_build_jobs }}
+      bindings_jobs: ${{ steps.sizing.outputs.bindings_jobs }}
       ctest_parallel: ${{ steps.sizing.outputs.ctest_parallel }}
     steps:
     - id: sizing
@@ -89,10 +90,15 @@ jobs:
         [[ "$linux_cpu" =~ ^[0-9]+$ ]] || { echo "::error::linux_cpu must be a positive integer (got '$linux_cpu')"; exit 1; }
         (( linux_cpu >= 2 )) || { echo "::error::linux_cpu must be >= 2 (got $linux_cpu)"; exit 1; }
         {
-          # Cap compile concurrency by RAM: the GitHub-hosted runner has 16 GB and
-          # template-heavy TUs peak ~2 GB each, so cpu-1 keeps peak RAM well under
-          # the box while using all but one vCPU.
+          # Cap compile concurrency by RAM: the GitHub-hosted runner has only
+          # 16 GB. Ordinary TUs (the library and the ~400 test binaries) peak
+          # ~2 GB each, so cpu-1 keeps their peak RAM well under the box while
+          # using all but one vCPU.
           echo "linux_build_jobs=$((linux_cpu - 1))"
+          # The pybind11 binding TUs instantiate deeply-nested Dune templates and
+          # peak far higher (well above 4 GB each) -- building them at the shared
+          # cpu-1 OOM-killed the 16 GB runner -- so give them a tighter cap.
+          echo "bindings_jobs=$((linux_cpu / 2))"
           # Tests are ~400 short, IO-light executables: oversubscribe at 2x vCPU.
           echo "ctest_parallel=$((linux_cpu * 2))"
         } >> "$GITHUB_OUTPUT"
@@ -108,16 +114,18 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.non_docs == 'true')
     # GitHub-hosted standard runner (4 vCPU / 16 GB). The bindings compile is the
     # memory driver: its pybind11 TUs instantiate deeply-nested Dune templates and
-    # peak well above the ~2 GB/TU of the test binaries, so it is built at the
-    # shared -j cpu-1 (linux_build_jobs from the config job, = 3 on the standard
-    # 4-vCPU runner) to keep peak RAM well under 16 GB. Neither preset uses LTO, so
-    # there is no /tmp ltrans explosion like build_wheels.
+    # peak far above the ~2 GB/TU of the test binaries, so they get their own
+    # tighter cap (bindings_jobs = cpu/2 from the config job) -- the shared cpu-1
+    # level OOM-killed this 16 GB runner. Every compile step (incl. the main Build)
+    # is -j capped for the same reason. Neither preset uses LTO, so there is no
+    # /tmp ltrans explosion like build_wheels.
     runs-on: ubuntu-26.04
     # A fully cold leg (no build cache) compiles every vcpkg dependency as a shared
     # library, the project, the ~400 test binaries and the Python bindings from
-    # scratch; the 180 min timeout leaves ample headroom. Warm runs restore the
-    # ccache and finish much faster.
-    timeout-minutes: 180
+    # scratch; on the 4 vCPU hosted runner with the memory-bounded -j caps above
+    # that is slower than the old self-hosted fleet, so the timeout is generous.
+    # Warm runs restore the ccache and finish much faster.
+    timeout-minutes: 240
     permissions:
       contents: read
       # codecov's GitHub Action authenticates to codecov.io via OpenID Connect
@@ -198,7 +206,9 @@ jobs:
         cmake --preset=${{ matrix.preset }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
-      run: cmake --build --preset=${{ matrix.preset }} --parallel
+      # Cap the library build at the memory-bounded -j too: ninja would otherwise
+      # default to nproc+2, and the heavy template TUs can exhaust the 16 GB runner.
+      run: cmake --build --preset=${{ matrix.preset }} --parallel -- -j ${{ needs.config.outputs.linux_build_jobs }}
 
     - name: Build test binaries
       run: |
@@ -214,7 +224,9 @@ jobs:
       # Both legs run the Python test suite (now part of ctest), so both build the
       # .so bindings first — CTest does not build dependencies, and the
       # xt_test_python / gdt_test_python tests need the compiled modules present.
-      run: cmake --build --preset=${{ matrix.preset }} --target bindings --parallel -- -j ${{ needs.config.outputs.linux_build_jobs }}
+      # bindings_jobs (cpu/2) caps these memory-heavy pybind11 TUs below the wider
+      # linux_build_jobs used elsewhere, to stay under the 16 GB runner.
+      run: cmake --build --preset=${{ matrix.preset }} --target bindings --parallel -- -j ${{ needs.config.outputs.bindings_jobs }}
 
     - name: Test with CTest
       # Runs both the C++ suite and the Python (pytest) suite — the latter is now
@@ -299,12 +311,17 @@ jobs:
     if: >-
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.non_docs == 'true')
     # GitHub-hosted standard runner (4 vCPU / 16 GB). build-wheels.sh builds at
-    # -j "$(nproc --ignore 1)" (= 3 on a standard 4-vCPU runner), so its compile parallelism auto-scales
-    # with the runner; at -j3 the parallel LTO links keep their *.ltrans.o scratch
-    # within /tmp and the build stays within memory (the much wider -j on the old
-    # self-hosted box needed an enlarged volume for the spill — moot at -j3).
+    # -j "$(nproc --ignore 1)" (= 3 on a standard 4-vCPU runner), so its compile
+    # parallelism auto-scales with the runner; at -j3 the parallel LTO links keep
+    # their *.ltrans.o scratch within /tmp and the build stays within memory (the
+    # much wider -j on the old self-hosted box needed an enlarged volume for the
+    # spill — moot at -j3).
     runs-on: ubuntu-26.04
-    timeout-minutes: 120
+    # A cold build compiles every vcpkg dependency plus the LTO release bindings
+    # from scratch. On the 4 vCPU hosted runner (half the cores of the old
+    # self-hosted box, and -j3 vs -j7) that is far slower, so the timeout is raised
+    # well above the old 120 min to leave headroom.
+    timeout-minutes: 300
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -27,7 +27,7 @@ jobs:
   # pipeline. `push`/`workflow_dispatch` ignore the outputs and always run full.
   changes:
     name: Detect changed paths
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       # paths-filter reads the PR file list via the API on pull_request events
@@ -67,7 +67,7 @@ jobs:
     # workflow-wide constant; a job output (needs.config.outputs.*) is the
     # simplest shared value.
     name: CI sizing constants
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -80,7 +80,7 @@ jobs:
         # ---- GitHub-hosted runner vCPU count ----
         # Detect the runner's core count instead of hard-coding it, so the derived
         # -j / --parallel levels stay correct if the runner class ever changes. The
-        # config job shares build-linux's ubuntu-26.04 label, so its nproc matches
+        # config job shares build-linux's ubuntu-24.04 label, so its nproc matches
         # that job's core count; standard GitHub-hosted runners report 4.
         linux_cpu="$(nproc)"
         # -----------------------------------------
@@ -119,7 +119,7 @@ jobs:
     # level OOM-killed this 16 GB runner. Every compile step (incl. the main Build)
     # is -j capped for the same reason. Neither preset uses LTO, so there is no
     # /tmp ltrans explosion like build_wheels.
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     # A fully cold leg (no build cache) compiles every vcpkg dependency as a shared
     # library, the project, the ~400 test binaries and the Python bindings from
     # scratch; on the 4 vCPU hosted runner with the memory-bounded -j caps above
@@ -316,7 +316,7 @@ jobs:
     # their *.ltrans.o scratch within /tmp and the build stays within memory (the
     # much wider -j on the old self-hosted box needed an enlarged volume for the
     # spill — moot at -j3).
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     # A cold build compiles every vcpkg dependency plus the LTO release bindings
     # from scratch. On the 4 vCPU hosted runner (half the cores of the old
     # self-hosted box, and -j3 vs -j7) that is far slower, so the timeout is raised
@@ -430,7 +430,7 @@ jobs:
     # GitHub-hosted standard runner (4 vCPU / 16 GB). The docs build is
     # single-threaded (sphinx -j 1), so the standard runner is plenty (it only
     # downloads the wheels artifact and renders HTML).
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
       contents: read
@@ -588,7 +588,7 @@ jobs:
 
   deploy_docs:
     name: Deploy docs to GitHub Pages
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     needs: build_docs
     # publish only on pushes to main; PRs and the merge queue build (above) but
     # never deploy. build_docs must have succeeded, so broken docs are not
@@ -625,7 +625,7 @@ jobs:
 
   test_publish:
     name: Publish to Test PyPI
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     needs: build_wheels
     # only publish to Test PyPI on pushes to main, never on PRs, the merge
     # queue, or manual runs
@@ -656,7 +656,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     needs: build_wheels
     if: startsWith(github.ref, 'refs/tags/')
     timeout-minutes: 120
@@ -689,7 +689,7 @@ jobs:
   # check pending forever. Matrix job results aggregate (any failed leg => failure).
   ci-gate:
     name: CI gate
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     permissions: {}
     if: always()
     needs: [changes, config, build-linux, build_wheels, build_docs]

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -11,7 +11,7 @@ name: Sanity checks
 jobs:
   message-check:
     name: Block Autosquash Commits
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
     - name: Block Autosquash Commits
       uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
@@ -19,7 +19,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   merge_conflict_job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     name: Find merge conflicts
     steps:
     - name: Checkout repository

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -11,7 +11,7 @@ name: Sanity checks
 jobs:
   message-check:
     name: Block Autosquash Commits
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Block Autosquash Commits
       uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
@@ -19,7 +19,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   merge_conflict_job:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     name: Find merge conflicts
     steps:
     - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ discrete function spaces.
 ## Continuous integration
 
 CI for this project (Linux build & test, Python wheels, and documentation) runs on
-GitHub-hosted Actions runners (`ubuntu-26.04`).
+GitHub-hosted Actions runners (`ubuntu-24.04`).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,4 @@ discrete function spaces.
 ## Continuous integration
 
 CI for this project (Linux build & test, Python wheels, and documentation) runs on
-self-hosted GitHub Actions runners provided by [RunsOn](https://runs-on.com).
-
-[![CI powered by RunsOn](https://img.shields.io/badge/CI%20powered%20by-RunsOn-7B68EE?logo=githubactions&logoColor=white)](https://runs-on.com)
+GitHub-hosted Actions runners (`ubuntu-26.04`).


### PR DESCRIPTION
## Summary

Switches every CI job off the RunsOn self-hosted fleet and back onto **GitHub-hosted runners**.

The base image is **`ubuntu-24.04`**. (This started as `ubuntu-26.04`, but that image ships GCC 15, under which 7 dune-gdt tests fail — a dangling-reference crash in `raviart-thomas.hh`, an out-of-bounds `std::vector` access, and several numerical EOC-table tests sensitive to the newer FP codegen. `ubuntu-24.04` uses GCC 13/14 — the same toolchain generation as the old self-hosted `ubuntu24` image — and builds/tests cleanly.)

## Changes

### `non_docker_build.yml`
- **`build-linux`, `build_wheels`, `build_docs`**: replaced the RunsOn label lists with `runs-on: ubuntu-24.04` and removed the `runs-on/action` Magic Cache sidecar steps (S3 cache was RunsOn-only; `actions/cache` now uses the GitHub backend).
- **Memory sizing for the 16 GB hosted runner** (the old self-hosted boxes were 32–64 GB):
  - `config` job derives parallelism from `nproc` and adds a `bindings_jobs` (`cpu/2`) output; the memory-heavy pybind11 **bindings** compile uses it instead of the wider `cpu-1` that OOM-killed the runner.
  - the previously-uncapped main `Build` step is now `-j`-capped too.
- **Timeouts** raised for the slower 4-vCPU hosted runner: `build-linux` `180 → 240 min`, `build_wheels` `120 → 300 min` (its earlier failure was a 120-min timeout, not OOM).
- All remaining jobs (`changes`, `deploy_docs`, `test_publish`, `publish`, `ci-gate`) → `ubuntu-24.04`.

### Other workflows
- `sanity_checks.yml`, `check_markdown_links.yml`, `benchmarks.yml`, `dependabot.yml`: all runners → `ubuntu-24.04`.

### Misc
- `actionlint.yaml`: removed the RunsOn `self-hosted-runner` label allowlist (no custom labels remain; `ubuntu-24.04` is a known label).
- `README.md`: CI section updated to GitHub-hosted `ubuntu-24.04`, RunsOn badge removed.

## Notes
- The fork-trust `if:` gates and cache-poisoning protections are kept unchanged, so the heavy jobs are still skipped for external-fork PRs (same as before). Removing those to let fork PRs build can be a follow-up.
- **Follow-up worth filing:** the GCC 15 failures on `ubuntu-26.04` are real latent issues (the dangling-reference UB and the vector OOB especially) and would need fixing before the project can move to a newer compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and workflow jobs to use the latest GitHub-hosted Linux runner environment.
  * Simplified CI sizing and job setup for build and documentation pipelines.
  * Removed references to older self-hosted runner setup from CI documentation.
* **Bug Fixes**
  * Improved consistency across link checking, dependency updates, and sanity check workflows by aligning them with the new runner environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->