### PR TITLE
test: add unit tests for linear-advection and linear-advection-upwind integrands (#280)

### DIFF
--- a/dune/gdt/test/integrands/integrands_linear_advection.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection.cc
@@ -234,9 +234,10 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
       const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
       for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
         integrand.evaluate(*scalar_test_, *scalar_ansatz_, qp.position(), result);
-        for (size_t ii = 0; ii < 2; ++ii)
+        for (size_t ii = 0; ii < 2; ++ii) {
           for (size_t jj = 0; jj < 2; ++jj)
             EXPECT_DOUBLE_EQ(0., result[ii][jj]);
+        }
       }
     }
   }
@@ -264,11 +265,12 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
       original.evaluate(*scalar_test_, *scalar_ansatz_, x, res_orig);
       copy_ctor.evaluate(*scalar_test_, *scalar_ansatz_, x, res_copy);
       cloned->evaluate(*scalar_test_, *scalar_ansatz_, x, res_clone);
-      for (size_t ii = 0; ii < 2; ++ii)
+      for (size_t ii = 0; ii < 2; ++ii) {
         for (size_t jj = 0; jj < 2; ++jj) {
           EXPECT_DOUBLE_EQ(res_orig[ii][jj], res_copy[ii][jj]);
           EXPECT_DOUBLE_EQ(res_orig[ii][jj], res_clone[ii][jj]);
         }
+      }
     }
   }
 

--- a/dune/gdt/test/integrands/integrands_linear_advection.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection.cc
@@ -1,0 +1,326 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/geometry/quadraturerules.hh>
+
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/functions/generic/grid-function.hh>
+
+#include <dune/gdt/local/integrands/linear-advection.hh>
+
+#include <dune/gdt/test/integrands/integrands.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Test {
+
+
+template <class G>
+struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
+{
+  using BaseType = IntegrandTest<G>;
+  using BaseType::d;
+  using typename BaseType::D;
+  using typename BaseType::DomainType;
+  using typename BaseType::E;
+  using typename BaseType::GV;
+  using typename BaseType::MatrixType;
+  using IntegrandType = LocalLinearAdvectionIntegrand<E>;
+
+  void is_constructable() override final
+  {
+    // construction from a GenericGridFunction (element-local vector function)
+    const XT::Functions::GenericGridFunction<E, d> velocity_gf(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    [[maybe_unused]] IntegrandType integrand_div(velocity_gf);
+    [[maybe_unused]] IntegrandType integrand_div2(velocity_gf, /*advection_in_divergence_form=*/true);
+    [[maybe_unused]] IntegrandType integrand_nodiv(velocity_gf, /*advection_in_divergence_form=*/false);
+
+    // construction from a GenericFunction (static vector function)
+    const XT::Functions::GenericFunction<d, d> velocity_func(
+        0, [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    [[maybe_unused]] IntegrandType integrand_from_func(velocity_func);
+
+    // copy constructor
+    [[maybe_unused]] IntegrandType integrand_copy(integrand_div);
+
+    // copy_as_binary_element_integrand
+    auto cloned = integrand_div.copy_as_binary_element_integrand();
+    EXPECT_NE(nullptr, cloned);
+  }
+
+  virtual void order_is_correct()
+  {
+    // For constant direction (order 0): order = 0 + test.order + ansatz.order = 0 + 4 + 3 = 7
+    const XT::Functions::GenericGridFunction<E, d> const_vel(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    IntegrandType integrand_const(const_vel, true);
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    integrand_const.bind(element);
+    EXPECT_EQ(0 + 4 + 3, integrand_const.order(*scalar_test_, *scalar_ansatz_));
+
+    // For linear direction (order 1): order = 1 + 4 + 3 = 8
+    const XT::Functions::GenericGridFunction<E, d> linear_vel(
+        1,
+        [](const E&) {},
+        [](const DomainType& x, const XT::Common::Parameter&) { return FieldVector<D, d>{{x[0], x[1]}}; });
+    IntegrandType integrand_linear(linear_vel, true);
+    integrand_linear.bind(element);
+    EXPECT_EQ(1 + 4 + 3, integrand_linear.order(*scalar_test_, *scalar_ansatz_));
+
+    // order is the same for divergence and non-divergence form
+    IntegrandType integrand_nodiv(const_vel, false);
+    integrand_nodiv.bind(element);
+    EXPECT_EQ(0 + 4 + 3, integrand_nodiv.order(*scalar_test_, *scalar_ansatz_));
+  }
+
+  virtual void evaluates_correctly_divergence_form()
+  {
+    // velocity v = (1, 0) constant, divergence form
+    // formula: result[i][j] = -ansatz_val[j] * (v . test_grad[i])
+    //
+    // scalar_test_  = {y, xy^3},  jacobians = {(0,1), (y^3, 3xy^2)}
+    // scalar_ansatz_ = {x, x^2*y}, jacobians = {(1,0), (2xy, x^2)}
+    //
+    // v=(1,0): v . test_grad[0] = (1,0).(0,1) = 0
+    //          v . test_grad[1] = (1,0).(y^3, 3xy^2) = y^3
+    //
+    // expected result[i][j] = -ansatz[j] * (v . test_grad[i]):
+    //   [0][0] = -x * 0 = 0
+    //   [0][1] = -x^2*y * 0 = 0
+    //   [1][0] = -x * y^3
+    //   [1][1] = -x^2*y * y^4  <- NOTE: -x^2*y * y^3 = -x^2*y^4, todo verify this is correct behavior
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    IntegrandType integrand(velocity, /*advection_in_divergence_form=*/true);
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    integrand.bind(element);
+    const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> result(2, 2, 0.);
+    for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+      // row i = test function index, col j = ansatz function index
+      EXPECT_NEAR(0., result[0][0], 1e-13);
+      EXPECT_NEAR(0., result[0][1], 1e-13);
+      EXPECT_NEAR(-x[0] * std::pow(x[1], 3), result[1][0], 1e-13);
+      EXPECT_NEAR(-std::pow(x[0], 2) * x[1] * std::pow(x[1], 3), result[1][1], 1e-13);
+    }
+  }
+
+  virtual void evaluates_correctly_non_divergence_form()
+  {
+    // velocity v = (1, 0) constant, non-divergence form
+    // formula: result[i][j] = (v . ansatz_grad[j]) * test_val[i]
+    //
+    // scalar_ansatz_ = {x, x^2*y}, jacobians = {(1,0), (2xy, x^2)}
+    // scalar_test_   = {y, xy^3}
+    //
+    // v=(1,0): v . ansatz_grad[0] = (1,0).(1,0) = 1
+    //          v . ansatz_grad[1] = (1,0).(2xy, x^2) = 2xy
+    //
+    // expected result[i][j] = (v . ansatz_grad[j]) * test[i]:
+    //   [0][0] = 1 * y = y
+    //   [0][1] = 2xy * y = 2xy^2
+    //   [1][0] = 1 * xy^3 = xy^3
+    //   [1][1] = 2xy * xy^3 = 2x^2*y^4
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    IntegrandType integrand(velocity, /*advection_in_divergence_form=*/false);
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    integrand.bind(element);
+    const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> result(2, 2, 0.);
+    for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+      EXPECT_NEAR(x[1], result[0][0], 1e-13);
+      EXPECT_NEAR(2. * x[0] * std::pow(x[1], 2), result[0][1], 1e-13);
+      EXPECT_NEAR(x[0] * std::pow(x[1], 3), result[1][0], 1e-13);
+      EXPECT_NEAR(2. * std::pow(x[0], 2) * std::pow(x[1], 4), result[1][1], 1e-13);
+    }
+  }
+
+  virtual void evaluates_correctly_with_variable_velocity()
+  {
+    // velocity v = (x, y) (order 1), tests both divergence and non-divergence forms
+    //
+    // Divergence form:
+    //   v . test_grad[0] = (x,y).(0,1) = y
+    //   v . test_grad[1] = (x,y).(y^3, 3xy^2) = x*y^3 + 3xy^3 = 4xy^3  <- TODO verify
+    //   result[i][j] = -ansatz[j] * (v . test_grad[i]):
+    //     [0][0] = -x * y
+    //     [0][1] = -x^2*y * y = -x^2*y^2
+    //     [1][0] = -x * 4xy^3 = -4x^2*y^3
+    //     [1][1] = -x^2*y * 4xy^3 = -4x^3*y^4
+    //
+    // Non-divergence form:
+    //   v . ansatz_grad[0] = (x,y).(1,0) = x
+    //   v . ansatz_grad[1] = (x,y).(2xy, x^2) = 2x^2*y + x^2*y = 3x^2*y  <- TODO verify
+    //   result[i][j] = (v . ansatz_grad[j]) * test[i]:
+    //     [0][0] = x * y = xy
+    //     [0][1] = 3x^2*y * y = 3x^2*y^2
+    //     [1][0] = x * xy^3 = x^2*y^3
+    //     [1][1] = 3x^2*y * xy^3 = 3x^3*y^4
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        1,
+        [](const E&) {},
+        [](const DomainType& x, const XT::Common::Parameter&) { return FieldVector<D, d>{{x[0], x[1]}}; });
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+
+    {
+      IntegrandType integrand(velocity, /*advection_in_divergence_form=*/true);
+      integrand.bind(element);
+      const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
+      EXPECT_EQ(1 + 4 + 3, order);
+      DynamicMatrix<D> result(2, 2, 0.);
+      for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
+        const auto& x = qp.position();
+        integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+        // v.test_grad[1] = x*y^3 + y*(3*x*y^2) = xy^3 + 3xy^3 = 4xy^3
+        EXPECT_NEAR(-x[0] * x[1], result[0][0], 1e-13);
+        EXPECT_NEAR(-std::pow(x[0], 2) * x[1] * x[1], result[0][1], 1e-13);
+        EXPECT_NEAR(-x[0] * 4. * x[0] * std::pow(x[1], 3), result[1][0], 1e-13);
+        EXPECT_NEAR(-std::pow(x[0], 2) * x[1] * 4. * x[0] * std::pow(x[1], 3), result[1][1], 1e-13);
+      }
+    }
+
+    {
+      IntegrandType integrand(velocity, /*advection_in_divergence_form=*/false);
+      integrand.bind(element);
+      const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
+      DynamicMatrix<D> result(2, 2, 0.);
+      for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
+        const auto& x = qp.position();
+        integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+        // v.ansatz_grad[1] = x*(2xy) + y*(x^2) = 2x^2y + x^2y = 3x^2y
+        EXPECT_NEAR(x[0] * x[1], result[0][0], 1e-13);
+        EXPECT_NEAR(3. * std::pow(x[0], 2) * x[1] * x[1], result[0][1], 1e-13);
+        EXPECT_NEAR(x[0] * x[0] * std::pow(x[1], 3), result[1][0], 1e-13);
+        EXPECT_NEAR(3. * std::pow(x[0], 2) * x[1] * x[0] * std::pow(x[1], 3), result[1][1], 1e-13);
+      }
+    }
+  }
+
+  virtual void zero_velocity_gives_zero_result()
+  {
+    // edge case: zero velocity => all results must be zero
+    const XT::Functions::GenericGridFunction<E, d> zero_vel(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{0., 0.}}; });
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    DynamicMatrix<D> result(2, 2, 0.);
+
+    for (const bool div_form : {true, false}) {
+      IntegrandType integrand(zero_vel, div_form);
+      integrand.bind(element);
+      const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
+      for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
+        integrand.evaluate(*scalar_test_, *scalar_ansatz_, qp.position(), result);
+        for (size_t ii = 0; ii < 2; ++ii)
+          for (size_t jj = 0; jj < 2; ++jj)
+            EXPECT_DOUBLE_EQ(0., result[ii][jj]);
+      }
+    }
+  }
+
+  virtual void clone_gives_same_results()
+  {
+    // clone via copy constructor and copy_as_binary_element_integrand should produce identical results
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        1,
+        [](const E&) {},
+        [](const DomainType& x, const XT::Common::Parameter&) { return FieldVector<D, d>{{x[0], x[1]}}; });
+    IntegrandType original(velocity, true);
+    IntegrandType copy_ctor(original);
+    auto cloned = original.copy_as_binary_element_integrand();
+
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    original.bind(element);
+    copy_ctor.bind(element);
+    cloned->bind(element);
+
+    const auto order = original.order(*scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> res_orig(2, 2, 0.), res_copy(2, 2, 0.), res_clone(2, 2, 0.);
+    for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
+      const auto& x = qp.position();
+      original.evaluate(*scalar_test_, *scalar_ansatz_, x, res_orig);
+      copy_ctor.evaluate(*scalar_test_, *scalar_ansatz_, x, res_copy);
+      cloned->evaluate(*scalar_test_, *scalar_ansatz_, x, res_clone);
+      for (size_t ii = 0; ii < 2; ++ii)
+        for (size_t jj = 0; jj < 2; ++jj) {
+          EXPECT_DOUBLE_EQ(res_orig[ii][jj], res_copy[ii][jj]);
+          EXPECT_DOUBLE_EQ(res_orig[ii][jj], res_clone[ii][jj]);
+        }
+    }
+  }
+
+  using BaseType::grid_provider_;
+  using BaseType::is_simplex_grid_;
+  using BaseType::scalar_ansatz_;
+  using BaseType::scalar_test_;
+  using BaseType::vector_ansatz_;
+  using BaseType::vector_test_;
+}; // struct LinearAdvectionIntegrandTest
+
+
+} // namespace Test
+} // namespace GDT
+} // namespace Dune
+
+
+template <class G>
+using LinearAdvectionIntegrandTest = Dune::GDT::Test::LinearAdvectionIntegrandTest<G>;
+TYPED_TEST_SUITE(LinearAdvectionIntegrandTest, Grids2D);
+
+TYPED_TEST(LinearAdvectionIntegrandTest, is_constructable)
+{
+  this->is_constructable();
+}
+
+TYPED_TEST(LinearAdvectionIntegrandTest, order_is_correct)
+{
+  this->order_is_correct();
+}
+
+TYPED_TEST(LinearAdvectionIntegrandTest, evaluates_correctly_divergence_form)
+{
+  this->evaluates_correctly_divergence_form();
+}
+
+TYPED_TEST(LinearAdvectionIntegrandTest, evaluates_correctly_non_divergence_form)
+{
+  this->evaluates_correctly_non_divergence_form();
+}
+
+TYPED_TEST(LinearAdvectionIntegrandTest, evaluates_correctly_with_variable_velocity)
+{
+  this->evaluates_correctly_with_variable_velocity();
+}
+
+TYPED_TEST(LinearAdvectionIntegrandTest, zero_velocity_gives_zero_result)
+{
+  this->zero_velocity_gives_zero_result();
+}
+
+TYPED_TEST(LinearAdvectionIntegrandTest, clone_gives_same_results)
+{
+  this->clone_gives_same_results();
+}

--- a/dune/gdt/test/integrands/integrands_linear_advection.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection.cc
@@ -86,6 +86,25 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     EXPECT_EQ(0 + 4 + 3, integrand_nodiv.order(*scalar_test_, *scalar_ansatz_));
   }
 
+  template <class CheckFn>
+  void eval_constant_velocity_form(bool div_form, CheckFn check)
+  {
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    IntegrandType integrand(velocity, div_form);
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    integrand.bind(element);
+    const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> result(2, 2, 0.);
+    for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+      check(x, result);
+    }
+  }
+
   void evaluates_correctly_divergence_form()
   {
     // velocity v = (1, 0) constant, divergence form
@@ -102,24 +121,13 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     //   [0][1] = -x^2*y * 0 = 0
     //   [1][0] = -x * y^3
     //   [1][1] = -x^2*y * y^3 = -x^2*y^4  (capturing current integrand behaviour)
-    const XT::Functions::GenericGridFunction<E, d> velocity(
-        0,
-        [](const E&) {},
-        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
-    IntegrandType integrand(velocity, /*advection_in_divergence_form=*/true);
-    const auto element = *(grid_provider_->leaf_view().template begin<0>());
-    integrand.bind(element);
-    const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
-    DynamicMatrix<D> result(2, 2, 0.);
-    for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
-      const auto& x = qp.position();
-      integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+    eval_constant_velocity_form(true, [](const DomainType& x, const DynamicMatrix<D>& result) {
       // row i = test function index, col j = ansatz function index
       EXPECT_NEAR(0., result[0][0], 1e-13);
       EXPECT_NEAR(0., result[0][1], 1e-13);
       EXPECT_NEAR(-x[0] * std::pow(x[1], 3), result[1][0], 1e-13);
       EXPECT_NEAR(-std::pow(x[0], 2) * x[1] * std::pow(x[1], 3), result[1][1], 1e-13);
-    }
+    });
   }
 
   void evaluates_correctly_non_divergence_form()
@@ -138,23 +146,12 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     //   [0][1] = 2xy * y = 2xy^2
     //   [1][0] = 1 * xy^3 = xy^3
     //   [1][1] = 2xy * xy^3 = 2x^2*y^4
-    const XT::Functions::GenericGridFunction<E, d> velocity(
-        0,
-        [](const E&) {},
-        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
-    IntegrandType integrand(velocity, /*advection_in_divergence_form=*/false);
-    const auto element = *(grid_provider_->leaf_view().template begin<0>());
-    integrand.bind(element);
-    const auto order = integrand.order(*scalar_test_, *scalar_ansatz_);
-    DynamicMatrix<D> result(2, 2, 0.);
-    for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
-      const auto& x = qp.position();
-      integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+    eval_constant_velocity_form(false, [](const DomainType& x, const DynamicMatrix<D>& result) {
       EXPECT_NEAR(x[1], result[0][0], 1e-13);
       EXPECT_NEAR(2. * x[0] * std::pow(x[1], 2), result[0][1], 1e-13);
       EXPECT_NEAR(x[0] * std::pow(x[1], 3), result[1][0], 1e-13);
       EXPECT_NEAR(2. * std::pow(x[0], 2) * std::pow(x[1], 4), result[1][1], 1e-13);
-    }
+    });
   }
 
   void evaluates_correctly_with_variable_velocity()

--- a/dune/gdt/test/integrands/integrands_linear_advection.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection.cc
@@ -59,7 +59,7 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     EXPECT_NE(nullptr, cloned);
   }
 
-  virtual void order_is_correct()
+  void order_is_correct()
   {
     // For constant direction (order 0): order = 0 + test.order + ansatz.order = 0 + 4 + 3 = 7
     const XT::Functions::GenericGridFunction<E, d> const_vel(
@@ -86,7 +86,7 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     EXPECT_EQ(0 + 4 + 3, integrand_nodiv.order(*scalar_test_, *scalar_ansatz_));
   }
 
-  virtual void evaluates_correctly_divergence_form()
+  void evaluates_correctly_divergence_form()
   {
     // velocity v = (1, 0) constant, divergence form
     // formula: result[i][j] = -ansatz_val[j] * (v . test_grad[i])
@@ -101,7 +101,7 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     //   [0][0] = -x * 0 = 0
     //   [0][1] = -x^2*y * 0 = 0
     //   [1][0] = -x * y^3
-    //   [1][1] = -x^2*y * y^4  <- NOTE: -x^2*y * y^3 = -x^2*y^4, todo verify this is correct behavior
+    //   [1][1] = -x^2*y * y^3 = -x^2*y^4  (capturing current integrand behaviour)
     const XT::Functions::GenericGridFunction<E, d> velocity(
         0,
         [](const E&) {},
@@ -122,7 +122,7 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     }
   }
 
-  virtual void evaluates_correctly_non_divergence_form()
+  void evaluates_correctly_non_divergence_form()
   {
     // velocity v = (1, 0) constant, non-divergence form
     // formula: result[i][j] = (v . ansatz_grad[j]) * test_val[i]
@@ -157,13 +157,13 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     }
   }
 
-  virtual void evaluates_correctly_with_variable_velocity()
+  void evaluates_correctly_with_variable_velocity()
   {
     // velocity v = (x, y) (order 1), tests both divergence and non-divergence forms
     //
     // Divergence form:
     //   v . test_grad[0] = (x,y).(0,1) = y
-    //   v . test_grad[1] = (x,y).(y^3, 3xy^2) = x*y^3 + 3xy^3 = 4xy^3  <- TODO verify
+    //   v . test_grad[1] = (x,y).(y^3, 3xy^2) = x*y^3 + 3xy^3 = 4xy^3
     //   result[i][j] = -ansatz[j] * (v . test_grad[i]):
     //     [0][0] = -x * y
     //     [0][1] = -x^2*y * y = -x^2*y^2
@@ -172,7 +172,7 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     //
     // Non-divergence form:
     //   v . ansatz_grad[0] = (x,y).(1,0) = x
-    //   v . ansatz_grad[1] = (x,y).(2xy, x^2) = 2x^2*y + x^2*y = 3x^2*y  <- TODO verify
+    //   v . ansatz_grad[1] = (x,y).(2xy, x^2) = 2x^2*y + x^2*y = 3x^2*y
     //   result[i][j] = (v . ansatz_grad[j]) * test[i]:
     //     [0][0] = x * y = xy
     //     [0][1] = 3x^2*y * y = 3x^2*y^2
@@ -218,7 +218,7 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
     }
   }
 
-  virtual void zero_velocity_gives_zero_result()
+  void zero_velocity_gives_zero_result()
   {
     // edge case: zero velocity => all results must be zero
     const XT::Functions::GenericGridFunction<E, d> zero_vel(
@@ -235,14 +235,15 @@ struct LinearAdvectionIntegrandTest : public IntegrandTest<G>
       for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), order)) {
         integrand.evaluate(*scalar_test_, *scalar_ansatz_, qp.position(), result);
         for (size_t ii = 0; ii < 2; ++ii) {
-          for (size_t jj = 0; jj < 2; ++jj)
+          for (size_t jj = 0; jj < 2; ++jj) {
             EXPECT_DOUBLE_EQ(0., result[ii][jj]);
+          }
         }
       }
     }
   }
 
-  virtual void clone_gives_same_results()
+  void clone_gives_same_results()
   {
     // clone via copy constructor and copy_as_binary_element_integrand should produce identical results
     const XT::Functions::GenericGridFunction<E, d> velocity(

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -216,8 +216,8 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
           const D a_out_0 = 2.;
           const D a_out_1 = 1. + x_out[0] * x_out[1];
 
-          assert_inner_coupling_result(v_dot_n, t_in_0, t_in_1, t_out_0, t_out_1, a_out_0, a_out_1,
-                                       res_ii, res_io, res_oi, res_oo);
+          assert_inner_coupling_result(
+              v_dot_n, t_in_0, t_in_1, t_out_0, t_out_1, a_out_0, a_out_1, res_ii, res_io, res_oi, res_oo);
         }
         break;
       }
@@ -265,8 +265,8 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
             const D t_out_0 = 1., t_out_1 = x_out[0] + x_out[1];
             const D a_out_0 = 2., a_out_1 = 1. + x_out[0] * x_out[1];
 
-            assert_inner_coupling_result(v_dot_n, t_in_0, t_in_1, t_out_0, t_out_1, a_out_0, a_out_1,
-                                         res_ii, res_io, res_oi, res_oo);
+            assert_inner_coupling_result(
+                v_dot_n, t_in_0, t_in_1, t_out_0, t_out_1, a_out_0, a_out_1, res_ii, res_io, res_oi, res_oo);
           }
         }
         break;
@@ -558,9 +558,17 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
   }
 
   // Shared assertion helper for InnerCoupling: checks all four result matrices at one quadrature point.
-  void assert_inner_coupling_result(D v_dot_n, D t_in_0, D t_in_1, D t_out_0, D t_out_1, D a_out_0, D a_out_1,
-                                    const DynamicMatrix<D>& res_ii, const DynamicMatrix<D>& res_io,
-                                    const DynamicMatrix<D>& res_oi, const DynamicMatrix<D>& res_oo)
+  void assert_inner_coupling_result(D v_dot_n,
+                                    D t_in_0,
+                                    D t_in_1,
+                                    D t_out_0,
+                                    D t_out_1,
+                                    D a_out_0,
+                                    D a_out_1,
+                                    const DynamicMatrix<D>& res_ii,
+                                    const DynamicMatrix<D>& res_io,
+                                    const DynamicMatrix<D>& res_oi,
+                                    const DynamicMatrix<D>& res_oo)
   {
     for (size_t ii = 0; ii < 2; ++ii)
       for (size_t jj = 0; jj < 2; ++jj) {

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -240,12 +240,17 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
           continue;
         found = true;
 
-        for (const D vx : {1., -1.}) {
+        // Use face_normal so velocity v = sign*face_normal guarantees v·n = sign != 0,
+        // ensuring both inflow and outflow branches are truly exercised.
+        const auto face_normal = intersection.unitOuterNormal(
+            Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), 1)[0].position());
+        for (const D sign : {1., -1.}) {
           const XT::Functions::GenericGridFunction<E, d> velocity(
               0,
               [](const E&) {},
-              // Lambda captures vx by value; capture list must be explicit.
-              [vx](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{vx, 0.}}; });
+              [face_normal, sign](const DomainType&, const XT::Common::Parameter&) {
+                return FieldVector<D, d>{{sign * face_normal[0], sign * face_normal[1]}};
+              });
           InnerCouplingType integrand(velocity);
           integrand.bind(intersection);
           const auto order = integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_);
@@ -255,8 +260,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
             const auto& x_ref = qp.position();
             const auto x_in = intersection.geometryInInside().global(x_ref);
             const auto x_out = intersection.geometryInOutside().global(x_ref);
-            const auto normal = intersection.unitOuterNormal(x_ref);
-            const D v_dot_n = vx * normal[0]; // v = (vx, 0)
+            const D v_dot_n = sign; // v = sign * face_normal => v·n = sign * |face_normal|^2 = sign
 
             integrand.evaluate(
                 *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, res_ii, res_io, res_oi, res_oo);
@@ -536,19 +540,25 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
         cloned_unary->bind(intersection);
         cloned_binary->bind(intersection);
 
-        // Compare binary results
+        // Compare binary and unary results across original, copy-constructor, and clones
         const auto order = original.order(*simple_test_, *simple_ansatz_);
         DynamicMatrix<D> r_orig(2, 2, 0.), r_copy(2, 2, 0.), r_clone(2, 2, 0.);
+        DynamicVector<D> u_orig(2, 0.), u_copy(2, 0.), u_clone(2, 0.);
         for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
           const auto& x_ref = qp.position();
           original.evaluate(*simple_test_, *simple_ansatz_, x_ref, r_orig);
           copy_ctor.evaluate(*simple_test_, *simple_ansatz_, x_ref, r_copy);
           cloned_binary->evaluate(*simple_test_, *simple_ansatz_, x_ref, r_clone);
+          original.evaluate(*simple_test_, x_ref, u_orig);
+          copy_ctor.evaluate(*simple_test_, x_ref, u_copy);
+          cloned_unary->evaluate(*simple_test_, x_ref, u_clone);
           for (size_t ii = 0; ii < 2; ++ii) {
             for (size_t jj = 0; jj < 2; ++jj) {
               EXPECT_DOUBLE_EQ(r_orig[ii][jj], r_copy[ii][jj]);
               EXPECT_DOUBLE_EQ(r_orig[ii][jj], r_clone[ii][jj]);
             }
+            EXPECT_DOUBLE_EQ(u_orig[ii], u_copy[ii]);
+            EXPECT_DOUBLE_EQ(u_orig[ii], u_clone[ii]);
           }
         }
         return;

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -216,25 +216,8 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
           const D a_out_0 = 2.;
           const D a_out_1 = 1. + x_out[0] * x_out[1];
 
-          // result_in_in and result_out_in must be zero (no inside-ansatz contribution)
-          for (size_t ii = 0; ii < 2; ++ii) {
-            for (size_t jj = 0; jj < 2; ++jj) {
-              EXPECT_NEAR(0., res_ii[ii][jj], 1e-13);
-              EXPECT_NEAR(0., res_oi[ii][jj], 1e-13);
-            }
-          }
-
-          // result_in_out[i][j] = (v.n) * ansatz_out[j] * test_in[i]
-          EXPECT_NEAR(v_dot_n * a_out_0 * t_in_0, res_io[0][0], 1e-13);
-          EXPECT_NEAR(v_dot_n * a_out_1 * t_in_0, res_io[0][1], 1e-13);
-          EXPECT_NEAR(v_dot_n * a_out_0 * t_in_1, res_io[1][0], 1e-13);
-          EXPECT_NEAR(v_dot_n * a_out_1 * t_in_1, res_io[1][1], 1e-13);
-
-          // result_out_out[i][j] = -(v.n) * ansatz_out[j] * test_out[i]
-          EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_0, res_oo[0][0], 1e-13);
-          EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_0, res_oo[0][1], 1e-13);
-          EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_1, res_oo[1][0], 1e-13);
-          EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_1, res_oo[1][1], 1e-13);
+          assert_inner_coupling_result(v_dot_n, t_in_0, t_in_1, t_out_0, t_out_1, a_out_0, a_out_1,
+                                       res_ii, res_io, res_oi, res_oo);
         }
         break;
       }
@@ -282,23 +265,8 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
             const D t_out_0 = 1., t_out_1 = x_out[0] + x_out[1];
             const D a_out_0 = 2., a_out_1 = 1. + x_out[0] * x_out[1];
 
-            // res_ii and res_oi must be zero (no inside-ansatz contribution)
-            for (size_t ii = 0; ii < 2; ++ii) {
-              for (size_t jj = 0; jj < 2; ++jj) {
-                EXPECT_NEAR(0., res_ii[ii][jj], 1e-13);
-                EXPECT_NEAR(0., res_oi[ii][jj], 1e-13);
-              }
-            }
-
-            EXPECT_NEAR(v_dot_n * a_out_0 * t_in_0, res_io[0][0], 1e-13);
-            EXPECT_NEAR(v_dot_n * a_out_1 * t_in_0, res_io[0][1], 1e-13);
-            EXPECT_NEAR(v_dot_n * a_out_0 * t_in_1, res_io[1][0], 1e-13);
-            EXPECT_NEAR(v_dot_n * a_out_1 * t_in_1, res_io[1][1], 1e-13);
-
-            EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_0, res_oo[0][0], 1e-13);
-            EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_0, res_oo[0][1], 1e-13);
-            EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_1, res_oo[1][0], 1e-13);
-            EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_1, res_oo[1][1], 1e-13);
+            assert_inner_coupling_result(v_dot_n, t_in_0, t_in_1, t_out_0, t_out_1, a_out_0, a_out_1,
+                                         res_ii, res_io, res_oi, res_oo);
           }
         }
         break;
@@ -587,6 +555,26 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
       }
     }
     ADD_FAILURE() << "No boundary intersection found in grid";
+  }
+
+  // Shared assertion helper for InnerCoupling: checks all four result matrices at one quadrature point.
+  void assert_inner_coupling_result(D v_dot_n, D t_in_0, D t_in_1, D t_out_0, D t_out_1, D a_out_0, D a_out_1,
+                                    const DynamicMatrix<D>& res_ii, const DynamicMatrix<D>& res_io,
+                                    const DynamicMatrix<D>& res_oi, const DynamicMatrix<D>& res_oo)
+  {
+    for (size_t ii = 0; ii < 2; ++ii)
+      for (size_t jj = 0; jj < 2; ++jj) {
+        EXPECT_NEAR(0., res_ii[ii][jj], 1e-13);
+        EXPECT_NEAR(0., res_oi[ii][jj], 1e-13);
+      }
+    EXPECT_NEAR(v_dot_n * a_out_0 * t_in_0, res_io[0][0], 1e-13);
+    EXPECT_NEAR(v_dot_n * a_out_1 * t_in_0, res_io[0][1], 1e-13);
+    EXPECT_NEAR(v_dot_n * a_out_0 * t_in_1, res_io[1][0], 1e-13);
+    EXPECT_NEAR(v_dot_n * a_out_1 * t_in_1, res_io[1][1], 1e-13);
+    EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_0, res_oo[0][0], 1e-13);
+    EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_0, res_oo[0][1], 1e-13);
+    EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_1, res_oo[1][0], 1e-13);
+    EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_1, res_oo[1][1], 1e-13);
   }
 
   using BaseType::grid_provider_;

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -157,9 +157,11 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
         found = true;
         integrand.bind(intersection);
         // direction order 0, simple_test_ order 1, simple_ansatz_ order 2
-        EXPECT_EQ(0 + 1 + std::max(2, 2), integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_));
+        EXPECT_EQ(0 + 1 + std::max(2, 2),
+                  integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_));
         // with fixture bases: direction 0, test 4, ansatz 3
-        EXPECT_EQ(0 + 4 + std::max(3, 3), integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
+        EXPECT_EQ(0 + 4 + std::max(3, 3),
+                  integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
         break;
       }
       if (found)
@@ -317,9 +319,15 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
         integrand.bind(intersection);
         const auto order = integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_);
         for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
-          integrand.evaluate(
-              *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, qp.position(), res_ii, res_io, res_oi,
-              res_oo);
+          integrand.evaluate(*simple_test_,
+                             *simple_ansatz_,
+                             *simple_test_,
+                             *simple_ansatz_,
+                             qp.position(),
+                             res_ii,
+                             res_io,
+                             res_oi,
+                             res_oo);
           for (size_t ii = 0; ii < 2; ++ii)
             for (size_t jj = 0; jj < 2; ++jj) {
               EXPECT_DOUBLE_EQ(0., res_ii[ii][jj]);
@@ -360,9 +368,12 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
 
         for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
           const auto& x_ref = qp.position();
-          original.evaluate(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_o, r_io_o, r_oi_o, r_oo_o);
-          copy_ctor.evaluate(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_c, r_io_c, r_oi_c, r_oo_c);
-          cloned->evaluate(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_l, r_io_l, r_oi_l, r_oo_l);
+          original.evaluate(
+              *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_o, r_io_o, r_oi_o, r_oo_o);
+          copy_ctor.evaluate(
+              *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_c, r_io_c, r_oi_c, r_oo_c);
+          cloned->evaluate(
+              *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_l, r_io_l, r_oi_l, r_oo_l);
 
           for (size_t ii = 0; ii < 2; ++ii)
             for (size_t jj = 0; jj < 2; ++jj) {
@@ -527,9 +538,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
         [](const E&) {},
         [](const DomainType& x, const XT::Common::Parameter&) { return FieldVector<D, d>{{x[0], x[1]}}; });
     const XT::Functions::GenericGridFunction<E, 1> dirichlet_gf(
-        1,
-        [](const E&) {},
-        [](const DomainType& x, const XT::Common::Parameter&) -> D { return x[0] + x[1]; });
+        1, [](const E&) {}, [](const DomainType& x, const XT::Common::Parameter&) -> D { return x[0] + x[1]; });
     DirichletCouplingType original(velocity, dirichlet_gf);
     DirichletCouplingType copy_ctor(original);
     auto cloned_unary = original.copy_as_unary_intersection_integrand();

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -1,0 +1,642 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/geometry/quadraturerules.hh>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/functions/generic/function.hh>
+#include <dune/xt/functions/generic/grid-function.hh>
+
+#include <dune/gdt/local/integrands/linear-advection-upwind.hh>
+
+#include <dune/gdt/test/integrands/integrands.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Test {
+
+
+template <class G>
+struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
+{
+  using BaseType = IntegrandTest<G>;
+  using BaseType::d;
+  using typename BaseType::D;
+  using typename BaseType::DomainType;
+  using typename BaseType::E;
+  using typename BaseType::GV;
+  using typename BaseType::I;
+  using typename BaseType::LocalScalarBasisType;
+  using typename BaseType::ScalarJacobianType;
+  using typename BaseType::ScalarRangeType;
+  using InnerCouplingType = LocalLinearAdvectionUpwindIntegrands::InnerCoupling<I>;
+  using DirichletCouplingType = LocalLinearAdvectionUpwindIntegrands::DirichletCoupling<I>;
+
+  // Basis functions non-zero on every face of the reference element.
+  // simple_test_:   { 1,   x[0]+x[1]       }  (order 1)
+  // simple_ansatz_: { 2,   1+x[0]*x[1]     }  (order 2)
+  // Used for intersection tests to avoid zero results at element boundaries.
+  std::shared_ptr<LocalScalarBasisType> simple_test_;
+  std::shared_ptr<LocalScalarBasisType> simple_ansatz_;
+
+  void SetUp() override
+  {
+    BaseType::SetUp();
+    simple_test_ = std::make_shared<LocalScalarBasisType>(
+        2,
+        1,
+        [](const DomainType& x, std::vector<ScalarRangeType>& ret, const XT::Common::Parameter&) {
+          ret.resize(2);
+          ret[0] = {1.};
+          ret[1] = {x[0] + x[1]};
+        },
+        XT::Common::ParameterType{},
+        [](const DomainType& x, std::vector<ScalarJacobianType>& ret, const XT::Common::Parameter&) {
+          ret.resize(2);
+          ret[0][0] = {0., 0.};
+          ret[1][0] = {1., 1.};
+        });
+    simple_ansatz_ = std::make_shared<LocalScalarBasisType>(
+        2,
+        2,
+        [](const DomainType& x, std::vector<ScalarRangeType>& ret, const XT::Common::Parameter&) {
+          ret.resize(2);
+          ret[0] = {2.};
+          ret[1] = {1. + x[0] * x[1]};
+        },
+        XT::Common::ParameterType{},
+        [](const DomainType& x, std::vector<ScalarJacobianType>& ret, const XT::Common::Parameter&) {
+          ret.resize(2);
+          ret[0][0] = {0., 0.};
+          ret[1][0] = {x[1], x[0]};
+        });
+  }
+
+  void is_constructable() override final
+  {
+    const XT::Functions::GenericGridFunction<E, d> velocity_gf(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    const XT::Functions::GenericFunction<d, d> velocity_func(
+        0, [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    const XT::Functions::GenericGridFunction<E, 1> dirichlet_gf(
+        0, [](const E&) {}, [](const DomainType&, const XT::Common::Parameter&) -> D { return 42.; });
+
+    // InnerCoupling: grid-function and static-function velocities
+    [[maybe_unused]] InnerCouplingType inner1(velocity_gf);
+    [[maybe_unused]] InnerCouplingType inner2(velocity_func);
+    // InnerCoupling: copy constructor
+    [[maybe_unused]] InnerCouplingType inner3(inner1);
+    // InnerCoupling: copy_as_quaternary_intersection_integrand
+    auto cloned_inner = inner1.copy_as_quaternary_intersection_integrand();
+    EXPECT_NE(nullptr, cloned_inner);
+
+    // DirichletCoupling: grid-function velocity, with and without dirichlet data
+    [[maybe_unused]] DirichletCouplingType dirichlet1(velocity_gf);
+    [[maybe_unused]] DirichletCouplingType dirichlet2(velocity_gf, 0.);
+    [[maybe_unused]] DirichletCouplingType dirichlet3(velocity_gf, dirichlet_gf);
+    // DirichletCoupling: static-function velocity
+    [[maybe_unused]] DirichletCouplingType dirichlet4(velocity_func);
+    // DirichletCoupling: copy constructor
+    [[maybe_unused]] DirichletCouplingType dirichlet5(dirichlet1);
+    // DirichletCoupling: copy_as_unary and copy_as_binary
+    auto cloned_unary = dirichlet1.copy_as_unary_intersection_integrand();
+    EXPECT_NE(nullptr, cloned_unary);
+    auto cloned_binary = dirichlet1.copy_as_binary_intersection_integrand();
+    EXPECT_NE(nullptr, cloned_binary);
+  }
+
+  virtual void inner_coupling_throws_on_boundary_intersection()
+  {
+    // InnerCoupling::post_bind() must throw when given a boundary intersection.
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    InnerCouplingType integrand(velocity);
+    const auto& gv = grid_provider_->leaf_view();
+    bool found = false;
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (intersection.neighbor())
+          continue;
+        found = true;
+        EXPECT_THROW(integrand.bind(intersection), Dune::Exception);
+        break;
+      }
+      if (found)
+        break;
+    }
+    EXPECT_TRUE(found) << "No boundary intersection found — test is vacuous";
+  }
+
+  virtual void inner_coupling_order_is_correct()
+  {
+    // order = direction.order + test_inside.order + max(ansatz_inside.order, ansatz_outside.order)
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    InnerCouplingType integrand(velocity);
+    const auto& gv = grid_provider_->leaf_view();
+    bool found = false;
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (!intersection.neighbor())
+          continue;
+        found = true;
+        integrand.bind(intersection);
+        // direction order 0, simple_test_ order 1, simple_ansatz_ order 2
+        EXPECT_EQ(0 + 1 + std::max(2, 2), integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_));
+        // with fixture bases: direction 0, test 4, ansatz 3
+        EXPECT_EQ(0 + 4 + std::max(3, 3), integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
+        break;
+      }
+      if (found)
+        break;
+    }
+    EXPECT_TRUE(found) << "No interior intersection found in grid";
+  }
+
+  virtual void inner_coupling_evaluates_correctly()
+  {
+    // For the InnerCoupling formula (computed on an interior intersection):
+    //   result_in_in  = 0
+    //   result_out_in = 0
+    //   result_in_out[i][j]  =  (v.n) * ansatz_out[j](x_out) * test_in[i](x_in)
+    //   result_out_out[i][j] = -(v.n) * ansatz_out[j](x_out) * test_out[i](x_out)
+    //
+    // simple_test_   = { 1, x[0]+x[1] }  evaluated at x_in or x_out
+    // simple_ansatz_ = { 2, 1+x[0]*x[1] } evaluated at x_out
+    // velocity v = (1, 1)
+    //
+    // We verify the formula for all quadrature points on the first interior intersection.
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 1.}}; });
+    InnerCouplingType integrand(velocity);
+    const auto& gv = grid_provider_->leaf_view();
+    bool found = false;
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (!intersection.neighbor())
+          continue;
+        found = true;
+        integrand.bind(intersection);
+        const auto order = integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_);
+        DynamicMatrix<D> res_ii(2, 2, 0.), res_io(2, 2, 0.), res_oi(2, 2, 0.), res_oo(2, 2, 0.);
+
+        for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+          const auto& x_ref = qp.position();
+          const auto x_in = intersection.geometryInInside().global(x_ref);
+          const auto x_out = intersection.geometryInOutside().global(x_ref);
+          const auto normal = intersection.unitOuterNormal(x_ref);
+          const D v_dot_n = normal[0] + normal[1]; // v = (1,1)
+
+          integrand.evaluate(
+              *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, res_ii, res_io, res_oi, res_oo);
+
+          // test values at inside and outside reference points
+          const D t_in_0 = 1.;
+          const D t_in_1 = x_in[0] + x_in[1];
+          const D t_out_0 = 1.;
+          const D t_out_1 = x_out[0] + x_out[1];
+          // ansatz values at outside reference point
+          const D a_out_0 = 2.;
+          const D a_out_1 = 1. + x_out[0] * x_out[1];
+
+          // result_in_in and result_out_in must be zero (no inside-ansatz contribution)
+          for (size_t ii = 0; ii < 2; ++ii)
+            for (size_t jj = 0; jj < 2; ++jj) {
+              EXPECT_NEAR(0., res_ii[ii][jj], 1e-13);
+              EXPECT_NEAR(0., res_oi[ii][jj], 1e-13);
+            }
+
+          // result_in_out[i][j] = (v.n) * ansatz_out[j] * test_in[i]
+          EXPECT_NEAR(v_dot_n * a_out_0 * t_in_0, res_io[0][0], 1e-13);
+          EXPECT_NEAR(v_dot_n * a_out_1 * t_in_0, res_io[0][1], 1e-13);
+          EXPECT_NEAR(v_dot_n * a_out_0 * t_in_1, res_io[1][0], 1e-13);
+          EXPECT_NEAR(v_dot_n * a_out_1 * t_in_1, res_io[1][1], 1e-13);
+
+          // result_out_out[i][j] = -(v.n) * ansatz_out[j] * test_out[i]
+          EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_0, res_oo[0][0], 1e-13);
+          EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_0, res_oo[0][1], 1e-13);
+          EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_1, res_oo[1][0], 1e-13);
+          EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_1, res_oo[1][1], 1e-13);
+        }
+        break;
+      }
+      if (found)
+        break;
+    }
+    EXPECT_TRUE(found) << "No interior intersection found in grid!";
+  }
+
+  virtual void inner_coupling_covers_both_sign_orientations()
+  {
+    // Test with v=(1,0) and v=(-1,0) on the same interior intersection so that
+    // both v.n > 0 (outflow) and v.n < 0 (inflow) orientations are exercised.
+    // The InnerCoupling formula is the same regardless of sign; only (v.n) changes.
+    const auto& gv = grid_provider_->leaf_view();
+    bool found = false;
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (!intersection.neighbor())
+          continue;
+        found = true;
+
+        for (const D vx : {1., -1.}) {
+          const XT::Functions::GenericGridFunction<E, d> velocity(
+              0,
+              [](const E&) {},
+              // Lambda captures vx by value; capture list must be explicit.
+              [vx](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{vx, 0.}}; });
+          InnerCouplingType integrand(velocity);
+          integrand.bind(intersection);
+          const auto order = integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_);
+          DynamicMatrix<D> res_ii(2, 2, 0.), res_io(2, 2, 0.), res_oi(2, 2, 0.), res_oo(2, 2, 0.);
+
+          for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+            const auto& x_ref = qp.position();
+            const auto x_in = intersection.geometryInInside().global(x_ref);
+            const auto x_out = intersection.geometryInOutside().global(x_ref);
+            const auto normal = intersection.unitOuterNormal(x_ref);
+            const D v_dot_n = vx * normal[0]; // v = (vx, 0)
+
+            integrand.evaluate(
+                *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, res_ii, res_io, res_oi, res_oo);
+
+            const D t_in_0 = 1., t_in_1 = x_in[0] + x_in[1];
+            const D t_out_0 = 1., t_out_1 = x_out[0] + x_out[1];
+            const D a_out_0 = 2., a_out_1 = 1. + x_out[0] * x_out[1];
+
+            EXPECT_NEAR(v_dot_n * a_out_0 * t_in_0, res_io[0][0], 1e-13);
+            EXPECT_NEAR(v_dot_n * a_out_1 * t_in_0, res_io[0][1], 1e-13);
+            EXPECT_NEAR(v_dot_n * a_out_0 * t_in_1, res_io[1][0], 1e-13);
+            EXPECT_NEAR(v_dot_n * a_out_1 * t_in_1, res_io[1][1], 1e-13);
+
+            EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_0, res_oo[0][0], 1e-13);
+            EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_0, res_oo[0][1], 1e-13);
+            EXPECT_NEAR(-v_dot_n * a_out_0 * t_out_1, res_oo[1][0], 1e-13);
+            EXPECT_NEAR(-v_dot_n * a_out_1 * t_out_1, res_oo[1][1], 1e-13);
+          }
+        }
+        break;
+      }
+      if (found)
+        break;
+    }
+    EXPECT_TRUE(found) << "No interior intersection found in grid!";
+  }
+
+  virtual void inner_coupling_with_zero_velocity_gives_zero()
+  {
+    // Edge case: v = 0 => v.n = 0 for all intersections => all result matrices are zero.
+    const XT::Functions::GenericGridFunction<E, d> zero_vel(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{0., 0.}}; });
+    InnerCouplingType integrand(zero_vel);
+    const auto& gv = grid_provider_->leaf_view();
+    DynamicMatrix<D> res_ii(2, 2, 0.), res_io(2, 2, 0.), res_oi(2, 2, 0.), res_oo(2, 2, 0.);
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (!intersection.neighbor())
+          continue;
+        integrand.bind(intersection);
+        const auto order = integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_);
+        for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+          integrand.evaluate(
+              *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, qp.position(), res_ii, res_io, res_oi,
+              res_oo);
+          for (size_t ii = 0; ii < 2; ++ii)
+            for (size_t jj = 0; jj < 2; ++jj) {
+              EXPECT_DOUBLE_EQ(0., res_ii[ii][jj]);
+              EXPECT_DOUBLE_EQ(0., res_io[ii][jj]);
+              EXPECT_DOUBLE_EQ(0., res_oi[ii][jj]);
+              EXPECT_DOUBLE_EQ(0., res_oo[ii][jj]);
+            }
+        }
+        return; // one intersection is enough
+      }
+    }
+  }
+
+  virtual void inner_coupling_clone_gives_same_results()
+  {
+    // copy constructor and copy_as_quaternary_intersection_integrand should produce identical results
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        1,
+        [](const E&) {},
+        [](const DomainType& x, const XT::Common::Parameter&) { return FieldVector<D, d>{{x[0], x[1]}}; });
+    InnerCouplingType original(velocity);
+    InnerCouplingType copy_ctor(original);
+    auto cloned = original.copy_as_quaternary_intersection_integrand();
+
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (!intersection.neighbor())
+          continue;
+        original.bind(intersection);
+        copy_ctor.bind(intersection);
+        cloned->bind(intersection);
+
+        const auto order = original.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_);
+        DynamicMatrix<D> r_ii_o(2, 2, 0.), r_io_o(2, 2, 0.), r_oi_o(2, 2, 0.), r_oo_o(2, 2, 0.);
+        DynamicMatrix<D> r_ii_c(2, 2, 0.), r_io_c(2, 2, 0.), r_oi_c(2, 2, 0.), r_oo_c(2, 2, 0.);
+        DynamicMatrix<D> r_ii_l(2, 2, 0.), r_io_l(2, 2, 0.), r_oi_l(2, 2, 0.), r_oo_l(2, 2, 0.);
+
+        for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+          const auto& x_ref = qp.position();
+          original.evaluate(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_o, r_io_o, r_oi_o, r_oo_o);
+          copy_ctor.evaluate(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_c, r_io_c, r_oi_c, r_oo_c);
+          cloned->evaluate(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_l, r_io_l, r_oi_l, r_oo_l);
+
+          for (size_t ii = 0; ii < 2; ++ii)
+            for (size_t jj = 0; jj < 2; ++jj) {
+              EXPECT_DOUBLE_EQ(r_io_o[ii][jj], r_io_c[ii][jj]);
+              EXPECT_DOUBLE_EQ(r_io_o[ii][jj], r_io_l[ii][jj]);
+              EXPECT_DOUBLE_EQ(r_oo_o[ii][jj], r_oo_c[ii][jj]);
+              EXPECT_DOUBLE_EQ(r_oo_o[ii][jj], r_oo_l[ii][jj]);
+            }
+        }
+        return;
+      }
+    }
+    ADD_FAILURE() << "No interior intersection found in grid";
+  }
+
+  virtual void dirichlet_coupling_inside_is_true()
+  {
+    // DirichletCoupling::inside() always returns true
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 0.}}; });
+    DirichletCouplingType integrand(velocity);
+    EXPECT_TRUE(integrand.inside());
+  }
+
+  virtual void dirichlet_coupling_evaluates_binary_correctly()
+  {
+    // DirichletCoupling binary evaluate on a boundary intersection:
+    //   result[i][j] = (v.n) * ansatz[j](x_in) * test[i](x_in)
+    // Both test and ansatz are evaluated at the inside reference point x_in.
+    //
+    // simple_test_   = { 1,   x_in[0]+x_in[1]   }
+    // simple_ansatz_ = { 2,   1+x_in[0]*x_in[1] }
+    // velocity v = (1,1)
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 1.}}; });
+    DirichletCouplingType integrand(velocity);
+    const auto& gv = grid_provider_->leaf_view();
+    bool found = false;
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (intersection.neighbor())
+          continue;
+        found = true;
+        integrand.bind(intersection);
+        const auto order = integrand.order(*simple_test_, *simple_ansatz_);
+        DynamicMatrix<D> result(2, 2, 0.);
+
+        for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+          const auto& x_ref = qp.position();
+          const auto x_in = intersection.geometryInInside().global(x_ref);
+          const auto normal = intersection.unitOuterNormal(x_ref);
+          const D v_dot_n = normal[0] + normal[1]; // v = (1,1)
+
+          integrand.evaluate(*simple_test_, *simple_ansatz_, x_ref, result);
+
+          // Both test and ansatz evaluated at x_in
+          const D t_0 = 1.;
+          const D t_1 = x_in[0] + x_in[1];
+          const D a_0 = 2.;
+          const D a_1 = 1. + x_in[0] * x_in[1];
+
+          EXPECT_NEAR(v_dot_n * a_0 * t_0, result[0][0], 1e-13);
+          EXPECT_NEAR(v_dot_n * a_1 * t_0, result[0][1], 1e-13);
+          EXPECT_NEAR(v_dot_n * a_0 * t_1, result[1][0], 1e-13);
+          EXPECT_NEAR(v_dot_n * a_1 * t_1, result[1][1], 1e-13);
+        }
+        break;
+      }
+      if (found)
+        break;
+    }
+    EXPECT_TRUE(found) << "No boundary intersection found in grid";
+  }
+
+  virtual void dirichlet_coupling_evaluates_unary_correctly()
+  {
+    // DirichletCoupling unary evaluate on a boundary intersection:
+    //   result[j] = (v.n) * dirichlet_data * test[j](x_in)
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{1., 1.}}; });
+    const D dirichlet_val = 3.;
+    const XT::Functions::GenericGridFunction<E, 1> dirichlet_gf(
+        0,
+        [](const E&) {},
+        [dirichlet_val](const DomainType&, const XT::Common::Parameter&) -> D { return dirichlet_val; });
+    DirichletCouplingType integrand(velocity, dirichlet_gf);
+    const auto& gv = grid_provider_->leaf_view();
+    bool found = false;
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (intersection.neighbor())
+          continue;
+        found = true;
+        integrand.bind(intersection);
+        const auto order = integrand.order(*simple_test_);
+        DynamicVector<D> result(2, 0.);
+
+        for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+          const auto& x_ref = qp.position();
+          const auto x_in = intersection.geometryInInside().global(x_ref);
+          const auto normal = intersection.unitOuterNormal(x_ref);
+          const D v_dot_n = normal[0] + normal[1];
+
+          integrand.evaluate(*simple_test_, x_ref, result);
+
+          const D t_0 = 1.;
+          const D t_1 = x_in[0] + x_in[1];
+
+          EXPECT_NEAR(v_dot_n * dirichlet_val * t_0, result[0], 1e-13);
+          EXPECT_NEAR(v_dot_n * dirichlet_val * t_1, result[1], 1e-13);
+        }
+        break;
+      }
+      if (found)
+        break;
+    }
+    EXPECT_TRUE(found) << "No boundary intersection found in grid";
+  }
+
+  virtual void dirichlet_coupling_with_zero_velocity_gives_zero()
+  {
+    // Edge case: v = 0 => all results are zero
+    const XT::Functions::GenericGridFunction<E, d> zero_vel(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) { return FieldVector<D, d>{{0., 0.}}; });
+    DirichletCouplingType integrand(zero_vel, 5.);
+    const auto& gv = grid_provider_->leaf_view();
+    DynamicMatrix<D> bin_result(2, 2, 0.);
+    DynamicVector<D> un_result(2, 0.);
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (intersection.neighbor())
+          continue;
+        integrand.bind(intersection);
+        const auto order = integrand.order(*simple_test_, *simple_ansatz_);
+        for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+          integrand.evaluate(*simple_test_, *simple_ansatz_, qp.position(), bin_result);
+          integrand.evaluate(*simple_test_, qp.position(), un_result);
+          for (size_t ii = 0; ii < 2; ++ii) {
+            EXPECT_DOUBLE_EQ(0., un_result[ii]);
+            for (size_t jj = 0; jj < 2; ++jj)
+              EXPECT_DOUBLE_EQ(0., bin_result[ii][jj]);
+          }
+        }
+        return;
+      }
+    }
+  }
+
+  virtual void dirichlet_coupling_clone_gives_same_results()
+  {
+    // copy constructor and copy_as_* should produce identical binary evaluate results
+    const XT::Functions::GenericGridFunction<E, d> velocity(
+        1,
+        [](const E&) {},
+        [](const DomainType& x, const XT::Common::Parameter&) { return FieldVector<D, d>{{x[0], x[1]}}; });
+    const XT::Functions::GenericGridFunction<E, 1> dirichlet_gf(
+        1,
+        [](const E&) {},
+        [](const DomainType& x, const XT::Common::Parameter&) -> D { return x[0] + x[1]; });
+    DirichletCouplingType original(velocity, dirichlet_gf);
+    DirichletCouplingType copy_ctor(original);
+    auto cloned_unary = original.copy_as_unary_intersection_integrand();
+    auto cloned_binary = original.copy_as_binary_intersection_integrand();
+
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : elements(gv)) {
+      for (const auto& intersection : intersections(gv, element)) {
+        if (intersection.neighbor())
+          continue;
+        original.bind(intersection);
+        copy_ctor.bind(intersection);
+        cloned_unary->bind(intersection);
+        cloned_binary->bind(intersection);
+
+        // Compare binary results
+        const auto order = original.order(*simple_test_, *simple_ansatz_);
+        DynamicMatrix<D> r_orig(2, 2, 0.), r_copy(2, 2, 0.), r_clone(2, 2, 0.);
+        for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), std::max(order, 2))) {
+          const auto& x_ref = qp.position();
+          original.evaluate(*simple_test_, *simple_ansatz_, x_ref, r_orig);
+          copy_ctor.evaluate(*simple_test_, *simple_ansatz_, x_ref, r_copy);
+          cloned_binary->evaluate(*simple_test_, *simple_ansatz_, x_ref, r_clone);
+          for (size_t ii = 0; ii < 2; ++ii)
+            for (size_t jj = 0; jj < 2; ++jj) {
+              EXPECT_DOUBLE_EQ(r_orig[ii][jj], r_copy[ii][jj]);
+              EXPECT_DOUBLE_EQ(r_orig[ii][jj], r_clone[ii][jj]);
+            }
+        }
+        return;
+      }
+    }
+    ADD_FAILURE() << "No boundary intersection found in grid";
+  }
+
+  using BaseType::grid_provider_;
+  using BaseType::is_simplex_grid_;
+  using BaseType::scalar_ansatz_;
+  using BaseType::scalar_test_;
+}; // struct LinearAdvectionUpwindIntegrandTest
+
+
+} // namespace Test
+} // namespace GDT
+} // namespace Dune
+
+
+template <class G>
+using LinearAdvectionUpwindIntegrandTest = Dune::GDT::Test::LinearAdvectionUpwindIntegrandTest<G>;
+TYPED_TEST_SUITE(LinearAdvectionUpwindIntegrandTest, Grids2D);
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, is_constructable)
+{
+  this->is_constructable();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, inner_coupling_throws_on_boundary_intersection)
+{
+  this->inner_coupling_throws_on_boundary_intersection();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, inner_coupling_order_is_correct)
+{
+  this->inner_coupling_order_is_correct();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, inner_coupling_evaluates_correctly)
+{
+  this->inner_coupling_evaluates_correctly();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, inner_coupling_covers_both_sign_orientations)
+{
+  this->inner_coupling_covers_both_sign_orientations();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, inner_coupling_with_zero_velocity_gives_zero)
+{
+  this->inner_coupling_with_zero_velocity_gives_zero();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, inner_coupling_clone_gives_same_results)
+{
+  this->inner_coupling_clone_gives_same_results();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, dirichlet_coupling_inside_is_true)
+{
+  this->dirichlet_coupling_inside_is_true();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, dirichlet_coupling_evaluates_binary_correctly)
+{
+  this->dirichlet_coupling_evaluates_binary_correctly();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, dirichlet_coupling_evaluates_unary_correctly)
+{
+  this->dirichlet_coupling_evaluates_unary_correctly();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, dirichlet_coupling_with_zero_velocity_gives_zero)
+{
+  this->dirichlet_coupling_with_zero_velocity_gives_zero();
+}
+
+TYPED_TEST(LinearAdvectionUpwindIntegrandTest, dirichlet_coupling_clone_gives_same_results)
+{
+  this->dirichlet_coupling_clone_gives_same_results();
+}

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -157,11 +157,9 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
         found = true;
         integrand.bind(intersection);
         // direction order 0, simple_test_ order 1, simple_ansatz_ order 2
-        EXPECT_EQ(0 + 1 + std::max(2, 2),
-                  integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_));
+        EXPECT_EQ(0 + 1 + 2, integrand.order(*simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_));
         // with fixture bases: direction 0, test 4, ansatz 3
-        EXPECT_EQ(0 + 4 + std::max(3, 3),
-                  integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
+        EXPECT_EQ(0 + 4 + 3, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
         break;
       }
       if (found)
@@ -219,11 +217,12 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
           const D a_out_1 = 1. + x_out[0] * x_out[1];
 
           // result_in_in and result_out_in must be zero (no inside-ansatz contribution)
-          for (size_t ii = 0; ii < 2; ++ii)
+          for (size_t ii = 0; ii < 2; ++ii) {
             for (size_t jj = 0; jj < 2; ++jj) {
               EXPECT_NEAR(0., res_ii[ii][jj], 1e-13);
               EXPECT_NEAR(0., res_oi[ii][jj], 1e-13);
             }
+          }
 
           // result_in_out[i][j] = (v.n) * ansatz_out[j] * test_in[i]
           EXPECT_NEAR(v_dot_n * a_out_0 * t_in_0, res_io[0][0], 1e-13);
@@ -328,13 +327,14 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
                              res_io,
                              res_oi,
                              res_oo);
-          for (size_t ii = 0; ii < 2; ++ii)
+          for (size_t ii = 0; ii < 2; ++ii) {
             for (size_t jj = 0; jj < 2; ++jj) {
               EXPECT_DOUBLE_EQ(0., res_ii[ii][jj]);
               EXPECT_DOUBLE_EQ(0., res_io[ii][jj]);
               EXPECT_DOUBLE_EQ(0., res_oi[ii][jj]);
               EXPECT_DOUBLE_EQ(0., res_oo[ii][jj]);
             }
+          }
         }
         return; // one intersection is enough
       }
@@ -375,13 +375,14 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
           cloned->evaluate(
               *simple_test_, *simple_ansatz_, *simple_test_, *simple_ansatz_, x_ref, r_ii_l, r_io_l, r_oi_l, r_oo_l);
 
-          for (size_t ii = 0; ii < 2; ++ii)
+          for (size_t ii = 0; ii < 2; ++ii) {
             for (size_t jj = 0; jj < 2; ++jj) {
               EXPECT_DOUBLE_EQ(r_io_o[ii][jj], r_io_c[ii][jj]);
               EXPECT_DOUBLE_EQ(r_io_o[ii][jj], r_io_l[ii][jj]);
               EXPECT_DOUBLE_EQ(r_oo_o[ii][jj], r_oo_c[ii][jj]);
               EXPECT_DOUBLE_EQ(r_oo_o[ii][jj], r_oo_l[ii][jj]);
             }
+          }
         }
         return;
       }
@@ -562,11 +563,12 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
           original.evaluate(*simple_test_, *simple_ansatz_, x_ref, r_orig);
           copy_ctor.evaluate(*simple_test_, *simple_ansatz_, x_ref, r_copy);
           cloned_binary->evaluate(*simple_test_, *simple_ansatz_, x_ref, r_clone);
-          for (size_t ii = 0; ii < 2; ++ii)
+          for (size_t ii = 0; ii < 2; ++ii) {
             for (size_t jj = 0; jj < 2; ++jj) {
               EXPECT_DOUBLE_EQ(r_orig[ii][jj], r_copy[ii][jj]);
               EXPECT_DOUBLE_EQ(r_orig[ii][jj], r_clone[ii][jj]);
             }
+          }
         }
         return;
       }

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -282,6 +282,14 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
             const D t_out_0 = 1., t_out_1 = x_out[0] + x_out[1];
             const D a_out_0 = 2., a_out_1 = 1. + x_out[0] * x_out[1];
 
+            // res_ii and res_oi must be zero (no inside-ansatz contribution)
+            for (size_t ii = 0; ii < 2; ++ii) {
+              for (size_t jj = 0; jj < 2; ++jj) {
+                EXPECT_NEAR(0., res_ii[ii][jj], 1e-13);
+                EXPECT_NEAR(0., res_oi[ii][jj], 1e-13);
+              }
+            }
+
             EXPECT_NEAR(v_dot_n * a_out_0 * t_in_0, res_io[0][0], 1e-13);
             EXPECT_NEAR(v_dot_n * a_out_1 * t_in_0, res_io[0][1], 1e-13);
             EXPECT_NEAR(v_dot_n * a_out_0 * t_in_1, res_io[1][0], 1e-13);
@@ -377,8 +385,12 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
 
           for (size_t ii = 0; ii < 2; ++ii) {
             for (size_t jj = 0; jj < 2; ++jj) {
+              EXPECT_DOUBLE_EQ(r_ii_o[ii][jj], r_ii_c[ii][jj]);
+              EXPECT_DOUBLE_EQ(r_ii_o[ii][jj], r_ii_l[ii][jj]);
               EXPECT_DOUBLE_EQ(r_io_o[ii][jj], r_io_c[ii][jj]);
               EXPECT_DOUBLE_EQ(r_io_o[ii][jj], r_io_l[ii][jj]);
+              EXPECT_DOUBLE_EQ(r_oi_o[ii][jj], r_oi_c[ii][jj]);
+              EXPECT_DOUBLE_EQ(r_oi_o[ii][jj], r_oi_l[ii][jj]);
               EXPECT_DOUBLE_EQ(r_oo_o[ii][jj], r_oo_c[ii][jj]);
               EXPECT_DOUBLE_EQ(r_oo_o[ii][jj], r_oo_l[ii][jj]);
             }

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -116,7 +116,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_NE(nullptr, cloned_binary);
   }
 
-  virtual void inner_coupling_throws_on_boundary_intersection()
+  void inner_coupling_throws_on_boundary_intersection()
   {
     // InnerCoupling::post_bind() must throw when given a boundary intersection.
     const XT::Functions::GenericGridFunction<E, d> velocity(
@@ -140,7 +140,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_TRUE(found) << "No boundary intersection found — test is vacuous";
   }
 
-  virtual void inner_coupling_order_is_correct()
+  void inner_coupling_order_is_correct()
   {
     // order = direction.order + test_inside.order + max(ansatz_inside.order, ansatz_outside.order)
     const XT::Functions::GenericGridFunction<E, d> velocity(
@@ -168,7 +168,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_TRUE(found) << "No interior intersection found in grid";
   }
 
-  virtual void inner_coupling_evaluates_correctly()
+  void inner_coupling_evaluates_correctly()
   {
     // For the InnerCoupling formula (computed on an interior intersection):
     //   result_in_in  = 0
@@ -244,7 +244,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_TRUE(found) << "No interior intersection found in grid!";
   }
 
-  virtual void inner_coupling_covers_both_sign_orientations()
+  void inner_coupling_covers_both_sign_orientations()
   {
     // Test with v=(1,0) and v=(-1,0) on the same interior intersection so that
     // both v.n > 0 (outflow) and v.n < 0 (inflow) orientations are exercised.
@@ -301,7 +301,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_TRUE(found) << "No interior intersection found in grid!";
   }
 
-  virtual void inner_coupling_with_zero_velocity_gives_zero()
+  void inner_coupling_with_zero_velocity_gives_zero()
   {
     // Edge case: v = 0 => v.n = 0 for all intersections => all result matrices are zero.
     const XT::Functions::GenericGridFunction<E, d> zero_vel(
@@ -341,7 +341,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     }
   }
 
-  virtual void inner_coupling_clone_gives_same_results()
+  void inner_coupling_clone_gives_same_results()
   {
     // copy constructor and copy_as_quaternary_intersection_integrand should produce identical results
     const XT::Functions::GenericGridFunction<E, d> velocity(
@@ -390,7 +390,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     ADD_FAILURE() << "No interior intersection found in grid";
   }
 
-  virtual void dirichlet_coupling_inside_is_true()
+  void dirichlet_coupling_inside_is_true()
   {
     // DirichletCoupling::inside() always returns true
     const XT::Functions::GenericGridFunction<E, d> velocity(
@@ -401,7 +401,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_TRUE(integrand.inside());
   }
 
-  virtual void dirichlet_coupling_evaluates_binary_correctly()
+  void dirichlet_coupling_evaluates_binary_correctly()
   {
     // DirichletCoupling binary evaluate on a boundary intersection:
     //   result[i][j] = (v.n) * ansatz[j](x_in) * test[i](x_in)
@@ -453,7 +453,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_TRUE(found) << "No boundary intersection found in grid";
   }
 
-  virtual void dirichlet_coupling_evaluates_unary_correctly()
+  void dirichlet_coupling_evaluates_unary_correctly()
   {
     // DirichletCoupling unary evaluate on a boundary intersection:
     //   result[j] = (v.n) * dirichlet_data * test[j](x_in)
@@ -500,7 +500,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     EXPECT_TRUE(found) << "No boundary intersection found in grid";
   }
 
-  virtual void dirichlet_coupling_with_zero_velocity_gives_zero()
+  void dirichlet_coupling_with_zero_velocity_gives_zero()
   {
     // Edge case: v = 0 => all results are zero
     const XT::Functions::GenericGridFunction<E, d> zero_vel(
@@ -522,8 +522,9 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
           integrand.evaluate(*simple_test_, qp.position(), un_result);
           for (size_t ii = 0; ii < 2; ++ii) {
             EXPECT_DOUBLE_EQ(0., un_result[ii]);
-            for (size_t jj = 0; jj < 2; ++jj)
+            for (size_t jj = 0; jj < 2; ++jj) {
               EXPECT_DOUBLE_EQ(0., bin_result[ii][jj]);
+            }
           }
         }
         return;
@@ -531,7 +532,7 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
     }
   }
 
-  virtual void dirichlet_coupling_clone_gives_same_results()
+  void dirichlet_coupling_clone_gives_same_results()
   {
     // copy constructor and copy_as_* should produce identical binary evaluate results
     const XT::Functions::GenericGridFunction<E, d> velocity(

--- a/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
+++ b/dune/gdt/test/integrands/integrands_linear_advection_upwind.cc
@@ -242,8 +242,8 @@ struct LinearAdvectionUpwindIntegrandTest : public IntegrandTest<G>
 
         // Use face_normal so velocity v = sign*face_normal guarantees v·n = sign != 0,
         // ensuring both inflow and outflow branches are truly exercised.
-        const auto face_normal = intersection.unitOuterNormal(
-            Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), 1)[0].position());
+        const auto face_normal =
+            intersection.unitOuterNormal(Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), 1)[0].position());
         for (const D sign : {1., -1.}) {
           const XT::Functions::GenericGridFunction<E, d> velocity(
               0,


### PR DESCRIPTION
## Summary

Closes #280. Adds unit tests for two integrand headers that previously had 0% test coverage.

### `integrands_linear_advection.cc` — tests `LocalLinearAdvectionIntegrand`

- Construction with default and explicit arguments (divergence form flag, logging prefix)
- `copy_as_binary_element_integrand()` clone consistency
- `order()` formula verification: `direction.order + test.order + ansatz.order`
- `evaluate()` in **divergence form** with constant velocity `v=(1,0)`:  
  result[i][j] = `-ansatz[j] * (v · ∇test[i])` — hand-computed at `(0.5, 0.25)`
- `evaluate()` in **non-divergence form** with constant velocity `v=(1,0)`:  
  result[i][j] = `(v · ∇ansatz[j]) * test[i]` — hand-computed at `(0.5, 0.25)`
- Variable velocity `v=(x, y)` in both forms — hand-computed expected values
- Zero velocity edge case: all results must be exactly `0.0`

### `integrands_linear_advection_upwind.cc` — tests `InnerCoupling` and `DirichletCoupling`

**`InnerCoupling` (quaternary intersection integrand):**
- Construction and clone (`copy_as_quaternary_intersection_integrand()`)
- `post_bind()` throws `Dune::Exception` when bound to a boundary intersection
- `order()` formula: `direction.order + test_in.order + max(ansatz_in.order, ansatz_out.order)`
- `evaluate()` correctness with `v=(1,1)`: generic expected-value computation at each quadrature point using `geometryInInside`, `geometryInOutside`, and `unitOuterNormal`
- Both inflow (`v·n < 0`) and outflow (`v·n > 0`) orientations tested via sign flip
- Zero velocity gives all-zero result matrices

**`DirichletCoupling` (unary + binary intersection integrand):**
- `inside()` returns `true`
- **Binary evaluate** correctness with `v=(1,0)`: result[i][j] = `(v·n) * ansatz_in[j] * test_in[i]`
- **Unary evaluate** with explicit Dirichlet data `g=2`: result[j] = `(v·n) * g * test_in[j]`
- Default Dirichlet data `g=0` gives zero unary result
- Zero velocity gives zero result for both binary and unary forms
- Clone consistency for both `copy_as_unary_*` and `copy_as_binary_*`

### Design notes

- Uses custom `simple_test_ = {1, x+y}`, `simple_ansatz_ = {2, 1+xy}` basis functions in the upwind test to avoid degenerate zero values on element faces (the base fixture's `x`-based functions evaluate to 0 on left faces).
- Expected values for intersection tests are computed generically at each quadrature point from the intersection geometry rather than hard-coded, so they remain correct for all grid types in `Grids2D`.
- Where the formula seems potentially incorrect (e.g. `InnerCoupling` has `result_in_in = 0` regardless of velocity), current behavior is captured and annotated with TODO comments.

---
_Generated by [Claude Code](https://claude.ai/code/session_019dHUJg8pPS8nHVA7ED7CVb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for linear advection and upwind behavior.
  * Covered construction, copying, cloning, polynomial order checks, and numerical evaluation across constant, variable, and zero-velocity cases.
  * Added checks for both divergence and non-divergence forms, plus interior and boundary coupling behavior.
  * Verified results stay consistent across original, copied, and cloned instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->