### PR TITLE
test(integrands): unit tests for intersection integrands (issue #281)

### DIFF
--- a/dune/gdt/test/integrands/integrands.hh
+++ b/dune/gdt/test/integrands/integrands.hh
@@ -14,6 +14,7 @@
 
 #include <dune/geometry/quadraturerules.hh>
 #include <dune/geometry/type.hh>
+#include <dune/grid/common/rangegenerators.hh>
 
 #include <gtest/gtest.h>
 #include <dune/xt/common/fvector.hh>
@@ -143,6 +144,26 @@ struct IntegrandTest : public ::testing::Test
           ret[1][1] = {1., 1.};
         });
   } // ... SetUp(...)
+
+  I find_inner_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No inner intersection found in grid!");
+  }
+
+  I find_boundary_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (!intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No boundary intersection found in grid!");
+  }
 
   virtual void is_constructable() = 0;
 }; // struct IntegrandTest

--- a/dune/gdt/test/integrands/integrands_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_ipdg.cc
@@ -67,9 +67,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     const XT::Functions::GenericGridFunction<E, d, d> weight_gf(
         0,
         [](const E&) {},
-        [](const DomainType&, const XT::Common::Parameter&) {
-          return VectorJacobianType{{2., 0.}, {0., 2.}};
-        });
+        [](const DomainType&, const XT::Common::Parameter&) { return VectorJacobianType{{2., 0.}, {0., 2.}}; });
     [[maybe_unused]] InnerPenaltyType inner3(3.0, weight_gf);
     // InnerPenalty: with custom intersection diameter
     [[maybe_unused]] InnerPenaltyType inner4(1.0, 1.0, [](const I& i) { return XT::Grid::diameter(i); });
@@ -135,11 +133,9 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     integrand.bind(intersection);
     const double h = XT::Grid::diameter(intersection);
     const double effective_penalty = sigma * 0.5 / h;
-    const auto integrand_order =
-        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       integrand.evaluate(
           *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
@@ -189,11 +185,9 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     // delta = c * (n · I · n) = c * |n|^2 = c  (unit normal)
     // weight_harmonic = (c * c) / (c + c) = c/2
     const double effective_penalty = sigma * (c / 2.) / h;
-    const auto integrand_order =
-        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       integrand.evaluate(
           *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
@@ -221,8 +215,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     InnerPenaltyType integrand(0.0);
     const auto& intersection = find_inner_intersection();
     integrand.bind(intersection);
-    const auto integrand_order =
-        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
     const auto center = FieldVector<D, d - 1>(0.5);
     integrand.evaluate(
@@ -259,8 +252,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     const double h = XT::Grid::diameter(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> result(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
       const auto x_in = intersection.geometryInInside().global(x);

--- a/dune/gdt/test/integrands/integrands_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_ipdg.cc
@@ -94,23 +94,13 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
   }
 
-  void inner_penalty_evaluates_correctly_unit_weight()
+  // Shared helper: run the quadrature loop for a bound InnerPenalty integrand and verify
+  // result[i][j] = ±effective_penalty * phi_j_{in,out} * psi_i_{in,out}.
+  void check_inner_penalty_evaluate(InnerPenaltyType& integrand,
+                                    const I& intersection,
+                                    const double effective_penalty,
+                                    const double tol = 1e-13)
   {
-    // Formula with weight = I (identity):
-    //   delta_plus = delta_minus = n · n = 1
-    //   weight_harmonic = (1 * 1)/(1 + 1) = 0.5
-    //   h = diameter(intersection)
-    //   effective_penalty = sigma * 0.5 / h
-    //   result_in_in[i][j]  = effective_penalty * phi_j_in * psi_i_in
-    //   result_in_out[i][j] = -effective_penalty * phi_j_out * psi_i_in
-    //   result_out_in[i][j] = -effective_penalty * phi_j_in * psi_i_out
-    //   result_out_out[i][j] = effective_penalty * phi_j_out * psi_i_out
-    const double sigma = 8.0;
-    InnerPenaltyType integrand(sigma);
-    const auto& intersection = find_inner_intersection();
-    integrand.bind(intersection);
-    const double h = XT::Grid::diameter(intersection);
-    const double effective_penalty = sigma * 0.5 / h;
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
     for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
@@ -124,29 +114,34 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
       scalar_ansatz_->evaluate(x_out, phi_out);
       scalar_test_->evaluate(x_in, psi_in);
       scalar_test_->evaluate(x_out, psi_out);
-      for (size_t ii = 0; ii < 2; ++ii) {
+      for (size_t ii = 0; ii < 2; ++ii)
         for (size_t jj = 0; jj < 2; ++jj) {
-          EXPECT_NEAR(effective_penalty * phi_in[jj][0] * psi_in[ii][0], rin_in[ii][jj], 1e-13);
-          EXPECT_NEAR(-effective_penalty * phi_out[jj][0] * psi_in[ii][0], rin_out[ii][jj], 1e-13);
-          EXPECT_NEAR(-effective_penalty * phi_in[jj][0] * psi_out[ii][0], rout_in[ii][jj], 1e-13);
-          EXPECT_NEAR(effective_penalty * phi_out[jj][0] * psi_out[ii][0], rout_out[ii][jj], 1e-13);
+          EXPECT_NEAR(effective_penalty * phi_in[jj][0] * psi_in[ii][0], rin_in[ii][jj], tol);
+          EXPECT_NEAR(-effective_penalty * phi_out[jj][0] * psi_in[ii][0], rin_out[ii][jj], tol);
+          EXPECT_NEAR(-effective_penalty * phi_in[jj][0] * psi_out[ii][0], rout_in[ii][jj], tol);
+          EXPECT_NEAR(effective_penalty * phi_out[jj][0] * psi_out[ii][0], rout_out[ii][jj], tol);
         }
-      }
     }
+  }
+
+  void inner_penalty_evaluates_correctly_unit_weight()
+  {
+    // Formula with weight = I (identity):
+    //   delta_plus = delta_minus = n · n = 1  →  weight_harmonic = 0.5
+    //   effective_penalty = sigma * 0.5 / h
+    const double sigma = 8.0;
+    InnerPenaltyType integrand(sigma);
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    check_inner_penalty_evaluate(integrand, intersection, sigma * 0.5 / XT::Grid::diameter(intersection));
   }
 
   void inner_penalty_evaluates_correctly_with_constant_weight()
   {
-    // With weight = c * I (c > 0, constant scalar * identity):
-    //   delta_plus = delta_minus = c * n · n = c
-    //   weight_harmonic = (c * c) / (c + c) = c/2
+    // With weight = c * I:  delta = c  →  weight_harmonic = c/2
     //   effective_penalty = sigma * c/2 / h
-    // So effective_penalty changes proportionally to c.
-    // We verify that using weight = 2 * I gives effective_penalty = sigma * 1 / h
-    // (i.e., weight harmonic mean doubles from 0.5 to 1).
     const double sigma = 8.0;
     const double c = 2.0;
-    // Create 2*I weight function
     const XT::Functions::GenericGridFunction<E, d, d> weight_2I(
         0,
         [](const E&) {},
@@ -159,32 +154,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     InnerPenaltyType integrand(sigma, weight_2I);
     const auto& intersection = find_inner_intersection();
     integrand.bind(intersection);
-    const double h = XT::Grid::diameter(intersection);
-    // delta = c * (n · I · n) = c * |n|^2 = c  (unit normal)
-    // weight_harmonic = (c * c) / (c + c) = c/2
-    const double effective_penalty = sigma * (c / 2.) / h;
-    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
-    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
-    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
-      const auto& x = qp.position();
-      integrand.evaluate(
-          *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
-      const auto x_in = intersection.geometryInInside().global(x);
-      const auto x_out = intersection.geometryInOutside().global(x);
-      std::vector<ScalarRangeType> phi_in, phi_out, psi_in, psi_out;
-      scalar_ansatz_->evaluate(x_in, phi_in);
-      scalar_ansatz_->evaluate(x_out, phi_out);
-      scalar_test_->evaluate(x_in, psi_in);
-      scalar_test_->evaluate(x_out, psi_out);
-      for (size_t ii = 0; ii < 2; ++ii) {
-        for (size_t jj = 0; jj < 2; ++jj) {
-          EXPECT_NEAR(effective_penalty * phi_in[jj][0] * psi_in[ii][0], rin_in[ii][jj], 1e-12);
-          EXPECT_NEAR(-effective_penalty * phi_out[jj][0] * psi_in[ii][0], rin_out[ii][jj], 1e-12);
-          EXPECT_NEAR(-effective_penalty * phi_in[jj][0] * psi_out[ii][0], rout_in[ii][jj], 1e-12);
-          EXPECT_NEAR(effective_penalty * phi_out[jj][0] * psi_out[ii][0], rout_out[ii][jj], 1e-12);
-        }
-      }
-    }
+    check_inner_penalty_evaluate(integrand, intersection, sigma * (c / 2.) / XT::Grid::diameter(intersection), 1e-12);
   }
 
   void inner_penalty_zero_penalty_gives_zero_result()

--- a/dune/gdt/test/integrands/integrands_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_ipdg.cc
@@ -77,7 +77,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
   void inner_penalty_post_bind_throws_on_boundary_intersection()
   {
     InnerPenaltyType integrand(1.0);
-    const auto& bnd = find_boundary_intersection();
+    const auto& bnd = this->find_boundary_intersection();
     EXPECT_THROW(integrand.bind(bnd), Dune::Exception);
   }
 
@@ -89,7 +89,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     // With unit weight (order 0), scalar_test_ (order 4), scalar_ansatz_ (order 3):
     // expected order = 0 + 4 + 3 = 7
     InnerPenaltyType integrand(10.0);
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
   }
@@ -131,7 +131,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     //   effective_penalty = sigma * 0.5 / h
     const double sigma = 8.0;
     InnerPenaltyType integrand(sigma);
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     check_inner_penalty_evaluate(integrand, intersection, sigma * 0.5 / XT::Grid::diameter(intersection));
   }
@@ -152,7 +152,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
           return mat;
         });
     InnerPenaltyType integrand(sigma, weight_2I);
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     check_inner_penalty_evaluate(integrand, intersection, sigma * (c / 2.) / XT::Grid::diameter(intersection), 1e-12);
   }
@@ -161,7 +161,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
   {
     // TODO: Is zero penalty actually valid? The code divides sigma*weight/h, so sigma=0 → 0 results.
     InnerPenaltyType integrand(0.0);
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
@@ -181,7 +181,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
   {
     // order = weight_order + test_order + ansatz_order = 0 + 4 + 3 = 7
     BoundaryPenaltyType integrand(5.0);
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_));
   }
@@ -195,7 +195,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
     //   result[i][j] = effective_penalty * phi_j * psi_i
     const double sigma = 5.0;
     BoundaryPenaltyType integrand(sigma);
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     const double h = XT::Grid::diameter(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_);
@@ -220,7 +220,7 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
   void boundary_penalty_zero_penalty_gives_zero_result()
   {
     BoundaryPenaltyType integrand(0.0);
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     const auto center = FieldVector<D, d - 1>(0.5);
     DynamicMatrix<D> result(2, 2, 0.);

--- a/dune/gdt/test/integrands/integrands_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_ipdg.cc
@@ -1,0 +1,351 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/functions/generic/grid-function.hh>
+#include <dune/xt/grid/intersection.hh>
+
+#include <dune/gdt/local/integrands/ipdg.hh>
+
+#include <dune/gdt/test/integrands/integrands.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Test {
+
+
+template <class G>
+struct IPDGIntegrandTest : public IntegrandTest<G>
+{
+  using BaseType = IntegrandTest<G>;
+  using BaseType::d;
+  using typename BaseType::D;
+  using typename BaseType::DomainType;
+  using typename BaseType::E;
+  using typename BaseType::GV;
+  using typename BaseType::I;
+  using typename BaseType::ScalarRangeType;
+  using typename BaseType::VectorJacobianType;
+
+  using InnerPenaltyType = LocalIPDGIntegrands::InnerPenalty<I>;
+  using BoundaryPenaltyType = LocalIPDGIntegrands::BoundaryPenalty<I>;
+
+  I find_inner_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No inner intersection found in grid!");
+  }
+
+  I find_boundary_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (!intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No boundary intersection found in grid!");
+  }
+
+  void is_constructable() final
+  {
+    // InnerPenalty: penalty only (weight = identity by default)
+    [[maybe_unused]] InnerPenaltyType inner1(1.0);
+    // InnerPenalty: penalty + constant weight
+    [[maybe_unused]] InnerPenaltyType inner2(2.0, 1.0);
+    // InnerPenalty: penalty + matrix weight function
+    const XT::Functions::GenericGridFunction<E, d, d> weight_gf(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) {
+          return VectorJacobianType{{2., 0.}, {0., 2.}};
+        });
+    [[maybe_unused]] InnerPenaltyType inner3(3.0, weight_gf);
+    // InnerPenalty: with custom intersection diameter
+    [[maybe_unused]] InnerPenaltyType inner4(1.0, 1.0, [](const I& i) { return XT::Grid::diameter(i); });
+    // Copy constructor
+    InnerPenaltyType inner_src(4.0);
+    [[maybe_unused]] InnerPenaltyType inner5(inner_src);
+    // copy_as_quaternary_intersection_integrand
+    auto clone = inner_src.copy_as_quaternary_intersection_integrand();
+    EXPECT_NE(clone, nullptr);
+
+    // BoundaryPenalty: penalty only
+    [[maybe_unused]] BoundaryPenaltyType bnd1(1.0);
+    // BoundaryPenalty: penalty + constant weight
+    [[maybe_unused]] BoundaryPenaltyType bnd2(2.0, 1.0);
+    // BoundaryPenalty: penalty + matrix weight function
+    [[maybe_unused]] BoundaryPenaltyType bnd3(3.0, weight_gf);
+    // BoundaryPenalty: with custom intersection diameter
+    [[maybe_unused]] BoundaryPenaltyType bnd4(1.0, 1.0, [](const I& i) { return XT::Grid::diameter(i); });
+    // Copy constructor
+    BoundaryPenaltyType bnd_src(5.0);
+    [[maybe_unused]] BoundaryPenaltyType bnd5(bnd_src);
+    // copy_as_binary_intersection_integrand
+    auto bclone = bnd_src.copy_as_binary_intersection_integrand();
+    EXPECT_NE(bclone, nullptr);
+    // inside() returns true for BoundaryPenalty
+    EXPECT_TRUE(bnd1.inside());
+  }
+
+  void inner_penalty_post_bind_throws_on_boundary_intersection()
+  {
+    InnerPenaltyType integrand(1.0);
+    const auto& bnd = find_boundary_intersection();
+    EXPECT_THROW(integrand.bind(bnd), Dune::Exception);
+  }
+
+  void inner_penalty_order_is_correct()
+  {
+    // order = max(weight_order_in, weight_order_out)
+    //       + max(test_order_in, test_order_out)
+    //       + max(ansatz_order_in, ansatz_order_out)
+    // With unit weight (order 0), scalar_test_ (order 4), scalar_ansatz_ (order 3):
+    // expected order = 0 + 4 + 3 = 7
+    InnerPenaltyType integrand(10.0);
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
+  }
+
+  void inner_penalty_evaluates_correctly_unit_weight()
+  {
+    // Formula with weight = I (identity):
+    //   delta_plus = delta_minus = n · n = 1
+    //   weight_harmonic = (1 * 1)/(1 + 1) = 0.5
+    //   h = diameter(intersection)
+    //   effective_penalty = sigma * 0.5 / h
+    //   result_in_in[i][j]  = effective_penalty * phi_j_in * psi_i_in
+    //   result_in_out[i][j] = -effective_penalty * phi_j_out * psi_i_in
+    //   result_out_in[i][j] = -effective_penalty * phi_j_in * psi_i_out
+    //   result_out_out[i][j] = effective_penalty * phi_j_out * psi_i_out
+    const double sigma = 8.0;
+    InnerPenaltyType integrand(sigma);
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    const double h = XT::Grid::diameter(intersection);
+    const double effective_penalty = sigma * 0.5 / h;
+    const auto integrand_order =
+        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(
+          *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto x_out = intersection.geometryInOutside().global(x);
+      std::vector<ScalarRangeType> phi_in, phi_out, psi_in, psi_out;
+      scalar_ansatz_->evaluate(x_in, phi_in);
+      scalar_ansatz_->evaluate(x_out, phi_out);
+      scalar_test_->evaluate(x_in, psi_in);
+      scalar_test_->evaluate(x_out, psi_out);
+      for (size_t ii = 0; ii < 2; ++ii) {
+        for (size_t jj = 0; jj < 2; ++jj) {
+          EXPECT_NEAR(effective_penalty * phi_in[jj][0] * psi_in[ii][0], rin_in[ii][jj], 1e-13);
+          EXPECT_NEAR(-effective_penalty * phi_out[jj][0] * psi_in[ii][0], rin_out[ii][jj], 1e-13);
+          EXPECT_NEAR(-effective_penalty * phi_in[jj][0] * psi_out[ii][0], rout_in[ii][jj], 1e-13);
+          EXPECT_NEAR(effective_penalty * phi_out[jj][0] * psi_out[ii][0], rout_out[ii][jj], 1e-13);
+        }
+      }
+    }
+  }
+
+  void inner_penalty_evaluates_correctly_with_constant_weight()
+  {
+    // With weight = c * I (c > 0, constant scalar * identity):
+    //   delta_plus = delta_minus = c * n · n = c
+    //   weight_harmonic = (c * c) / (c + c) = c/2
+    //   effective_penalty = sigma * c/2 / h
+    // So effective_penalty changes proportionally to c.
+    // We verify that using weight = 2 * I gives effective_penalty = sigma * 1 / h
+    // (i.e., weight harmonic mean doubles from 0.5 to 1).
+    const double sigma = 8.0;
+    const double c = 2.0;
+    // Create 2*I weight function
+    const XT::Functions::GenericGridFunction<E, d, d> weight_2I(
+        0,
+        [](const E&) {},
+        [c](const DomainType&, const XT::Common::Parameter&) {
+          VectorJacobianType mat{{0., 0.}, {0., 0.}};
+          for (size_t i = 0; i < d; ++i)
+            mat[i][i] = c;
+          return mat;
+        });
+    InnerPenaltyType integrand(sigma, weight_2I);
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    const double h = XT::Grid::diameter(intersection);
+    // delta = c * (n · I · n) = c * |n|^2 = c  (unit normal)
+    // weight_harmonic = (c * c) / (c + c) = c/2
+    const double effective_penalty = sigma * (c / 2.) / h;
+    const auto integrand_order =
+        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(
+          *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto x_out = intersection.geometryInOutside().global(x);
+      std::vector<ScalarRangeType> phi_in, phi_out, psi_in, psi_out;
+      scalar_ansatz_->evaluate(x_in, phi_in);
+      scalar_ansatz_->evaluate(x_out, phi_out);
+      scalar_test_->evaluate(x_in, psi_in);
+      scalar_test_->evaluate(x_out, psi_out);
+      for (size_t ii = 0; ii < 2; ++ii) {
+        for (size_t jj = 0; jj < 2; ++jj) {
+          EXPECT_NEAR(effective_penalty * phi_in[jj][0] * psi_in[ii][0], rin_in[ii][jj], 1e-12);
+          EXPECT_NEAR(-effective_penalty * phi_out[jj][0] * psi_in[ii][0], rin_out[ii][jj], 1e-12);
+          EXPECT_NEAR(-effective_penalty * phi_in[jj][0] * psi_out[ii][0], rout_in[ii][jj], 1e-12);
+          EXPECT_NEAR(effective_penalty * phi_out[jj][0] * psi_out[ii][0], rout_out[ii][jj], 1e-12);
+        }
+      }
+    }
+  }
+
+  void inner_penalty_zero_penalty_gives_zero_result()
+  {
+    // TODO: Is zero penalty actually valid? The code divides sigma*weight/h, so sigma=0 → 0 results.
+    InnerPenaltyType integrand(0.0);
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    const auto integrand_order =
+        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
+    const auto center = FieldVector<D, d - 1>(0.5);
+    integrand.evaluate(
+        *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, center, rin_in, rin_out, rout_in, rout_out);
+    for (size_t ii = 0; ii < 2; ++ii)
+      for (size_t jj = 0; jj < 2; ++jj) {
+        EXPECT_NEAR(0., rin_in[ii][jj], 1e-15);
+        EXPECT_NEAR(0., rin_out[ii][jj], 1e-15);
+        EXPECT_NEAR(0., rout_in[ii][jj], 1e-15);
+        EXPECT_NEAR(0., rout_out[ii][jj], 1e-15);
+      }
+  }
+
+  void boundary_penalty_order_is_correct()
+  {
+    // order = weight_order + test_order + ansatz_order = 0 + 4 + 3 = 7
+    BoundaryPenaltyType integrand(5.0);
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_));
+  }
+
+  void boundary_penalty_evaluates_correctly()
+  {
+    // Formula:
+    //   n_dot_weight_n = n · (I * n) = 1  (unit weight, unit normal)
+    //   h = diameter(intersection)
+    //   effective_penalty = sigma * 1 / h
+    //   result[i][j] = effective_penalty * phi_j * psi_i
+    const double sigma = 5.0;
+    BoundaryPenaltyType integrand(sigma);
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    const double h = XT::Grid::diameter(intersection);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> result(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto n = intersection.unitOuterNormal(x);
+      // With unit weight (I): n · (I * n) = n · n = 1
+      const double n_dot_weight_n = n * n; // should be 1 for unit normal
+      const double effective_penalty = sigma * n_dot_weight_n / h;
+      std::vector<ScalarRangeType> phi, psi;
+      scalar_ansatz_->evaluate(x_in, phi);
+      scalar_test_->evaluate(x_in, psi);
+      for (size_t ii = 0; ii < 2; ++ii)
+        for (size_t jj = 0; jj < 2; ++jj)
+          EXPECT_NEAR(effective_penalty * phi[jj][0] * psi[ii][0], result[ii][jj], 1e-13);
+    }
+  }
+
+  void boundary_penalty_zero_penalty_gives_zero_result()
+  {
+    BoundaryPenaltyType integrand(0.0);
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    const auto center = FieldVector<D, d - 1>(0.5);
+    DynamicMatrix<D> result(2, 2, 0.);
+    integrand.evaluate(*scalar_test_, *scalar_ansatz_, center, result);
+    for (size_t ii = 0; ii < 2; ++ii)
+      for (size_t jj = 0; jj < 2; ++jj)
+        EXPECT_NEAR(0., result[ii][jj], 1e-15);
+  }
+
+  using BaseType::grid_provider_;
+  using BaseType::scalar_ansatz_;
+  using BaseType::scalar_test_;
+}; // struct IPDGIntegrandTest
+
+
+} // namespace Test
+} // namespace GDT
+} // namespace Dune
+
+
+template <class G>
+using IPDGIntegrandTest = Dune::GDT::Test::IPDGIntegrandTest<G>;
+TYPED_TEST_SUITE(IPDGIntegrandTest, Grids2D);
+
+TYPED_TEST(IPDGIntegrandTest, is_constructable)
+{
+  this->is_constructable();
+}
+
+TYPED_TEST(IPDGIntegrandTest, inner_penalty_post_bind_throws_on_boundary_intersection)
+{
+  this->inner_penalty_post_bind_throws_on_boundary_intersection();
+}
+
+TYPED_TEST(IPDGIntegrandTest, inner_penalty_order_is_correct)
+{
+  this->inner_penalty_order_is_correct();
+}
+
+TYPED_TEST(IPDGIntegrandTest, inner_penalty_evaluates_correctly_unit_weight)
+{
+  this->inner_penalty_evaluates_correctly_unit_weight();
+}
+
+TYPED_TEST(IPDGIntegrandTest, inner_penalty_evaluates_correctly_with_constant_weight)
+{
+  this->inner_penalty_evaluates_correctly_with_constant_weight();
+}
+
+TYPED_TEST(IPDGIntegrandTest, inner_penalty_zero_penalty_gives_zero_result)
+{
+  this->inner_penalty_zero_penalty_gives_zero_result();
+}
+
+TYPED_TEST(IPDGIntegrandTest, boundary_penalty_order_is_correct)
+{
+  this->boundary_penalty_order_is_correct();
+}
+
+TYPED_TEST(IPDGIntegrandTest, boundary_penalty_evaluates_correctly)
+{
+  this->boundary_penalty_evaluates_correctly();
+}
+
+TYPED_TEST(IPDGIntegrandTest, boundary_penalty_zero_penalty_gives_zero_result)
+{
+  this->boundary_penalty_zero_penalty_gives_zero_result();
+}

--- a/dune/gdt/test/integrands/integrands_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_ipdg.cc
@@ -7,8 +7,6 @@
 
 #include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
 
-#include <dune/grid/common/rangegenerators.hh>
-
 #include <dune/xt/functions/generic/grid-function.hh>
 #include <dune/xt/grid/intersection.hh>
 
@@ -36,26 +34,6 @@ struct IPDGIntegrandTest : public IntegrandTest<G>
 
   using InnerPenaltyType = LocalIPDGIntegrands::InnerPenalty<I>;
   using BoundaryPenaltyType = LocalIPDGIntegrands::BoundaryPenalty<I>;
-
-  I find_inner_intersection() const
-  {
-    const auto& gv = grid_provider_->leaf_view();
-    for (const auto& element : Dune::elements(gv))
-      for (const auto& intersection : Dune::intersections(gv, element))
-        if (intersection.neighbor())
-          return intersection;
-    DUNE_THROW(Dune::InvalidStateException, "No inner intersection found in grid!");
-  }
-
-  I find_boundary_intersection() const
-  {
-    const auto& gv = grid_provider_->leaf_view();
-    for (const auto& element : Dune::elements(gv))
-      for (const auto& intersection : Dune::intersections(gv, element))
-        if (!intersection.neighbor())
-          return intersection;
-    DUNE_THROW(Dune::InvalidStateException, "No boundary intersection found in grid!");
-  }
 
   void is_constructable() final
   {

--- a/dune/gdt/test/integrands/integrands_jump.cc
+++ b/dune/gdt/test/integrands/integrands_jump.cc
@@ -118,13 +118,6 @@ struct JumpIntegrandTest : public IntegrandTest<G>
           EXPECT_NEAR(h * phi_out[jj][0] * psi_out[ii][0], rout_out[ii][jj], 1e-13);
         }
       }
-      // Sign pattern: in-in and out-out are non-negative when phi and psi have same sign;
-      // in-out and out-in have opposite sign. Verify block-diagonal sign symmetry.
-      for (size_t ii = 0; ii < 2; ++ii)
-        for (size_t jj = 0; jj < 2; ++jj) {
-          EXPECT_NEAR(rin_in[ii][jj], rout_out[jj][ii], 1e-13); // symmetric w.r.t. in/out swap
-          EXPECT_NEAR(rin_out[ii][jj], rout_in[jj][ii], 1e-13);
-        }
     }
   }
 

--- a/dune/gdt/test/integrands/integrands_jump.cc
+++ b/dune/gdt/test/integrands/integrands_jump.cc
@@ -65,8 +65,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     // Inner with default diameter function
     [[maybe_unused]] ScalarInnerIntegrandType inner1;
     // Inner with custom diameter function
-    [[maybe_unused]] ScalarInnerIntegrandType inner2(
-        [](const I& i) { return XT::Grid::diameter(i); });
+    [[maybe_unused]] ScalarInnerIntegrandType inner2([](const I& i) { return XT::Grid::diameter(i); });
     // Inner copy constructor
     ScalarInnerIntegrandType inner3;
     [[maybe_unused]] ScalarInnerIntegrandType inner4(inner3);
@@ -76,14 +75,12 @@ struct JumpIntegrandTest : public IntegrandTest<G>
 
     // Vector variant
     [[maybe_unused]] VectorInnerIntegrandType vec_inner1;
-    [[maybe_unused]] VectorInnerIntegrandType vec_inner2(
-        [](const I& i) { return XT::Grid::diameter(i); });
+    [[maybe_unused]] VectorInnerIntegrandType vec_inner2([](const I& i) { return XT::Grid::diameter(i); });
 
     // Boundary with default diameter function
     [[maybe_unused]] ScalarBoundaryIntegrandType boundary1;
     // Boundary with custom diameter function
-    [[maybe_unused]] ScalarBoundaryIntegrandType boundary2(
-        [](const I& i) { return XT::Grid::diameter(i); });
+    [[maybe_unused]] ScalarBoundaryIntegrandType boundary2([](const I& i) { return XT::Grid::diameter(i); });
     // Boundary copy constructor
     ScalarBoundaryIntegrandType boundary3;
     [[maybe_unused]] ScalarBoundaryIntegrandType boundary4(boundary3);
@@ -123,11 +120,9 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     const auto& intersection = find_inner_intersection();
     integrand.bind(intersection);
     const auto h = XT::Grid::diameter(intersection);
-    const auto integrand_order =
-        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       integrand.evaluate(
           *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
@@ -166,11 +161,9 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     const auto& intersection = find_inner_intersection();
     integrand.bind(intersection);
     const auto h = XT::Grid::diameter(intersection);
-    const auto integrand_order =
-        integrand.order(*vector_test_, *vector_ansatz_, *vector_test_, *vector_ansatz_);
+    const auto integrand_order = integrand.order(*vector_test_, *vector_ansatz_, *vector_test_, *vector_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       integrand.evaluate(
           *vector_test_, *vector_ansatz_, *vector_test_, *vector_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
@@ -221,8 +214,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     const auto h = XT::Grid::diameter(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> result(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
       const auto x_in = intersection.geometryInInside().global(x);
@@ -242,8 +234,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     ScalarInnerIntegrandType integrand([custom_h](const I&) { return custom_h; });
     const auto& intersection = find_inner_intersection();
     integrand.bind(intersection);
-    const auto integrand_order =
-        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     // Use a single quadrature point at the center of the intersection.
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
     const auto center = FieldVector<D, d - 1>(0.5);

--- a/dune/gdt/test/integrands/integrands_jump.cc
+++ b/dune/gdt/test/integrands/integrands_jump.cc
@@ -1,0 +1,323 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/grid/intersection.hh>
+
+#include <dune/gdt/local/integrands/jump.hh>
+
+#include <dune/gdt/test/integrands/integrands.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Test {
+
+
+template <class G>
+struct JumpIntegrandTest : public IntegrandTest<G>
+{
+  using BaseType = IntegrandTest<G>;
+  using BaseType::d;
+  using typename BaseType::D;
+  using typename BaseType::DomainType;
+  using typename BaseType::E;
+  using typename BaseType::GV;
+  using typename BaseType::I;
+  using typename BaseType::ScalarJacobianType;
+  using typename BaseType::ScalarRangeType;
+  using typename BaseType::VectorRangeType;
+
+  using ScalarInnerIntegrandType = LocalJumpIntegrands::Inner<I, 1>;
+  using VectorInnerIntegrandType = LocalJumpIntegrands::Inner<I, d>;
+  using ScalarBoundaryIntegrandType = LocalJumpIntegrands::Boundary<I, 1>;
+
+  // Helper: return first inner intersection found, or throw if none exists.
+  I find_inner_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No inner intersection found in grid!");
+  }
+
+  // Helper: return first boundary intersection found, or throw if none exists.
+  I find_boundary_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (!intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No boundary intersection found in grid!");
+  }
+
+  void is_constructable() final
+  {
+    // Inner with default diameter function
+    [[maybe_unused]] ScalarInnerIntegrandType inner1;
+    // Inner with custom diameter function
+    [[maybe_unused]] ScalarInnerIntegrandType inner2(
+        [](const I& i) { return XT::Grid::diameter(i); });
+    // Inner copy constructor
+    ScalarInnerIntegrandType inner3;
+    [[maybe_unused]] ScalarInnerIntegrandType inner4(inner3);
+    // copy_as_quaternary_intersection_integrand
+    auto clone = inner3.copy_as_quaternary_intersection_integrand();
+    EXPECT_NE(clone, nullptr);
+
+    // Vector variant
+    [[maybe_unused]] VectorInnerIntegrandType vec_inner1;
+    [[maybe_unused]] VectorInnerIntegrandType vec_inner2(
+        [](const I& i) { return XT::Grid::diameter(i); });
+
+    // Boundary with default diameter function
+    [[maybe_unused]] ScalarBoundaryIntegrandType boundary1;
+    // Boundary with custom diameter function
+    [[maybe_unused]] ScalarBoundaryIntegrandType boundary2(
+        [](const I& i) { return XT::Grid::diameter(i); });
+    // Boundary copy constructor
+    ScalarBoundaryIntegrandType boundary3;
+    [[maybe_unused]] ScalarBoundaryIntegrandType boundary4(boundary3);
+    // copy_as_binary_intersection_integrand
+    auto bclone = boundary3.copy_as_binary_intersection_integrand();
+    EXPECT_NE(bclone, nullptr);
+    // inside() returns true for Boundary
+    EXPECT_TRUE(boundary3.inside());
+  }
+
+  void inner_post_bind_throws_on_boundary_intersection()
+  {
+    ScalarInnerIntegrandType integrand;
+    const auto& boundary_intersection = find_boundary_intersection();
+    EXPECT_THROW(integrand.bind(boundary_intersection), Dune::Exception);
+  }
+
+  void inner_order_is_correct()
+  {
+    // order = max(test_order_in, test_order_out) + max(ansatz_order_in, ansatz_order_out)
+    // scalar_test_ has order 4, scalar_ansatz_ has order 3: expected order = 4 + 3 = 7
+    ScalarInnerIntegrandType integrand;
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
+  }
+
+  void inner_evaluates_correctly_scalar()
+  {
+    // Formula (r=1): result_in_in[ii][jj] = h * phi_j_in * psi_i_in
+    //                result_in_out[ii][jj] = -h * phi_j_out * psi_i_in
+    //                result_out_in[ii][jj] = -h * phi_j_in * psi_i_out
+    //                result_out_out[ii][jj] = h * phi_j_out * psi_i_out
+    // We verify by independently evaluating the scalar_ansatz_ / scalar_test_ bases and
+    // re-applying the formula, then comparing with evaluate().
+    ScalarInnerIntegrandType integrand;
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    const auto h = XT::Grid::diameter(intersection);
+    const auto integrand_order =
+        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(
+          *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
+      // Map intersection ref point to element ref points and evaluate bases independently.
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto x_out = intersection.geometryInOutside().global(x);
+      std::vector<ScalarRangeType> phi_in, phi_out, psi_in, psi_out;
+      scalar_ansatz_->evaluate(x_in, phi_in);
+      scalar_ansatz_->evaluate(x_out, phi_out);
+      scalar_test_->evaluate(x_in, psi_in);
+      scalar_test_->evaluate(x_out, psi_out);
+      for (size_t ii = 0; ii < 2; ++ii) {
+        for (size_t jj = 0; jj < 2; ++jj) {
+          EXPECT_NEAR(h * phi_in[jj][0] * psi_in[ii][0], rin_in[ii][jj], 1e-13);
+          EXPECT_NEAR(-h * phi_out[jj][0] * psi_in[ii][0], rin_out[ii][jj], 1e-13);
+          EXPECT_NEAR(-h * phi_in[jj][0] * psi_out[ii][0], rout_in[ii][jj], 1e-13);
+          EXPECT_NEAR(h * phi_out[jj][0] * psi_out[ii][0], rout_out[ii][jj], 1e-13);
+        }
+      }
+      // Sign pattern: in-in and out-out are non-negative when phi and psi have same sign;
+      // in-out and out-in have opposite sign. Verify block-diagonal sign symmetry.
+      for (size_t ii = 0; ii < 2; ++ii)
+        for (size_t jj = 0; jj < 2; ++jj) {
+          EXPECT_NEAR(rin_in[ii][jj], rout_out[jj][ii], 1e-13); // symmetric w.r.t. in/out swap
+          EXPECT_NEAR(rin_out[ii][jj], rout_in[jj][ii], 1e-13);
+        }
+    }
+  }
+
+  void inner_evaluates_correctly_vector()
+  {
+    // Formula (r=d): result_in_in[ii][jj] = h * (phi_j_in · n) * (psi_i_in · n)
+    //                result_in_out[ii][jj] = -h * (phi_j_out · n) * (psi_i_in · n)
+    //                etc.
+    VectorInnerIntegrandType integrand;
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    const auto h = XT::Grid::diameter(intersection);
+    const auto integrand_order =
+        integrand.order(*vector_test_, *vector_ansatz_, *vector_test_, *vector_ansatz_);
+    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(
+          *vector_test_, *vector_ansatz_, *vector_test_, *vector_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto x_out = intersection.geometryInOutside().global(x);
+      const auto n = intersection.unitOuterNormal(x);
+      std::vector<VectorRangeType> phi_in, phi_out, psi_in, psi_out;
+      vector_ansatz_->evaluate(x_in, phi_in);
+      vector_ansatz_->evaluate(x_out, phi_out);
+      vector_test_->evaluate(x_in, psi_in);
+      vector_test_->evaluate(x_out, psi_out);
+      for (size_t ii = 0; ii < 2; ++ii) {
+        for (size_t jj = 0; jj < 2; ++jj) {
+          const double phi_in_dot_n = phi_in[jj] * n;
+          const double phi_out_dot_n = phi_out[jj] * n;
+          const double psi_in_dot_n = psi_in[ii] * n;
+          const double psi_out_dot_n = psi_out[ii] * n;
+          EXPECT_NEAR(h * phi_in_dot_n * psi_in_dot_n, rin_in[ii][jj], 1e-13);
+          EXPECT_NEAR(-h * phi_out_dot_n * psi_in_dot_n, rin_out[ii][jj], 1e-13);
+          EXPECT_NEAR(-h * phi_in_dot_n * psi_out_dot_n, rout_in[ii][jj], 1e-13);
+          EXPECT_NEAR(h * phi_out_dot_n * psi_out_dot_n, rout_out[ii][jj], 1e-13);
+        }
+      }
+    }
+  }
+
+  void boundary_inside_returns_true()
+  {
+    ScalarBoundaryIntegrandType integrand;
+    EXPECT_TRUE(integrand.inside());
+  }
+
+  void boundary_order_is_correct()
+  {
+    // order = test_order + ansatz_order = 4 + 3 = 7
+    ScalarBoundaryIntegrandType integrand;
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_));
+  }
+
+  void boundary_evaluates_correctly()
+  {
+    // Formula (r=1): result[ii][jj] = h * phi_j * psi_i
+    ScalarBoundaryIntegrandType integrand;
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    const auto h = XT::Grid::diameter(intersection);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> result(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+      const auto x_in = intersection.geometryInInside().global(x);
+      std::vector<ScalarRangeType> phi, psi;
+      scalar_ansatz_->evaluate(x_in, phi);
+      scalar_test_->evaluate(x_in, psi);
+      for (size_t ii = 0; ii < 2; ++ii)
+        for (size_t jj = 0; jj < 2; ++jj)
+          EXPECT_NEAR(h * phi[jj][0] * psi[ii][0], result[ii][jj], 1e-13);
+    }
+  }
+
+  void custom_diameter_function_is_used()
+  {
+    // Verify that a custom diameter function is actually called.
+    double custom_h = 42.0;
+    ScalarInnerIntegrandType integrand([custom_h](const I&) { return custom_h; });
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    const auto integrand_order =
+        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    // Use a single quadrature point at the center of the intersection.
+    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
+    const auto center = FieldVector<D, d - 1>(0.5);
+    integrand.evaluate(
+        *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, center, rin_in, rin_out, rout_in, rout_out);
+    const auto x_in = intersection.geometryInInside().global(center);
+    const auto x_out = intersection.geometryInOutside().global(center);
+    std::vector<ScalarRangeType> phi_in, phi_out, psi_in, psi_out;
+    scalar_ansatz_->evaluate(x_in, phi_in);
+    scalar_ansatz_->evaluate(x_out, phi_out);
+    scalar_test_->evaluate(x_in, psi_in);
+    scalar_test_->evaluate(x_out, psi_out);
+    EXPECT_NEAR(custom_h * phi_in[0][0] * psi_in[0][0], rin_in[0][0], 1e-13);
+    EXPECT_NEAR(-custom_h * phi_out[0][0] * psi_in[0][0], rin_out[0][0], 1e-13);
+  }
+
+  using BaseType::grid_provider_;
+  using BaseType::scalar_ansatz_;
+  using BaseType::scalar_test_;
+  using BaseType::vector_ansatz_;
+  using BaseType::vector_test_;
+}; // struct JumpIntegrandTest
+
+
+} // namespace Test
+} // namespace GDT
+} // namespace Dune
+
+
+template <class G>
+using JumpIntegrandTest = Dune::GDT::Test::JumpIntegrandTest<G>;
+TYPED_TEST_SUITE(JumpIntegrandTest, Grids2D);
+
+TYPED_TEST(JumpIntegrandTest, is_constructable)
+{
+  this->is_constructable();
+}
+
+TYPED_TEST(JumpIntegrandTest, inner_post_bind_throws_on_boundary_intersection)
+{
+  this->inner_post_bind_throws_on_boundary_intersection();
+}
+
+TYPED_TEST(JumpIntegrandTest, inner_order_is_correct)
+{
+  this->inner_order_is_correct();
+}
+
+TYPED_TEST(JumpIntegrandTest, inner_evaluates_correctly_scalar)
+{
+  this->inner_evaluates_correctly_scalar();
+}
+
+TYPED_TEST(JumpIntegrandTest, inner_evaluates_correctly_vector)
+{
+  this->inner_evaluates_correctly_vector();
+}
+
+TYPED_TEST(JumpIntegrandTest, boundary_inside_returns_true)
+{
+  this->boundary_inside_returns_true();
+}
+
+TYPED_TEST(JumpIntegrandTest, boundary_order_is_correct)
+{
+  this->boundary_order_is_correct();
+}
+
+TYPED_TEST(JumpIntegrandTest, boundary_evaluates_correctly)
+{
+  this->boundary_evaluates_correctly();
+}
+
+TYPED_TEST(JumpIntegrandTest, custom_diameter_function_is_used)
+{
+  this->custom_diameter_function_is_used();
+}

--- a/dune/gdt/test/integrands/integrands_jump.cc
+++ b/dune/gdt/test/integrands/integrands_jump.cc
@@ -7,8 +7,6 @@
 
 #include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
 
-#include <dune/grid/common/rangegenerators.hh>
-
 #include <dune/xt/grid/intersection.hh>
 
 #include <dune/gdt/local/integrands/jump.hh>
@@ -37,28 +35,6 @@ struct JumpIntegrandTest : public IntegrandTest<G>
   using ScalarInnerIntegrandType = LocalJumpIntegrands::Inner<I, 1>;
   using VectorInnerIntegrandType = LocalJumpIntegrands::Inner<I, d>;
   using ScalarBoundaryIntegrandType = LocalJumpIntegrands::Boundary<I, 1>;
-
-  // Helper: return first inner intersection found, or throw if none exists.
-  I find_inner_intersection() const
-  {
-    const auto& gv = grid_provider_->leaf_view();
-    for (const auto& element : Dune::elements(gv))
-      for (const auto& intersection : Dune::intersections(gv, element))
-        if (intersection.neighbor())
-          return intersection;
-    DUNE_THROW(Dune::InvalidStateException, "No inner intersection found in grid!");
-  }
-
-  // Helper: return first boundary intersection found, or throw if none exists.
-  I find_boundary_intersection() const
-  {
-    const auto& gv = grid_provider_->leaf_view();
-    for (const auto& element : Dune::elements(gv))
-      for (const auto& intersection : Dune::intersections(gv, element))
-        if (!intersection.neighbor())
-          return intersection;
-    DUNE_THROW(Dune::InvalidStateException, "No boundary intersection found in grid!");
-  }
 
   void is_constructable() final
   {

--- a/dune/gdt/test/integrands/integrands_jump.cc
+++ b/dune/gdt/test/integrands/integrands_jump.cc
@@ -70,7 +70,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
   void inner_post_bind_throws_on_boundary_intersection()
   {
     ScalarInnerIntegrandType integrand;
-    const auto& boundary_intersection = find_boundary_intersection();
+    const auto& boundary_intersection = this->find_boundary_intersection();
     EXPECT_THROW(integrand.bind(boundary_intersection), Dune::Exception);
   }
 
@@ -79,7 +79,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     // order = max(test_order_in, test_order_out) + max(ansatz_order_in, ansatz_order_out)
     // scalar_test_ has order 4, scalar_ansatz_ has order 3: expected order = 4 + 3 = 7
     ScalarInnerIntegrandType integrand;
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
   }
@@ -93,7 +93,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     // We verify by independently evaluating the scalar_ansatz_ / scalar_test_ bases and
     // re-applying the formula, then comparing with evaluate().
     ScalarInnerIntegrandType integrand;
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     const auto h = XT::Grid::diameter(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
@@ -134,7 +134,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     //                result_in_out[ii][jj] = -h * (phi_j_out · n) * (psi_i_in · n)
     //                etc.
     VectorInnerIntegrandType integrand;
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     const auto h = XT::Grid::diameter(intersection);
     const auto integrand_order = integrand.order(*vector_test_, *vector_ansatz_, *vector_test_, *vector_ansatz_);
@@ -176,7 +176,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
   {
     // order = test_order + ansatz_order = 4 + 3 = 7
     ScalarBoundaryIntegrandType integrand;
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_));
   }
@@ -185,7 +185,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
   {
     // Formula (r=1): result[ii][jj] = h * phi_j * psi_i
     ScalarBoundaryIntegrandType integrand;
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     const auto h = XT::Grid::diameter(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_);
@@ -208,7 +208,7 @@ struct JumpIntegrandTest : public IntegrandTest<G>
     // Verify that a custom diameter function is actually called.
     double custom_h = 42.0;
     ScalarInnerIntegrandType integrand([custom_h](const I&) { return custom_h; });
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     // Use a single quadrature point at the center of the intersection.

--- a/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
@@ -64,15 +64,13 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
   {
     // InnerCoupling: (symmetry_prefactor, diffusion)
     [[maybe_unused]] InnerCouplingType inner_nipdg(-1., 1.); // NIPDG
-    [[maybe_unused]] InnerCouplingType inner_iipdg(0., 1.);  // IIPDG
-    [[maybe_unused]] InnerCouplingType inner_sipdg(1., 1.);  // SIPDG
+    [[maybe_unused]] InnerCouplingType inner_iipdg(0., 1.); // IIPDG
+    [[maybe_unused]] InnerCouplingType inner_sipdg(1., 1.); // SIPDG
     // InnerCoupling: with custom diffusion and weight
     const XT::Functions::GenericGridFunction<E, d, d> diffusion(
         0,
         [](const E&) {},
-        [](const DomainType&, const XT::Common::Parameter&) {
-          return VectorJacobianType{{2., 0.}, {0., 2.}};
-        });
+        [](const DomainType&, const XT::Common::Parameter&) { return VectorJacobianType{{2., 0.}, {0., 2.}}; });
     [[maybe_unused]] InnerCouplingType inner_with_diffusion(1., diffusion);
     [[maybe_unused]] InnerCouplingType inner_with_weight(1., diffusion, diffusion);
     // InnerCoupling: copy constructor
@@ -127,11 +125,9 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
     InnerCouplingType integrand(symmetry_prefactor, 1. /*diffusion=I*/, 1. /*weight=I*/);
     const auto& intersection = find_inner_intersection();
     integrand.bind(intersection);
-    const auto integrand_order =
-        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       integrand.evaluate(
           *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
@@ -162,14 +158,11 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
           const double dphi_out_dot_n = grad_phi_out[jj][0] * n;
           const double dpsi_in_dot_n = grad_psi_in[ii][0] * n;
           const double dpsi_out_dot_n = grad_psi_out[ii][0] * n;
-          const double expected_in_in = -wm * dphi_in_dot_n * psi_in[ii][0]
-                                        - s * wm * phi_in[jj][0] * dpsi_in_dot_n;
-          const double expected_in_out = -wp * dphi_out_dot_n * psi_in[ii][0]
-                                         + s * wm * phi_out[jj][0] * dpsi_in_dot_n;
-          const double expected_out_in = wm * dphi_in_dot_n * psi_out[ii][0]
-                                         - s * wp * phi_in[jj][0] * dpsi_out_dot_n;
-          const double expected_out_out = wp * dphi_out_dot_n * psi_out[ii][0]
-                                          + s * wp * phi_out[jj][0] * dpsi_out_dot_n;
+          const double expected_in_in = -wm * dphi_in_dot_n * psi_in[ii][0] - s * wm * phi_in[jj][0] * dpsi_in_dot_n;
+          const double expected_in_out = -wp * dphi_out_dot_n * psi_in[ii][0] + s * wm * phi_out[jj][0] * dpsi_in_dot_n;
+          const double expected_out_in = wm * dphi_in_dot_n * psi_out[ii][0] - s * wp * phi_in[jj][0] * dpsi_out_dot_n;
+          const double expected_out_out =
+              wp * dphi_out_dot_n * psi_out[ii][0] + s * wp * phi_out[jj][0] * dpsi_out_dot_n;
           EXPECT_NEAR(expected_in_in, rin_in[ii][jj], 1e-13);
           EXPECT_NEAR(expected_in_out, rin_out[ii][jj], 1e-13);
           EXPECT_NEAR(expected_out_in, rout_in[ii][jj], 1e-13);
@@ -234,8 +227,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
     const auto& binary = static_cast<BinaryBaseType&>(integrand);
     const auto integrand_order = binary.order(*scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> result(2, 2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       binary.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
       const auto x_in = intersection.geometryInInside().global(x);
@@ -282,8 +274,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
     const auto& unary = static_cast<UnaryBaseType&>(integrand);
     const auto integrand_order = unary.order(*scalar_test_);
     DynamicVector<D> result(2, 0.);
-    for (const auto& qp :
-         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+    for (const auto& qp : Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
       const auto& x = qp.position();
       unary.evaluate(*scalar_test_, x, result);
       const auto x_in = intersection.geometryInInside().global(x);

--- a/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
@@ -79,7 +79,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
   void inner_coupling_post_bind_throws_on_boundary_intersection()
   {
     InnerCouplingType integrand(1., 1.);
-    const auto& bnd = find_boundary_intersection();
+    const auto& bnd = this->find_boundary_intersection();
     EXPECT_THROW(integrand.bind(bnd), Dune::Exception);
   }
 
@@ -101,7 +101,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
   void check_inner_coupling(const double symmetry_prefactor)
   {
     InnerCouplingType integrand(symmetry_prefactor, 1. /*diffusion=I*/, 1. /*weight=I*/);
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     const auto integrand_order = integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
     DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
@@ -184,7 +184,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
     // With unit diffusion/weight (order 0) and scalar_test_(4), scalar_ansatz_(3):
     // order = 0 + 0 + 4 + 3 = 7
     InnerCouplingType integrand(1., 1.);
-    const auto& intersection = find_inner_intersection();
+    const auto& intersection = this->find_inner_intersection();
     integrand.bind(intersection);
     EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
   }
@@ -200,7 +200,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
     // Test with s=1 (SIPDG variant).
     const double s = 1.0;
     DirichletCouplingType integrand(s, 1. /*diffusion=I*/);
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     const auto& binary = static_cast<BinaryBaseType&>(integrand);
     const auto integrand_order = binary.order(*scalar_test_, *scalar_ansatz_);
@@ -231,7 +231,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
   {
     // order = diffusion_order + test_order + ansatz_order = 0 + 4 + 3 = 7
     DirichletCouplingType integrand(1., 1.);
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     const auto& binary = static_cast<BinaryBaseType&>(integrand);
     EXPECT_EQ(7, binary.order(*scalar_test_, *scalar_ansatz_));
@@ -247,7 +247,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
     const double s = 1.0;
     const double g_val = 2.0;
     DirichletCouplingType integrand(s, 1. /*diffusion=I*/, g_val /*dirichlet_data*/);
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     const auto& unary = static_cast<UnaryBaseType&>(integrand);
     const auto integrand_order = unary.order(*scalar_test_);
@@ -271,7 +271,7 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
   {
     // With s=0 (IIPDG): unary result should be 0.
     DirichletCouplingType integrand(0. /*s=0*/, 1. /*diffusion=I*/, 3.0 /*non-trivial data*/);
-    const auto& intersection = find_boundary_intersection();
+    const auto& intersection = this->find_boundary_intersection();
     integrand.bind(intersection);
     const auto& unary = static_cast<UnaryBaseType&>(integrand);
     const auto center = FieldVector<D, d - 1>(0.5);

--- a/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
@@ -1,0 +1,378 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/functions/generic/grid-function.hh>
+#include <dune/xt/grid/intersection.hh>
+
+#include <dune/gdt/local/integrands/laplace-ipdg.hh>
+
+#include <dune/gdt/test/integrands/integrands.hh>
+
+namespace Dune {
+namespace GDT {
+namespace Test {
+
+
+template <class G>
+struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
+{
+  using BaseType = IntegrandTest<G>;
+  using BaseType::d;
+  using typename BaseType::D;
+  using typename BaseType::DomainType;
+  using typename BaseType::E;
+  using typename BaseType::GV;
+  using typename BaseType::I;
+  using typename BaseType::ScalarJacobianType;
+  using typename BaseType::ScalarRangeType;
+  using typename BaseType::VectorJacobianType;
+
+  using InnerCouplingType = LocalLaplaceIPDGIntegrands::InnerCoupling<I>;
+  using DirichletCouplingType = LocalLaplaceIPDGIntegrands::DirichletCoupling<I>;
+  using UnaryBaseType = LocalUnaryIntersectionIntegrandInterface<I>;
+  using BinaryBaseType = LocalBinaryIntersectionIntegrandInterface<I>;
+
+  I find_inner_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No inner intersection found in grid!");
+  }
+
+  I find_boundary_intersection() const
+  {
+    const auto& gv = grid_provider_->leaf_view();
+    for (const auto& element : Dune::elements(gv))
+      for (const auto& intersection : Dune::intersections(gv, element))
+        if (!intersection.neighbor())
+          return intersection;
+    DUNE_THROW(Dune::InvalidStateException, "No boundary intersection found in grid!");
+  }
+
+  void is_constructable() final
+  {
+    // InnerCoupling: (symmetry_prefactor, diffusion)
+    [[maybe_unused]] InnerCouplingType inner_nipdg(-1., 1.); // NIPDG
+    [[maybe_unused]] InnerCouplingType inner_iipdg(0., 1.);  // IIPDG
+    [[maybe_unused]] InnerCouplingType inner_sipdg(1., 1.);  // SIPDG
+    // InnerCoupling: with custom diffusion and weight
+    const XT::Functions::GenericGridFunction<E, d, d> diffusion(
+        0,
+        [](const E&) {},
+        [](const DomainType&, const XT::Common::Parameter&) {
+          return VectorJacobianType{{2., 0.}, {0., 2.}};
+        });
+    [[maybe_unused]] InnerCouplingType inner_with_diffusion(1., diffusion);
+    [[maybe_unused]] InnerCouplingType inner_with_weight(1., diffusion, diffusion);
+    // InnerCoupling: copy constructor
+    InnerCouplingType src(1., 1.);
+    [[maybe_unused]] InnerCouplingType inner_copy(src);
+    // copy_as_quaternary_intersection_integrand
+    auto clone = src.copy_as_quaternary_intersection_integrand();
+    EXPECT_NE(clone, nullptr);
+
+    // DirichletCoupling: (symmetry_prefactor, diffusion)
+    [[maybe_unused]] DirichletCouplingType dir1(1., 1.);
+    [[maybe_unused]] DirichletCouplingType dir2(-1., 1.);
+    // DirichletCoupling: with dirichlet_data
+    [[maybe_unused]] DirichletCouplingType dir3(1., 1., 0.5);
+    [[maybe_unused]] DirichletCouplingType dir4(0., diffusion, 1.0);
+    // DirichletCoupling: copy constructor
+    DirichletCouplingType dir_src(1., 1.);
+    [[maybe_unused]] DirichletCouplingType dir_copy(dir_src);
+    // copy_as_binary / copy_as_unary
+    auto dir_binary_clone = dir_src.copy_as_binary_intersection_integrand();
+    EXPECT_NE(dir_binary_clone, nullptr);
+    auto dir_unary_clone = dir_src.copy_as_unary_intersection_integrand();
+    EXPECT_NE(dir_unary_clone, nullptr);
+    // inside() returns true for both uses
+    EXPECT_TRUE(dir_src.inside());
+  }
+
+  void inner_coupling_post_bind_throws_on_boundary_intersection()
+  {
+    InnerCouplingType integrand(1., 1.);
+    const auto& bnd = find_boundary_intersection();
+    EXPECT_THROW(integrand.bind(bnd), Dune::Exception);
+  }
+
+  // Helper that verifies InnerCoupling::evaluate for a given symmetry_prefactor.
+  //
+  // Formula with diffusion = identity and weight = identity:
+  //   delta_plus = delta_minus = n · n = 1
+  //   weight_minus = delta_plus / (delta_plus + delta_minus) = 0.5
+  //   weight_plus  = delta_minus / (delta_plus + delta_minus) = 0.5
+  //
+  //   result_in_in[i][j]   = -0.5 * (grad_phi_in[j] · n) * psi_in[i]
+  //                          - s * 0.5 * phi_in[j] * (grad_psi_in[i] · n)
+  //   result_in_out[i][j]  = -0.5 * (grad_phi_out[j] · n) * psi_in[i]
+  //                          + s * 0.5 * phi_out[j] * (grad_psi_in[i] · n)
+  //   result_out_in[i][j]  = +0.5 * (grad_phi_in[j] · n) * psi_out[i]
+  //                          - s * 0.5 * phi_in[j] * (grad_psi_out[i] · n)
+  //   result_out_out[i][j] = +0.5 * (grad_phi_out[j] · n) * psi_out[i]
+  //                          + s * 0.5 * phi_out[j] * (grad_psi_out[i] · n)
+  void check_inner_coupling(const double symmetry_prefactor)
+  {
+    InnerCouplingType integrand(symmetry_prefactor, 1. /*diffusion=I*/, 1. /*weight=I*/);
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    const auto integrand_order =
+        integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> rin_in(2, 2, 0.), rin_out(2, 2, 0.), rout_in(2, 2, 0.), rout_out(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(
+          *scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_, x, rin_in, rin_out, rout_in, rout_out);
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto x_out = intersection.geometryInOutside().global(x);
+      const auto n = intersection.unitOuterNormal(x);
+      // Evaluate basis functions and their gradients independently.
+      std::vector<ScalarRangeType> phi_in, phi_out, psi_in, psi_out;
+      std::vector<ScalarJacobianType> grad_phi_in, grad_phi_out, grad_psi_in, grad_psi_out;
+      scalar_ansatz_->evaluate(x_in, phi_in);
+      scalar_ansatz_->evaluate(x_out, phi_out);
+      scalar_test_->evaluate(x_in, psi_in);
+      scalar_test_->evaluate(x_out, psi_out);
+      scalar_ansatz_->jacobians(x_in, grad_phi_in);
+      scalar_ansatz_->jacobians(x_out, grad_phi_out);
+      scalar_test_->jacobians(x_in, grad_psi_in);
+      scalar_test_->jacobians(x_out, grad_psi_out);
+      // With diffusion = I and weight = I:
+      //   delta_plus = delta_minus = n · n = 1  →  weight_minus = weight_plus = 0.5
+      const double wm = 0.5; // weight_minus
+      const double wp = 0.5; // weight_plus
+      const double s = symmetry_prefactor;
+      for (size_t ii = 0; ii < 2; ++ii) {
+        for (size_t jj = 0; jj < 2; ++jj) {
+          // grad[jj][0] is the gradient row (FieldVector<D,d>) for the scalar function.
+          // With diffusion = I: (I * grad) * n = grad · n
+          const double dphi_in_dot_n = grad_phi_in[jj][0] * n;
+          const double dphi_out_dot_n = grad_phi_out[jj][0] * n;
+          const double dpsi_in_dot_n = grad_psi_in[ii][0] * n;
+          const double dpsi_out_dot_n = grad_psi_out[ii][0] * n;
+          const double expected_in_in = -wm * dphi_in_dot_n * psi_in[ii][0]
+                                        - s * wm * phi_in[jj][0] * dpsi_in_dot_n;
+          const double expected_in_out = -wp * dphi_out_dot_n * psi_in[ii][0]
+                                         + s * wm * phi_out[jj][0] * dpsi_in_dot_n;
+          const double expected_out_in = wm * dphi_in_dot_n * psi_out[ii][0]
+                                         - s * wp * phi_in[jj][0] * dpsi_out_dot_n;
+          const double expected_out_out = wp * dphi_out_dot_n * psi_out[ii][0]
+                                          + s * wp * phi_out[jj][0] * dpsi_out_dot_n;
+          EXPECT_NEAR(expected_in_in, rin_in[ii][jj], 1e-13);
+          EXPECT_NEAR(expected_in_out, rin_out[ii][jj], 1e-13);
+          EXPECT_NEAR(expected_out_in, rout_in[ii][jj], 1e-13);
+          EXPECT_NEAR(expected_out_out, rout_out[ii][jj], 1e-13);
+        }
+      }
+      // For IIPDG (s=0), the symmetry term vanishes → only consistency terms remain.
+      if (symmetry_prefactor == 0.) {
+        for (size_t ii = 0; ii < 2; ++ii)
+          for (size_t jj = 0; jj < 2; ++jj) {
+            const double dphi_in_dot_n = grad_phi_in[jj][0] * n;
+            const double dphi_out_dot_n = grad_phi_out[jj][0] * n;
+            EXPECT_NEAR(-wm * dphi_in_dot_n * psi_in[ii][0], rin_in[ii][jj], 1e-13);
+            EXPECT_NEAR(-wp * dphi_out_dot_n * psi_in[ii][0], rin_out[ii][jj], 1e-13);
+          }
+      }
+    }
+  }
+
+  void inner_coupling_evaluates_correctly_nipdg()
+  {
+    check_inner_coupling(-1.0);
+  }
+
+  void inner_coupling_evaluates_correctly_iipdg()
+  {
+    check_inner_coupling(0.0);
+  }
+
+  void inner_coupling_evaluates_correctly_sipdg()
+  {
+    check_inner_coupling(1.0);
+  }
+
+  void inner_coupling_order_is_correct()
+  {
+    // order = max(diffusion_order_in, diffusion_order_out)
+    //       + max(weight_order_in, weight_order_out)
+    //       + max(test_order_in, test_order_out)
+    //       + max(ansatz_order_in, ansatz_order_out)
+    // With unit diffusion/weight (order 0) and scalar_test_(4), scalar_ansatz_(3):
+    // order = 0 + 0 + 4 + 3 = 7
+    InnerCouplingType integrand(1., 1.);
+    const auto& intersection = find_inner_intersection();
+    integrand.bind(intersection);
+    EXPECT_EQ(7, integrand.order(*scalar_test_, *scalar_ansatz_, *scalar_test_, *scalar_ansatz_));
+  }
+
+  void dirichlet_coupling_binary_evaluates_correctly()
+  {
+    // Binary form formula with diffusion = I and symmetry_prefactor = s:
+    //   result[i][j] = -1 * (I * grad_phi[j] · n) * psi[i]
+    //                  - s * phi[j] * (I * grad_psi[i] · n)
+    //   with diffusion = I:
+    //   result[i][j] = -(grad_phi[j] · n) * psi[i] - s * phi[j] * (grad_psi[i] · n)
+    //
+    // Test with s=1 (SIPDG variant).
+    const double s = 1.0;
+    DirichletCouplingType integrand(s, 1. /*diffusion=I*/);
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    const auto& binary = static_cast<BinaryBaseType&>(integrand);
+    const auto integrand_order = binary.order(*scalar_test_, *scalar_ansatz_);
+    DynamicMatrix<D> result(2, 2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      binary.evaluate(*scalar_test_, *scalar_ansatz_, x, result);
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto n = intersection.unitOuterNormal(x);
+      std::vector<ScalarRangeType> phi, psi;
+      std::vector<ScalarJacobianType> grad_phi, grad_psi;
+      scalar_ansatz_->evaluate(x_in, phi);
+      scalar_test_->evaluate(x_in, psi);
+      scalar_ansatz_->jacobians(x_in, grad_phi);
+      scalar_test_->jacobians(x_in, grad_psi);
+      for (size_t ii = 0; ii < 2; ++ii) {
+        for (size_t jj = 0; jj < 2; ++jj) {
+          const double dphi_dot_n = grad_phi[jj][0] * n;
+          const double dpsi_dot_n = grad_psi[ii][0] * n;
+          const double expected = -dphi_dot_n * psi[ii][0] - s * phi[jj][0] * dpsi_dot_n;
+          EXPECT_NEAR(expected, result[ii][jj], 1e-13);
+        }
+      }
+    }
+  }
+
+  void dirichlet_coupling_binary_order_is_correct()
+  {
+    // order = diffusion_order + test_order + ansatz_order = 0 + 4 + 3 = 7
+    DirichletCouplingType integrand(1., 1.);
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    const auto& binary = static_cast<BinaryBaseType&>(integrand);
+    EXPECT_EQ(7, binary.order(*scalar_test_, *scalar_ansatz_));
+  }
+
+  void dirichlet_coupling_unary_evaluates_correctly()
+  {
+    // Unary form formula with diffusion = I, dirichlet_data = g, symmetry_prefactor = s:
+    //   result[i] = -s * g(x) * (I * grad_psi[i] · n)
+    //             = -s * g(x) * (grad_psi[i] · n)
+    //
+    // Test with s=1, g=2 (constant Dirichlet data).
+    const double s = 1.0;
+    const double g_val = 2.0;
+    DirichletCouplingType integrand(s, 1. /*diffusion=I*/, g_val /*dirichlet_data*/);
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    const auto& unary = static_cast<UnaryBaseType&>(integrand);
+    const auto integrand_order = unary.order(*scalar_test_);
+    DynamicVector<D> result(2, 0.);
+    for (const auto& qp :
+         Dune::QuadratureRules<D, d - 1>::rule(intersection.type(), integrand_order)) {
+      const auto& x = qp.position();
+      unary.evaluate(*scalar_test_, x, result);
+      const auto x_in = intersection.geometryInInside().global(x);
+      const auto n = intersection.unitOuterNormal(x);
+      std::vector<ScalarJacobianType> grad_psi;
+      scalar_test_->jacobians(x_in, grad_psi);
+      for (size_t ii = 0; ii < 2; ++ii) {
+        const double dpsi_dot_n = grad_psi[ii][0] * n;
+        const double expected = -s * g_val * dpsi_dot_n;
+        EXPECT_NEAR(expected, result[ii], 1e-13);
+      }
+    }
+  }
+
+  void dirichlet_coupling_unary_zero_prefactor_gives_zero()
+  {
+    // With s=0 (IIPDG): unary result should be 0.
+    DirichletCouplingType integrand(0. /*s=0*/, 1. /*diffusion=I*/, 3.0 /*non-trivial data*/);
+    const auto& intersection = find_boundary_intersection();
+    integrand.bind(intersection);
+    const auto& unary = static_cast<UnaryBaseType&>(integrand);
+    const auto center = FieldVector<D, d - 1>(0.5);
+    DynamicVector<D> result(2, 0.);
+    unary.evaluate(*scalar_test_, center, result);
+    for (size_t ii = 0; ii < 2; ++ii)
+      EXPECT_NEAR(0., result[ii], 1e-15);
+  }
+
+  using BaseType::grid_provider_;
+  using BaseType::scalar_ansatz_;
+  using BaseType::scalar_test_;
+}; // struct LaplaceIPDGIntegrandTest
+
+
+} // namespace Test
+} // namespace GDT
+} // namespace Dune
+
+
+template <class G>
+using LaplaceIPDGIntegrandTest = Dune::GDT::Test::LaplaceIPDGIntegrandTest<G>;
+TYPED_TEST_SUITE(LaplaceIPDGIntegrandTest, Grids2D);
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, is_constructable)
+{
+  this->is_constructable();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, inner_coupling_post_bind_throws_on_boundary_intersection)
+{
+  this->inner_coupling_post_bind_throws_on_boundary_intersection();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, inner_coupling_order_is_correct)
+{
+  this->inner_coupling_order_is_correct();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, inner_coupling_evaluates_correctly_nipdg)
+{
+  this->inner_coupling_evaluates_correctly_nipdg();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, inner_coupling_evaluates_correctly_iipdg)
+{
+  this->inner_coupling_evaluates_correctly_iipdg();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, inner_coupling_evaluates_correctly_sipdg)
+{
+  this->inner_coupling_evaluates_correctly_sipdg();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, dirichlet_coupling_binary_evaluates_correctly)
+{
+  this->dirichlet_coupling_binary_evaluates_correctly();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, dirichlet_coupling_binary_order_is_correct)
+{
+  this->dirichlet_coupling_binary_order_is_correct();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, dirichlet_coupling_unary_evaluates_correctly)
+{
+  this->dirichlet_coupling_unary_evaluates_correctly();
+}
+
+TYPED_TEST(LaplaceIPDGIntegrandTest, dirichlet_coupling_unary_zero_prefactor_gives_zero)
+{
+  this->dirichlet_coupling_unary_zero_prefactor_gives_zero();
+}

--- a/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
+++ b/dune/gdt/test/integrands/integrands_laplace_ipdg.cc
@@ -7,8 +7,6 @@
 
 #include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
 
-#include <dune/grid/common/rangegenerators.hh>
-
 #include <dune/xt/functions/generic/grid-function.hh>
 #include <dune/xt/grid/intersection.hh>
 
@@ -39,26 +37,6 @@ struct LaplaceIPDGIntegrandTest : public IntegrandTest<G>
   using DirichletCouplingType = LocalLaplaceIPDGIntegrands::DirichletCoupling<I>;
   using UnaryBaseType = LocalUnaryIntersectionIntegrandInterface<I>;
   using BinaryBaseType = LocalBinaryIntersectionIntegrandInterface<I>;
-
-  I find_inner_intersection() const
-  {
-    const auto& gv = grid_provider_->leaf_view();
-    for (const auto& element : Dune::elements(gv))
-      for (const auto& intersection : Dune::intersections(gv, element))
-        if (intersection.neighbor())
-          return intersection;
-    DUNE_THROW(Dune::InvalidStateException, "No inner intersection found in grid!");
-  }
-
-  I find_boundary_intersection() const
-  {
-    const auto& gv = grid_provider_->leaf_view();
-    for (const auto& element : Dune::elements(gv))
-      for (const auto& intersection : Dune::intersections(gv, element))
-        if (!intersection.neighbor())
-          return intersection;
-    DUNE_THROW(Dune::InvalidStateException, "No boundary intersection found in grid!");
-  }
 
   void is_constructable() final
   {

--- a/dune/gdt/test/integrands/integrands_symmetric_elliptic.cc
+++ b/dune/gdt/test/integrands/integrands_symmetric_elliptic.cc
@@ -66,6 +66,44 @@ struct SymmetrizedLaplaceIntegrandTest : public IntegrandTest<G>
         2, [](const DomainType& x, const XT::Common::Parameter&) { return x[0] * x[1]; });
     [[maybe_unused]] VectorIntegrandType vector_integrand3(scalar_function);
     [[maybe_unused]] VectorIntegrandType vector_integrand4(*diffusion_factor_);
+    // copy constructor
+    VectorIntegrandType src;
+    [[maybe_unused]] VectorIntegrandType vector_integrand5(src);
+    // copy_as_binary_element_integrand
+    auto clone = src.copy_as_binary_element_integrand();
+    EXPECT_NE(clone, nullptr);
+  }
+
+  void order_is_correct()
+  {
+    // order = diffusion_order + test_order + ansatz_order
+    // diffusion_factor_ has order 2, vector_test_ has order 2, vector_ansatz_ (custom, order 2)
+    // expected: 2 + 2 + 2 = 6
+    VectorIntegrandType integrand(*diffusion_factor_);
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    integrand.bind(element);
+    EXPECT_EQ(6, integrand.order(*vector_test_, *vector_ansatz_));
+    // With constant (order 0) diffusion: 0 + 2 + 2 = 4
+    VectorIntegrandType integrand_const(1.);
+    integrand_const.bind(element);
+    EXPECT_EQ(4, integrand_const.order(*vector_test_, *vector_ansatz_));
+  }
+
+  void evaluates_to_zero_with_zero_test_jacobian()
+  {
+    // vector_test_[0] = (1,2) has a zero jacobian, so result[0][*] must be zero
+    // for any ansatz. This holds regardless of the diffusion factor.
+    VectorIntegrandType integrand(*diffusion_factor_);
+    const auto element = *(grid_provider_->leaf_view().template begin<0>());
+    integrand.bind(element);
+    const auto integrand_order = integrand.order(*vector_test_, *vector_ansatz_);
+    DynamicMatrix<D> result(2, 2, 0.);
+    for (const auto& qp : Dune::QuadratureRules<D, d>::rule(element.type(), integrand_order)) {
+      const auto& x = qp.position();
+      integrand.evaluate(*vector_test_, *vector_ansatz_, x, result);
+      EXPECT_DOUBLE_EQ(0., result[0][0]);
+      EXPECT_DOUBLE_EQ(0., result[0][1]);
+    }
   }
 
   virtual void evaluates_correctly()
@@ -109,6 +147,16 @@ TYPED_TEST_SUITE(SymmetrizedLaplaceIntegrandTest, Grids2D);
 TYPED_TEST(SymmetrizedLaplaceIntegrandTest, is_constructable)
 {
   this->is_constructable();
+}
+
+TYPED_TEST(SymmetrizedLaplaceIntegrandTest, order_is_correct)
+{
+  this->order_is_correct();
+}
+
+TYPED_TEST(SymmetrizedLaplaceIntegrandTest, evaluates_to_zero_with_zero_test_jacobian)
+{
+  this->evaluates_to_zero_with_zero_test_jacobian();
 }
 
 TYPED_TEST(SymmetrizedLaplaceIntegrandTest, evaluates_correctly)


### PR DESCRIPTION
## Summary

Closes #281. Adds unit tests covering the four intersection integrand headers, plus augments the existing symmetric-elliptic test file.

- **`integrands_jump.cc`** — `LocalJumpIntegrands::Inner<I,r>` and `Boundary<I,r>`: construction (default and custom diameter function), `post_bind` throw on boundary intersection, order computation, scalar and vector evaluate formula verification, boundary evaluate, custom-diameter-function propagation.

- **`integrands_ipdg.cc`** — `LocalIPDGIntegrands::InnerPenalty<I>` and `BoundaryPenalty<I>`: construction (scalar sigma, constant weight, grid-function weight), `post_bind` throw on boundary intersection, order, harmonic-mean weight formula with unit and constant weight tensors, zero-penalty edge case.

- **`integrands_laplace_ipdg.cc`** — `LocalLaplaceIPDGIntegrands::InnerCoupling<I>` (NIPDG/IIPDG/SIPDG symmetry prefactors) and `DirichletCoupling<I>` (accessed through both its binary and unary base interfaces): construction, order, coupling formula verification for all three prefactors, zero-prefactor edge case, unary Dirichlet data evaluation.

- **`integrands_symmetric_elliptic.cc`** (augmented) — copy constructor, `copy_as_binary_element_integrand`, order with non-constant diffusion factor, zero-Jacobian test for `LocalSymmetrizedLaplaceIntegrand`.

### Design notes

All intersection tests use **formula-based verification**: basis functions are independently evaluated at `geometryInInside/Outside().global(x)` mapped coordinates, the integrand formula is recomputed explicitly, and the result is compared against `evaluate()` — this stays numerically correct across all grid types (YASP, ALU simplex/cube, UG, ALBERTA).

No CMakeLists changes are needed; `add_subdir_tests` auto-discovers new `.cc` files via `GLOB_RECURSE`.

## Test plan

- [ ] All 9 `JumpIntegrandTest` typed tests pass on all `Grids2D` types
- [ ] All 9 `IPDGIntegrandTest` typed tests pass
- [ ] All 10 `LaplaceIPDGIntegrandTest` typed tests pass
- [ ] All extended `SymmetrizedLaplaceIntegrandTest` typed tests pass (4 tests including 2 new ones)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6tuPHFiEfAgRMu8eDzr6r)_