### PR TITLE
ci: switch runners to ubuntu-26.04, add disk-cleanup script

### DIFF
--- a/.ci/free_disk_space.bash
+++ b/.ci/free_disk_space.bash
@@ -16,12 +16,13 @@ set -uo pipefail
 
 remove_path() {
   local path="$1"
-  if [ -e "${path}" ]; then
+  if [[ -e "${path}" ]]; then
     local size
     size="$(sudo du -sh "${path}" 2>/dev/null | cut -f1)"
     echo "removing ${path} (${size:-unknown size})"
     sudo rm -rf "${path}"
   fi
+  return 0
 }
 
 before_kib="$(df --output=avail -B1K / | tail -n1)"

--- a/.ci/free_disk_space.bash
+++ b/.ci/free_disk_space.bash
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Frees up disk space on the GitHub-hosted ubuntu-26.04 runner by removing preinstalled
+# toolchains this project never uses. The image ships with several large SDKs (Android,
+# .NET, Haskell, Swift, CodeQL) intended for other projects' CI -- see
+# https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md
+# for the full inventory. Together they occupy tens of GB that our vcpkg-from-source and
+# LTO wheel builds would rather have.
+#
+# Intended to run once, right after checkout, in disk-hungry jobs (the vcpkg/coverage
+# build, the wheel build, the benchmarks build). Safe to call unconditionally: every
+# removal is guarded by an existence check, so a path missing on a future image version
+# is silently skipped rather than failing the job.
+
+set -uo pipefail
+
+remove_path() {
+  local path="$1"
+  if [ -e "${path}" ]; then
+    local size
+    size="$(sudo du -sh "${path}" 2>/dev/null | cut -f1)"
+    echo "removing ${path} (${size:-unknown size})"
+    sudo rm -rf "${path}"
+  fi
+}
+
+before_kib="$(df --output=avail -B1K / | tail -n1)"
+
+# Android SDK + NDK: by far the largest single item on the image.
+remove_path "${ANDROID_HOME:-/usr/local/lib/android}"
+
+# .NET SDKs (several major versions preinstalled side by side).
+remove_path /usr/share/dotnet
+remove_path "${HOME}/.dotnet"
+
+# Haskell/GHC toolchain.
+remove_path /opt/ghc
+remove_path /usr/local/.ghcup
+
+# Swift toolchain.
+remove_path /usr/share/swift
+
+# CodeQL bundle (this repo has no code-scanning workflow).
+remove_path "${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}/CodeQL"
+
+after_kib="$(df --output=avail -B1K / | tail -n1)"
+freed_mib=$(( (after_kib - before_kib) / 1024 ))
+echo "freed approximately ${freed_mib} MiB (root filesystem avail: $((before_kib / 1024)) MiB -> $((after_kib / 1024)) MiB)"

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,5 @@
 ---
 # actionlint configuration.
 #
-# All jobs run on GitHub-hosted runners (ubuntu-24.04), so there are no custom
+# All jobs run on GitHub-hosted runners (ubuntu-26.04), so there are no custom
 # self-hosted runner labels to register here.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,13 @@
 ---
 # actionlint configuration.
 #
-# All jobs run on GitHub-hosted runners (ubuntu-26.04), so there are no custom
-# self-hosted runner labels to register here.
+# All jobs run on GitHub-hosted runners (ubuntu-26.04); there are no actual
+# self-hosted runners. ubuntu-26.04 is listed below purely as a workaround:
+# actionlint validates `runs-on` against a hardcoded list of known GitHub-hosted
+# labels baked into the pinned actionlint version, which predates the
+# ubuntu-26.04 image and would otherwise flag it as unknown. Registering it as
+# a "self-hosted" label is actionlint's documented escape hatch for labels it
+# doesn't recognize yet -- see https://github.com/rhysd/actionlint/blob/main/docs/config.md.
+self-hosted-runner:
+  labels:
+  - ubuntu-26.04

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   benchmarks:
     name: Build and run benchmarks (Release)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120
 
     steps:
@@ -31,6 +31,11 @@ jobs:
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
+
+    - name: Free disk space
+      # vcpkg builds every dependency from source; the runner's preinstalled SDKs
+      # (Android, .NET, Haskell, ...) are unused here and just eat into that budget.
+      run: ./.ci/free_disk_space.bash
 
     # The build/ tree and .vcpkg-root toolchain are intentionally NOT cached (see
     # non_docker_build.yml): a corrupted restore was repeatedly failing builds, so

--- a/.github/workflows/check_markdown_links.yml
+++ b/.github/workflows/check_markdown_links.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   markdown-link-check:
     name: Markdown
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - name: Checkout reposotiry
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
     - name: Fetch dependabot metadata

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -27,7 +27,7 @@ jobs:
   # pipeline. `push`/`workflow_dispatch` ignore the outputs and always run full.
   changes:
     name: Detect changed paths
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       # paths-filter reads the PR file list via the API on pull_request events
@@ -67,7 +67,7 @@ jobs:
     # workflow-wide constant; a job output (needs.config.outputs.*) is the
     # simplest shared value.
     name: CI sizing constants
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     outputs:
@@ -80,7 +80,7 @@ jobs:
         # ---- GitHub-hosted runner vCPU count ----
         # Detect the runner's core count instead of hard-coding it, so the derived
         # -j / --parallel levels stay correct if the runner class ever changes. The
-        # config job shares build-linux's ubuntu-24.04 label, so its nproc matches
+        # config job shares build-linux's ubuntu-26.04 label, so its nproc matches
         # that job's core count; standard GitHub-hosted runners report 4.
         linux_cpu="$(nproc)"
         # -----------------------------------------
@@ -119,7 +119,7 @@ jobs:
     # level OOM-killed this 16 GB runner. Every compile step (incl. the main Build)
     # is -j capped for the same reason. Neither preset uses LTO, so there is no
     # /tmp ltrans explosion like build_wheels.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     # A fully cold leg (no build cache) compiles every vcpkg dependency as a shared
     # library, the project, the ~400 test binaries and the Python bindings from
     # scratch; on the 4 vCPU hosted runner with the memory-bounded -j caps above
@@ -161,6 +161,12 @@ jobs:
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
+
+    - name: Free disk space
+      # vcpkg builds every dependency from source and this leg additionally keeps a
+      # coverage-instrumented build tree; the runner's preinstalled SDKs (Android,
+      # .NET, Haskell, ...) are unused here and just eat into that budget.
+      run: ./.ci/free_disk_space.bash
 
     # The build/ tree and .vcpkg-root toolchain are intentionally NOT cached: a
     # corrupted restore was repeatedly failing the build (vcpkg configure dying
@@ -316,7 +322,7 @@ jobs:
     # their *.ltrans.o scratch within /tmp and the build stays within memory (the
     # much wider -j on the old self-hosted box needed an enlarged volume for the
     # spill — moot at -j3).
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     # A cold build compiles every vcpkg dependency plus the LTO release bindings
     # from scratch. On the 4 vCPU hosted runner (half the cores of the old
     # self-hosted box, and -j3 vs -j7) that is far slower, so the timeout is raised
@@ -336,6 +342,12 @@ jobs:
         submodules: recursive
         fetch-tags: true
         fetch-depth: 0
+
+    - name: Free disk space
+      # vcpkg builds every dependency from source and the LTO release bindings spill
+      # link scratch to /tmp; the runner's preinstalled SDKs (Android, .NET, Haskell,
+      # ...) are unused here and just eat into that budget.
+      run: ./.ci/free_disk_space.bash
 
     - name: Restore wheel-build ccache
       # build-wheels.sh sets CCACHE_DIR to build/wheelhouse/cache (on the host
@@ -430,7 +442,7 @@ jobs:
     # GitHub-hosted standard runner (4 vCPU / 16 GB). The docs build is
     # single-threaded (sphinx -j 1), so the standard runner is plenty (it only
     # downloads the wheels artifact and renders HTML).
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     permissions:
       contents: read
@@ -588,7 +600,7 @@ jobs:
 
   deploy_docs:
     name: Deploy docs to GitHub Pages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: build_docs
     # publish only on pushes to main; PRs and the merge queue build (above) but
     # never deploy. build_docs must have succeeded, so broken docs are not
@@ -625,7 +637,7 @@ jobs:
 
   test_publish:
     name: Publish to Test PyPI
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: build_wheels
     # only publish to Test PyPI on pushes to main, never on PRs, the merge
     # queue, or manual runs
@@ -656,7 +668,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: build_wheels
     if: startsWith(github.ref, 'refs/tags/')
     timeout-minutes: 120
@@ -689,7 +701,7 @@ jobs:
   # check pending forever. Matrix job results aggregate (any failed leg => failure).
   ci-gate:
     name: CI gate
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions: {}
     if: always()
     needs: [changes, config, build-linux, build_wheels, build_docs]

--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -11,7 +11,7 @@ name: Sanity checks
 jobs:
   message-check:
     name: Block Autosquash Commits
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - name: Block Autosquash Commits
       uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
@@ -19,7 +19,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   merge_conflict_job:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     name: Find merge conflicts
     steps:
     - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,9 @@ if(DXT_USE_UV_PYTHON)
   find_program(UV_EXECUTABLE uv)
 endif()
 if(UV_EXECUTABLE)
-  # `uv python find` only locates an already-available interpreter; it does not download one. On a host/runner without
-  # the pinned (.python-version) interpreter -- e.g. ubuntu-24.04 ships 3.12, not 3.13 -- resolve it in two steps: try
-  # to find it, and if that fails install it with `uv python install` (uv downloads a managed CPython) and find it
-  # again.
+  # `uv python find` only locates an already-available interpreter; it does not download one. On a host/runner whose
+  # system Python doesn't match the pinned (.python-version) interpreter, resolve it in two steps: try to find it,
+  # and if that fails install it with `uv python install` (uv downloads a managed CPython) and find it again.
   execute_process(
     COMMAND ${UV_EXECUTABLE} python find
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,8 @@ if(DXT_USE_UV_PYTHON)
 endif()
 if(UV_EXECUTABLE)
   # `uv python find` only locates an already-available interpreter; it does not download one. On a host/runner whose
-  # system Python doesn't match the pinned (.python-version) interpreter, resolve it in two steps: try to find it,
-  # and if that fails install it with `uv python install` (uv downloads a managed CPython) and find it again.
+  # system Python doesn't match the pinned (.python-version) interpreter, resolve it in two steps: try to find it, and
+  # if that fails install it with `uv python install` (uv downloads a managed CPython) and find it again.
   execute_process(
     COMMAND ${UV_EXECUTABLE} python find
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ discrete function spaces.
 ## Continuous integration
 
 CI for this project (Linux build & test, Python wheels, and documentation) runs on
-GitHub-hosted Actions runners (`ubuntu-24.04`).
+GitHub-hosted Actions runners (`ubuntu-26.04`).


### PR DESCRIPTION
## Summary
- Switches every job's `runs-on` from `ubuntu-24.04` to `ubuntu-26.04` across all five workflows (`benchmarks.yml`, `check_markdown_links.yml`, `dependabot.yml`, `non_docker_build.yml`, `sanity_checks.yml`), and updates the matching comments in `non_docker_build.yml`, `README.md`, and `.github/actionlint.yaml`.
- Adds `.ci/free_disk_space.bash`, a common cleanup script that removes the largest preinstalled toolchains this project never uses (Android SDK/NDK, .NET SDKs, Haskell/GHC, Swift, the CodeQL bundle), per the [Ubuntu 26.04 runner-image inventory](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md). Every removal is guarded by an existence check, so it stays a no-op if a path moves on a future image.
- Wires the cleanup step in right after checkout in the three disk-hungry build jobs that compile vcpkg dependencies (and, for `build_wheels`, LTO release bindings) from scratch: `benchmarks`, `build-linux`, and `build_wheels`.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` over all five workflow YAML files — parses cleanly.
- [x] `bash -n .ci/free_disk_space.bash` — syntax check passes.
- [ ] CI run on this PR exercises the `ubuntu-26.04` label and the new cleanup step in `benchmarks`, `build-linux`, and `build_wheels`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XFGUMMJtDBC733Q7SYdGGY)_