### PR TITLE
Re-architecture D1–D4 from the adversarial PDE-solver review

### DIFF
--- a/dune/gdt/local/assembler/bilinear-form-assemblers.hh
+++ b/dune/gdt/local/assembler/bilinear-form-assemblers.hh
@@ -27,6 +27,48 @@
 
 namespace Dune {
 namespace GDT {
+namespace internal {
+
+
+/**
+ * \brief COO staging buffer for the matrix assemblers below.
+ *
+ * Each assembler functor (and thus each thread, since the grid walker copies functors per thread) stages its
+ * contributions here instead of scattering scalars into the global matrix under its entry locks (review A2/D2). The
+ * walker calls finalize() on every functor copy sequentially after the walk, so the bulk of the scatter is merged
+ * lock-free; buffers overflowing the size cap are flushed during the walk, where thread safety rests on the internal
+ * locking of Matrix::add_to_entry.
+ */
+template <class Matrix>
+class MatrixScatterBuffer
+{
+  static_assert(XT::LA::is_matrix<Matrix>::value, "");
+  using FieldType = typename Matrix::ScalarType;
+
+public:
+  void stage(const size_t ii, const size_t jj, const FieldType& value, Matrix& matrix)
+  {
+    entries_.emplace_back(ii, jj, value);
+    if (entries_.size() >= max_pending_entries)
+      this->flush(matrix);
+  }
+
+  void flush(Matrix& matrix)
+  {
+    for (const auto& [ii, jj, value] : entries_)
+      matrix.add_to_entry(ii, jj, value);
+    entries_.clear();
+  }
+
+private:
+  //! bounds the memory held between flushes (~6 MiB at 24 bytes/entry)
+  static constexpr size_t max_pending_entries = 1 << 18;
+
+  std::vector<std::tuple<size_t, size_t, FieldType>> entries_;
+}; // class MatrixScatterBuffer
+
+
+} // namespace internal
 
 
 template <class Matrix,
@@ -134,32 +176,17 @@ public:
     ansatz_space_->mapper().global_indices(element, global_ansatz_indices_);
     for (size_t ii = 0; ii < test_basis_->size(param_); ++ii)
       for (size_t jj = 0; jj < ansatz_basis_->size(param_); ++jj)
-        scatter_.emplace_back(global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj]);
-    if (scatter_.size() >= max_pending_scatter_entries)
-      flush_scatter();
+        scatter_.stage(
+            global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj], global_matrix_);
   } // ... apply_local(...)
 
-  /**
-   * Merges this functor's pending contributions into the global matrix. Called by the grid walker once per functor
-   * copy after the walk (sequentially, so the bulk of the scatter is lock-free); overflowing buffers are flushed
-   * during the walk, where thread safety rests on the internal locking of MatrixType::add_to_entry.
-   */
+  //! merges this functor's pending contributions into the global matrix, \sa internal::MatrixScatterBuffer
   void finalize() override final
   {
-    flush_scatter();
+    scatter_.flush(global_matrix_);
   }
 
 private:
-  void flush_scatter()
-  {
-    for (const auto& [ii, jj, value] : scatter_)
-      global_matrix_.add_to_entry(ii, jj, value);
-    scatter_.clear();
-  }
-
-  //! bounds the memory held between flushes (~6 MiB at 24 bytes/entry)
-  static constexpr size_t max_pending_scatter_entries = 1 << 18;
-
   const std::unique_ptr<TestSpaceType> test_space_;
   const std::unique_ptr<AnsatzSpaceType> ansatz_space_;
   const std::unique_ptr<LocalBilinearFormType> local_bilinear_form_;
@@ -171,7 +198,7 @@ private:
   DynamicVector<size_t> global_ansatz_indices_;
   mutable std::unique_ptr<typename TestSpaceType::GlobalBasisType::LocalizedType> test_basis_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_;
-  std::vector<std::tuple<size_t, size_t, FieldType>> scatter_;
+  internal::MatrixScatterBuffer<MatrixType> scatter_;
 }; // class LocalElementBilinearFormAssembler
 
 
@@ -299,45 +326,37 @@ public:
     ansatz_space_->mapper().global_indices(outside_element, global_ansatz_indices_out_);
     for (size_t ii = 0; ii < test_basis_inside_->size(param_); ++ii) {
       for (size_t jj = 0; jj < ansatz_basis_inside_->size(param_); ++jj)
-        scatter_.emplace_back(
-            global_test_indices_in_[ii], global_ansatz_indices_in_[jj], scaling_ * local_matrix_in_in_[ii][jj]);
+        scatter_.stage(global_test_indices_in_[ii],
+                       global_ansatz_indices_in_[jj],
+                       scaling_ * local_matrix_in_in_[ii][jj],
+                       global_matrix_);
       for (size_t jj = 0; jj < ansatz_basis_outside_->size(param_); ++jj)
-        scatter_.emplace_back(
-            global_test_indices_in_[ii], global_ansatz_indices_out_[jj], scaling_ * local_matrix_in_out_[ii][jj]);
+        scatter_.stage(global_test_indices_in_[ii],
+                       global_ansatz_indices_out_[jj],
+                       scaling_ * local_matrix_in_out_[ii][jj],
+                       global_matrix_);
     }
     for (size_t ii = 0; ii < test_basis_outside_->size(param_); ++ii) {
       for (size_t jj = 0; jj < ansatz_basis_inside_->size(param_); ++jj)
-        scatter_.emplace_back(
-            global_test_indices_out_[ii], global_ansatz_indices_in_[jj], scaling_ * local_matrix_out_in_[ii][jj]);
+        scatter_.stage(global_test_indices_out_[ii],
+                       global_ansatz_indices_in_[jj],
+                       scaling_ * local_matrix_out_in_[ii][jj],
+                       global_matrix_);
       for (size_t jj = 0; jj < ansatz_basis_outside_->size(param_); ++jj)
-        scatter_.emplace_back(
-            global_test_indices_out_[ii], global_ansatz_indices_out_[jj], scaling_ * local_matrix_out_out_[ii][jj]);
+        scatter_.stage(global_test_indices_out_[ii],
+                       global_ansatz_indices_out_[jj],
+                       scaling_ * local_matrix_out_out_[ii][jj],
+                       global_matrix_);
     }
-    if (scatter_.size() >= max_pending_scatter_entries)
-      flush_scatter();
   } // ... apply_local(...)
 
-  /**
-   * Merges this functor's pending contributions into the global matrix. Called by the grid walker once per functor
-   * copy after the walk (sequentially, so the bulk of the scatter is lock-free); overflowing buffers are flushed
-   * during the walk, where thread safety rests on the internal locking of MatrixType::add_to_entry.
-   */
+  //! merges this functor's pending contributions into the global matrix, \sa internal::MatrixScatterBuffer
   void finalize() override final
   {
-    flush_scatter();
+    scatter_.flush(global_matrix_);
   }
 
 private:
-  void flush_scatter()
-  {
-    for (const auto& [ii, jj, value] : scatter_)
-      global_matrix_.add_to_entry(ii, jj, value);
-    scatter_.clear();
-  }
-
-  //! bounds the memory held between flushes (~6 MiB at 24 bytes/entry)
-  static constexpr size_t max_pending_scatter_entries = 1 << 18;
-
   const std::unique_ptr<TestSpaceType> test_space_;
   const std::unique_ptr<AnsatzSpaceType> ansatz_space_;
   const std::unique_ptr<LocalBilinearFormType> local_bilinear_form_;
@@ -356,7 +375,7 @@ private:
   mutable std::unique_ptr<typename TestSpaceType::GlobalBasisType::LocalizedType> test_basis_outside_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_inside_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_outside_;
-  std::vector<std::tuple<size_t, size_t, FieldType>> scatter_;
+  internal::MatrixScatterBuffer<MatrixType> scatter_;
 }; // class LocalCouplingIntersectionBilinearFormAssembler
 
 
@@ -457,32 +476,17 @@ public:
     ansatz_space_->mapper().global_indices(element, global_ansatz_indices_);
     for (size_t ii = 0; ii < test_basis_->size(param_); ++ii)
       for (size_t jj = 0; jj < ansatz_basis_->size(param_); ++jj)
-        scatter_.emplace_back(global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj]);
-    if (scatter_.size() >= max_pending_scatter_entries)
-      flush_scatter();
+        scatter_.stage(
+            global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj], global_matrix_);
   } // ... apply_local(...)
 
-  /**
-   * Merges this functor's pending contributions into the global matrix. Called by the grid walker once per functor
-   * copy after the walk (sequentially, so the bulk of the scatter is lock-free); overflowing buffers are flushed
-   * during the walk, where thread safety rests on the internal locking of MatrixType::add_to_entry.
-   */
+  //! merges this functor's pending contributions into the global matrix, \sa internal::MatrixScatterBuffer
   void finalize() override final
   {
-    flush_scatter();
+    scatter_.flush(global_matrix_);
   }
 
 private:
-  void flush_scatter()
-  {
-    for (const auto& [ii, jj, value] : scatter_)
-      global_matrix_.add_to_entry(ii, jj, value);
-    scatter_.clear();
-  }
-
-  //! bounds the memory held between flushes (~6 MiB at 24 bytes/entry)
-  static constexpr size_t max_pending_scatter_entries = 1 << 18;
-
   const std::unique_ptr<TestSpaceType> test_space_;
   const std::unique_ptr<AnsatzSpaceType> ansatz_space_;
   const std::unique_ptr<LocalBilinearFormType> local_bilinear_form_;
@@ -494,7 +498,7 @@ private:
   DynamicVector<size_t> global_ansatz_indices_;
   mutable std::unique_ptr<typename TestSpaceType::GlobalBasisType::LocalizedType> test_basis_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_;
-  std::vector<std::tuple<size_t, size_t, FieldType>> scatter_;
+  internal::MatrixScatterBuffer<MatrixType> scatter_;
 }; // class LocalIntersectionBilinearFormAssembler
 
 

--- a/dune/gdt/local/assembler/bilinear-form-assemblers.hh
+++ b/dune/gdt/local/assembler/bilinear-form-assemblers.hh
@@ -15,6 +15,9 @@
 #ifndef DUNE_GDT_LOCAL_ASSEMBLER_TWO_FORM_ASSEMBLERS_HH
 #define DUNE_GDT_LOCAL_ASSEMBLER_TWO_FORM_ASSEMBLERS_HH
 
+#include <tuple>
+#include <vector>
+
 #include <dune/xt/grid/functors/interfaces.hh>
 #include <dune/xt/la/container/matrix-interface.hh>
 
@@ -126,16 +129,37 @@ public:
                 << "\n   {test|ansatz}_basis_->size(param_) = {" << test_basis_->size(param_) << "|"
                 << ansatz_basis_->size(param_) << "}"
                 << "\n   local_matrix_ = " << print(local_matrix_, {{"oneline", "true"}}) << std::endl;
-    // copy local matrix to global matrix
+    // stage the local matrix in this functor's (hence this thread's) scatter buffer
     test_space_->mapper().global_indices(element, global_test_indices_);
     ansatz_space_->mapper().global_indices(element, global_ansatz_indices_);
     for (size_t ii = 0; ii < test_basis_->size(param_); ++ii)
       for (size_t jj = 0; jj < ansatz_basis_->size(param_); ++jj)
-        global_matrix_.add_to_entry(
-            global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj]);
+        scatter_.emplace_back(global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj]);
+    if (scatter_.size() >= max_pending_scatter_entries)
+      flush_scatter();
   } // ... apply_local(...)
 
+  /**
+   * Merges this functor's pending contributions into the global matrix. Called by the grid walker once per functor
+   * copy after the walk (sequentially, so the bulk of the scatter is lock-free); overflowing buffers are flushed
+   * during the walk, where thread safety rests on the internal locking of MatrixType::add_to_entry.
+   */
+  void finalize() override final
+  {
+    flush_scatter();
+  }
+
 private:
+  void flush_scatter()
+  {
+    for (const auto& [ii, jj, value] : scatter_)
+      global_matrix_.add_to_entry(ii, jj, value);
+    scatter_.clear();
+  }
+
+  //! bounds the memory held between flushes (~6 MiB at 24 bytes/entry)
+  static constexpr size_t max_pending_scatter_entries = 1 << 18;
+
   const std::unique_ptr<TestSpaceType> test_space_;
   const std::unique_ptr<AnsatzSpaceType> ansatz_space_;
   const std::unique_ptr<LocalBilinearFormType> local_bilinear_form_;
@@ -147,6 +171,7 @@ private:
   DynamicVector<size_t> global_ansatz_indices_;
   mutable std::unique_ptr<typename TestSpaceType::GlobalBasisType::LocalizedType> test_basis_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_;
+  std::vector<std::tuple<size_t, size_t, FieldType>> scatter_;
 }; // class LocalElementBilinearFormAssembler
 
 
@@ -267,30 +292,52 @@ public:
                                  local_matrix_out_in_,
                                  local_matrix_out_out_,
                                  param_);
-    // copy local matrices to global matrix
+    // stage the local matrices in this functor's (hence this thread's) scatter buffer
     test_space_->mapper().global_indices(inside_element, global_test_indices_in_);
     test_space_->mapper().global_indices(outside_element, global_test_indices_out_);
     ansatz_space_->mapper().global_indices(inside_element, global_ansatz_indices_in_);
     ansatz_space_->mapper().global_indices(outside_element, global_ansatz_indices_out_);
     for (size_t ii = 0; ii < test_basis_inside_->size(param_); ++ii) {
       for (size_t jj = 0; jj < ansatz_basis_inside_->size(param_); ++jj)
-        global_matrix_.add_to_entry(
+        scatter_.emplace_back(
             global_test_indices_in_[ii], global_ansatz_indices_in_[jj], scaling_ * local_matrix_in_in_[ii][jj]);
       for (size_t jj = 0; jj < ansatz_basis_outside_->size(param_); ++jj)
-        global_matrix_.add_to_entry(
+        scatter_.emplace_back(
             global_test_indices_in_[ii], global_ansatz_indices_out_[jj], scaling_ * local_matrix_in_out_[ii][jj]);
     }
     for (size_t ii = 0; ii < test_basis_outside_->size(param_); ++ii) {
       for (size_t jj = 0; jj < ansatz_basis_inside_->size(param_); ++jj)
-        global_matrix_.add_to_entry(
+        scatter_.emplace_back(
             global_test_indices_out_[ii], global_ansatz_indices_in_[jj], scaling_ * local_matrix_out_in_[ii][jj]);
       for (size_t jj = 0; jj < ansatz_basis_outside_->size(param_); ++jj)
-        global_matrix_.add_to_entry(
+        scatter_.emplace_back(
             global_test_indices_out_[ii], global_ansatz_indices_out_[jj], scaling_ * local_matrix_out_out_[ii][jj]);
     }
+    if (scatter_.size() >= max_pending_scatter_entries)
+      flush_scatter();
   } // ... apply_local(...)
 
+  /**
+   * Merges this functor's pending contributions into the global matrix. Called by the grid walker once per functor
+   * copy after the walk (sequentially, so the bulk of the scatter is lock-free); overflowing buffers are flushed
+   * during the walk, where thread safety rests on the internal locking of MatrixType::add_to_entry.
+   */
+  void finalize() override final
+  {
+    flush_scatter();
+  }
+
 private:
+  void flush_scatter()
+  {
+    for (const auto& [ii, jj, value] : scatter_)
+      global_matrix_.add_to_entry(ii, jj, value);
+    scatter_.clear();
+  }
+
+  //! bounds the memory held between flushes (~6 MiB at 24 bytes/entry)
+  static constexpr size_t max_pending_scatter_entries = 1 << 18;
+
   const std::unique_ptr<TestSpaceType> test_space_;
   const std::unique_ptr<AnsatzSpaceType> ansatz_space_;
   const std::unique_ptr<LocalBilinearFormType> local_bilinear_form_;
@@ -309,6 +356,7 @@ private:
   mutable std::unique_ptr<typename TestSpaceType::GlobalBasisType::LocalizedType> test_basis_outside_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_inside_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_outside_;
+  std::vector<std::tuple<size_t, size_t, FieldType>> scatter_;
 }; // class LocalCouplingIntersectionBilinearFormAssembler
 
 
@@ -404,16 +452,37 @@ public:
     test_basis_->bind(element);
     ansatz_basis_->bind(element);
     local_bilinear_form_->apply2(intersection, *test_basis_, *ansatz_basis_, local_matrix_, param_);
-    // copy local matrices to global matrix
+    // stage the local matrix in this functor's (hence this thread's) scatter buffer
     test_space_->mapper().global_indices(element, global_test_indices_);
     ansatz_space_->mapper().global_indices(element, global_ansatz_indices_);
     for (size_t ii = 0; ii < test_basis_->size(param_); ++ii)
       for (size_t jj = 0; jj < ansatz_basis_->size(param_); ++jj)
-        global_matrix_.add_to_entry(
-            global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj]);
+        scatter_.emplace_back(global_test_indices_[ii], global_ansatz_indices_[jj], scaling_ * local_matrix_[ii][jj]);
+    if (scatter_.size() >= max_pending_scatter_entries)
+      flush_scatter();
   } // ... apply_local(...)
 
+  /**
+   * Merges this functor's pending contributions into the global matrix. Called by the grid walker once per functor
+   * copy after the walk (sequentially, so the bulk of the scatter is lock-free); overflowing buffers are flushed
+   * during the walk, where thread safety rests on the internal locking of MatrixType::add_to_entry.
+   */
+  void finalize() override final
+  {
+    flush_scatter();
+  }
+
 private:
+  void flush_scatter()
+  {
+    for (const auto& [ii, jj, value] : scatter_)
+      global_matrix_.add_to_entry(ii, jj, value);
+    scatter_.clear();
+  }
+
+  //! bounds the memory held between flushes (~6 MiB at 24 bytes/entry)
+  static constexpr size_t max_pending_scatter_entries = 1 << 18;
+
   const std::unique_ptr<TestSpaceType> test_space_;
   const std::unique_ptr<AnsatzSpaceType> ansatz_space_;
   const std::unique_ptr<LocalBilinearFormType> local_bilinear_form_;
@@ -425,6 +494,7 @@ private:
   DynamicVector<size_t> global_ansatz_indices_;
   mutable std::unique_ptr<typename TestSpaceType::GlobalBasisType::LocalizedType> test_basis_;
   mutable std::unique_ptr<typename AnsatzSpaceType::GlobalBasisType::LocalizedType> ansatz_basis_;
+  std::vector<std::tuple<size_t, size_t, FieldType>> scatter_;
 }; // class LocalIntersectionBilinearFormAssembler
 
 

--- a/dune/gdt/local/bilinear-forms/integrals.hh
+++ b/dune/gdt/local/bilinear-forms/integrals.hh
@@ -16,6 +16,9 @@
 #ifndef DUNE_GDT_LOCAL_BILINEAR_FORMS_INTEGRALS_HH
 #define DUNE_GDT_LOCAL_BILINEAR_FORMS_INTEGRALS_HH
 
+#include <type_traits>
+#include <utility>
+
 #include <dune/geometry/quadraturerules.hh>
 
 #include <dune/gdt/local/integrands/interfaces.hh>
@@ -144,6 +147,129 @@ private:
   const int over_integrate_;
   mutable DynamicMatrix<F> integrand_values_;
 }; // class LocalElementIntegralBilinearForm
+
+
+/**
+ * \brief Statically dispatched variant of LocalElementIntegralBilinearForm.
+ *
+ * While LocalElementIntegralBilinearForm calls its type-erased integrand through a pure-virtual evaluate() once per
+ * quadrature point (which the compiler can neither inline nor vectorize across), this variant keeps the concrete
+ * integrand as a template parameter and by value, and calls it via qualified (hence non-virtual) calls. Type erasure
+ * is thereby confined to the API boundary: this class still implements LocalElementBilinearFormInterface, so it can
+ * be appended to operators and assemblers like any other local bilinear form, at the cost of one virtual apply2()
+ * per element instead of several virtual calls per quadrature point (review D1).
+ *
+ * \sa make_local_element_integral_bilinear_form
+ */
+template <class Integrand>
+class StaticLocalElementIntegralBilinearForm
+  : public LocalElementBilinearFormInterface<typename Integrand::E,
+                                             Integrand::t_r,
+                                             Integrand::t_rC,
+                                             typename Integrand::TR,
+                                             typename Integrand::F,
+                                             Integrand::a_r,
+                                             Integrand::a_rC,
+                                             typename Integrand::AR>
+{
+  static_assert(std::is_base_of_v<LocalBinaryElementIntegrandInterface<typename Integrand::E,
+                                                                       Integrand::t_r,
+                                                                       Integrand::t_rC,
+                                                                       typename Integrand::TR,
+                                                                       typename Integrand::F,
+                                                                       Integrand::a_r,
+                                                                       Integrand::a_rC,
+                                                                       typename Integrand::AR>,
+                                  Integrand>,
+                "Integrand has to implement LocalBinaryElementIntegrandInterface!");
+
+  using ThisType = StaticLocalElementIntegralBilinearForm;
+  using BaseType = LocalElementBilinearFormInterface<typename Integrand::E,
+                                                     Integrand::t_r,
+                                                     Integrand::t_rC,
+                                                     typename Integrand::TR,
+                                                     typename Integrand::F,
+                                                     Integrand::a_r,
+                                                     Integrand::a_rC,
+                                                     typename Integrand::AR>;
+
+public:
+  using BaseType::d;
+  using typename BaseType::D;
+  using typename BaseType::F;
+  using typename BaseType::LocalAnsatzBasisType;
+  using typename BaseType::LocalTestBasisType;
+
+  using IntegrandType = Integrand;
+
+  explicit StaticLocalElementIntegralBilinearForm(IntegrandType integrand, const int over_integrate = 0)
+    : BaseType(integrand.parameter_type())
+    , integrand_(std::move(integrand))
+    , over_integrate_(over_integrate)
+  {
+  }
+
+  StaticLocalElementIntegralBilinearForm(const ThisType& other) = default;
+
+  StaticLocalElementIntegralBilinearForm(ThisType&& source) noexcept = default;
+
+  std::unique_ptr<BaseType> copy() const override final
+  {
+    return std::make_unique<ThisType>(*this);
+  }
+
+  using BaseType::apply2;
+
+  void apply2(const LocalTestBasisType& test_basis,
+              const LocalAnsatzBasisType& ansatz_basis,
+              DynamicMatrix<F>& result,
+              const XT::Common::Parameter& param = {}) const override final
+  {
+    // prepare integand
+    const auto& element = ansatz_basis.element();
+    assert(test_basis.element() == element && "This must not happen!");
+    integrand_.bind(element);
+    // prepare storage
+    const size_t rows = test_basis.size(param);
+    const size_t cols = ansatz_basis.size(param);
+    if (result.rows() < rows || result.cols() < cols)
+      result.resize(rows, cols);
+    result *= 0;
+    // loop over all quadrature points (note the qualified calls into the integrand, which suppress virtual dispatch)
+    const auto integrand_order = integrand_.IntegrandType::order(test_basis, ansatz_basis, param) + over_integrate_;
+    const auto quadrature_rule = QuadratureRules<D, d>::rule(element.type(), integrand_order);
+    const auto geometry = element.geometry();
+    for (auto [point_in_reference_element, quadrature_weight] : quadrature_rule) {
+      // integration factors
+      const auto factor = geometry.integrationElement(point_in_reference_element) * quadrature_weight;
+      // evaluate the integrand
+      integrand_.IntegrandType::evaluate(
+          test_basis, ansatz_basis, point_in_reference_element, integrand_values_, param);
+      assert(integrand_values_.rows() >= rows && "This must not happen!");
+      assert(integrand_values_.cols() >= cols && "This must not happen!");
+      // compute integral
+      for (size_t ii = 0; ii < rows; ++ii)
+        for (size_t jj = 0; jj < cols; ++jj)
+          result[ii][jj] += integrand_values_[ii][jj] * factor;
+    } // loop over all quadrature points
+  } // ... apply2(...)
+
+private:
+  mutable IntegrandType integrand_;
+  const int over_integrate_;
+  mutable DynamicMatrix<F> integrand_values_;
+}; // class StaticLocalElementIntegralBilinearForm
+
+
+/**
+ * \brief Creates a StaticLocalElementIntegralBilinearForm, deducing the concrete integrand type.
+ */
+template <class Integrand>
+StaticLocalElementIntegralBilinearForm<Integrand>
+make_local_element_integral_bilinear_form(Integrand integrand, const int over_integrate = 0)
+{
+  return StaticLocalElementIntegralBilinearForm<Integrand>(std::move(integrand), over_integrate);
+}
 
 
 /**

--- a/dune/gdt/local/bilinear-forms/integrals.hh
+++ b/dune/gdt/local/bilinear-forms/integrals.hh
@@ -121,7 +121,7 @@ public:
       result.resize(rows, cols);
     result *= 0;
     // loop over all quadrature points
-    const auto integrand_order = integrand_->order(test_basis, ansatz_basis) + over_integrate_;
+    const auto integrand_order = integrand_->order(test_basis, ansatz_basis, param) + over_integrate_;
     const auto quadrature_rule = QuadratureRules<D, d>::rule(element.type(), integrand_order);
     const auto geometry = element.geometry();
     for (auto [point_in_reference_element, quadrature_weight] : quadrature_rule) {
@@ -358,7 +358,7 @@ public:
     ensure_size_and_clear(result_out_out, rows_out, cols_out);
     // loop over all quadrature points
     const size_t integrand_order =
-        integrand_->order(test_basis_inside, ansatz_basis_inside, test_basis_outside, ansatz_basis_outside)
+        integrand_->order(test_basis_inside, ansatz_basis_inside, test_basis_outside, ansatz_basis_outside, param)
         + over_integrate_;
     const auto geometry = intersection.geometry();
     for (const auto& quadrature_point :
@@ -488,7 +488,7 @@ public:
       result.resize(rows, cols);
     result *= 0;
     // loop over all quadrature points
-    const size_t integrand_order = integrand_->order(test_basis, ansatz_basis) + over_integrate_;
+    const size_t integrand_order = integrand_->order(test_basis, ansatz_basis, param) + over_integrate_;
     const auto geometry = intersection.geometry();
     const auto quadrature_rule =
         QuadratureRules<D, d - 1>::rule(geometry.type(), XT::Common::numeric_cast<int>(integrand_order));

--- a/dune/gdt/local/bilinear-forms/restricted-integrals.hh
+++ b/dune/gdt/local/bilinear-forms/restricted-integrals.hh
@@ -109,7 +109,7 @@ public:
     ensure_size_and_clear(result_out_out, rows_out, cols_out);
     // loop over all quadrature points
     const size_t integrand_order =
-        integrand_->order(test_basis_inside, ansatz_basis_inside, test_basis_outside, ansatz_basis_outside)
+        integrand_->order(test_basis_inside, ansatz_basis_inside, test_basis_outside, ansatz_basis_outside, param)
         + over_integrate_;
     for (const auto& quadrature_point :
          QuadratureRules<D, d - 1>::rule(intersection.type(), XT::Common::numeric_cast<int>(integrand_order))) {
@@ -242,7 +242,7 @@ public:
       result.resize(rows, cols);
     result *= 0;
     // loop over all quadrature points
-    const size_t integrand_order = integrand_->order(test_basis, ansatz_basis) + over_integrate_;
+    const size_t integrand_order = integrand_->order(test_basis, ansatz_basis, param) + over_integrate_;
     const auto quadrature_rule =
         QuadratureRules<D, d - 1>::rule(intersection.geometry().type(), XT::Common::numeric_cast<int>(integrand_order));
     for (const auto& quadrature_point : quadrature_rule) {

--- a/dune/gdt/local/discretefunction.hh
+++ b/dune/gdt/local/discretefunction.hh
@@ -68,13 +68,18 @@ public:
   using typename BaseType::SingleDerivativeRangeReturnType;
   using typename BaseType::SingleDerivativeRangeType;
 
+  /**
+   * \note This local view borrows the space (it must not outlive spc, which holds for the usual case of local views
+   *       created by a discrete function) instead of copying it: a per-element view has no business owning a copy of
+   *       the space, and the copy used to make every local_function() call O(#grid elements) (review A3/D4).
+   */
   ConstLocalDiscreteFunction(const SpaceType& spc, const ConstDofVectorType& dof_vector)
     : BaseType()
-    , space_(spc.copy())
-    , space_is_fv_(space_->type() == GDT::SpaceType::finite_volume)
+    , space_(spc)
+    , space_is_fv_(space_.type() == GDT::SpaceType::finite_volume)
     , dof_vector_(dof_vector.localize())
-    , basis_(space_->basis().localize())
-    , basis_values_(space_is_fv_ ? 0 : space_->mapper().max_local_size())
+    , basis_(space_.basis().localize())
+    , basis_values_(space_is_fv_ ? 0 : space_.mapper().max_local_size())
     , dynamic_basis_values_(basis_values_.size())
     , basis_derivatives_(basis_values_.size())
     , dynamic_basis_derivatives_(basis_values_.size())
@@ -100,7 +105,7 @@ public:
 
   const SpaceType& space() const
   {
-    return *space_;
+    return space_;
   }
 
   const LocalBasisType& basis() const
@@ -290,7 +295,7 @@ public:
   /// \}
 
 private:
-  std::unique_ptr<const SpaceType> space_;
+  const SpaceType& space_;
   const bool space_is_fv_;
   ConstLocalDofVectorType dof_vector_;
   std::unique_ptr<LocalBasisType> basis_;

--- a/dune/gdt/local/discretefunction.hh
+++ b/dune/gdt/local/discretefunction.hh
@@ -330,12 +330,6 @@ public:
   {
   }
 
-  LocalDiscreteFunction(const SpaceType& spc, DofVectorType& dof_vector, const ElementType& ent)
-    : BaseType(spc, dof_vector, ent)
-    , dof_vector_(dof_vector.localize(ent))
-  {
-  }
-
 protected:
   void post_bind(const ElementType& ent) override final
   {

--- a/dune/gdt/local/dof-vector.hh
+++ b/dune/gdt/local/dof-vector.hh
@@ -293,13 +293,12 @@ protected:
 
 public:
   /**
-   * \note This is not thread-safe without the mutex because operator[] is not thread-safe for the vectors from
-   *dune-xt-la. \todo The mutex here is just a quick fix, properly fix thread safety.
+   * \note Accessing the same global DoF through overlapping local views from several threads concurrently is not safe
+   *       (the returned reference bypasses any synchronization of the underlying vector) -- the caller has to ensure
+   *       exclusive access, e.g. by thread-local accumulation or by scheduling threads on disjoint DoFs.
    **/
   ScalarType& operator[](const size_t ii)
   {
-    static std::mutex mutex;
-    [[maybe_unused]] std::lock_guard<std::mutex> guard{mutex};
     DUNE_THROW_IF(!this->is_bound_, Exceptions::not_bound_to_an_element_yet, "");
     assert(ii < size_);
     return global_vector_[global_DoF_indices_[ii]];

--- a/dune/gdt/local/finite-elements/default.hh
+++ b/dune/gdt/local/finite-elements/default.hh
@@ -15,6 +15,9 @@
 #ifndef DUNE_GDT_LOCAL_FINITE_ELEMENTS_DEFAULT_HH
 #define DUNE_GDT_LOCAL_FINITE_ELEMENTS_DEFAULT_HH
 
+#include <mutex>
+#include <shared_mutex>
+
 #include <dune/geometry/quadraturerules.hh>
 
 #include <dune/xt/common/memory.hh>
@@ -178,8 +181,9 @@ private:
 
 /**
  * \brief Implements LocalFiniteElementFamilyInterface by lazily creating and caching local finite elements from a
- *        user-provided factory, with creation guarded by a mutex.
- * \note  See the implementation of get() for a caveat regarding the double-checked locking pattern used here.
+ *        user-provided factory, with cache accesses synchronized by a shared mutex.
+ * \note  get() may be called concurrently from several threads; this class is the single synchronized home of the
+ *        finite element cache (spaces, mappers and bases all funnel through it).
  */
 template <class D, size_t d, class R = double, size_t r = 1, size_t rC = 1>
 class ThreadSafeDefaultLocalFiniteElementFamily : public LocalFiniteElementFamilyInterface<D, d, R, r, rC>
@@ -211,23 +215,27 @@ public:
   const LocalFiniteElementType& get(const GeometryType& geometry_type, const int order) const override final
   {
     const auto key = std::make_pair(geometry_type, order);
-    // if the FE already exists, no need to lock since at() is thread safe and we are returning the object reference,
-    // not a map iterator which might get invalidated
-    // TODO: Double checked locking pattern is not thread-safe without memory barriers.
-    if (fes_.count(key) == 0) {
-      // the FE needs to be created, we need to lock
-      [[maybe_unused]] std::lock_guard<std::mutex> guard(mutex_);
-      // and to check again if someone else created the FE while we were waiting to acquire the lock
-      if (fes_.count(key) == 0)
-        fes_[key] = factory_(geometry_type, order);
+    {
+      // common case: the FE already exists, a shared lock suffices (references into the map remain valid while other
+      // threads insert)
+      std::shared_lock<std::shared_mutex> read_guard(mutex_);
+      const auto it = fes_.find(key);
+      if (it != fes_.end())
+        return *it->second;
     }
-    return *fes_.at(key);
+    // the FE (probably) needs to be created, we need exclusive access; someone else may have created it while we were
+    // waiting to acquire the lock, so operator[] + check is used instead of an unconditional insert
+    std::lock_guard<std::shared_mutex> write_guard(mutex_);
+    auto& fe = fes_[key];
+    if (!fe)
+      fe = factory_(geometry_type, order);
+    return *fe;
   } // ... get(...)
 
 private:
   const std::function<std::unique_ptr<LocalFiniteElementType>(const GeometryType&, const int&)> factory_;
   mutable std::map<std::pair<GeometryType, int>, std::unique_ptr<LocalFiniteElementType>> fes_;
-  mutable std::mutex mutex_;
+  mutable std::shared_mutex mutex_;
 }; // class ThreadSafeDefaultLocalFiniteElementFamily
 
 

--- a/dune/gdt/local/functionals/integrals.hh
+++ b/dune/gdt/local/functionals/integrals.hh
@@ -16,6 +16,9 @@
 #ifndef DUNE_GDT_LOCAL_FUNCTIONALS_INTEGRALS_HH
 #define DUNE_GDT_LOCAL_FUNCTIONALS_INTEGRALS_HH
 
+#include <type_traits>
+#include <utility>
+
 #include <dune/geometry/quadraturerules.hh>
 
 #include <dune/gdt/local/integrands/interfaces.hh>
@@ -112,6 +115,111 @@ private:
   const int over_integrate_;
   mutable DynamicVector<F> integrand_values_;
 }; // class LocalElementIntegralFunctional
+
+
+/**
+ * \brief Statically dispatched variant of LocalElementIntegralFunctional.
+ *
+ * Keeps the concrete integrand as a template parameter and by value instead of type-erasing it, so the quadrature
+ * loop calls the integrand via qualified (hence non-virtual, inlinable) calls; type erasure is confined to the
+ * per-element apply() of the LocalElementFunctionalInterface (review D1).
+ *
+ * \sa StaticLocalElementIntegralBilinearForm
+ * \sa make_local_element_integral_functional
+ */
+template <class Integrand>
+class StaticLocalElementIntegralFunctional
+  : public LocalElementFunctionalInterface<typename Integrand::E,
+                                           Integrand::r,
+                                           Integrand::rC,
+                                           typename Integrand::R,
+                                           typename Integrand::F>
+{
+  static_assert(std::is_base_of_v<LocalUnaryElementIntegrandInterface<typename Integrand::E,
+                                                                      Integrand::r,
+                                                                      Integrand::rC,
+                                                                      typename Integrand::R,
+                                                                      typename Integrand::F>,
+                                  Integrand>,
+                "Integrand has to implement LocalUnaryElementIntegrandInterface!");
+
+  using ThisType = StaticLocalElementIntegralFunctional;
+  using BaseType = LocalElementFunctionalInterface<typename Integrand::E,
+                                                   Integrand::r,
+                                                   Integrand::rC,
+                                                   typename Integrand::R,
+                                                   typename Integrand::F>;
+
+public:
+  using BaseType::d;
+  using typename BaseType::D;
+  using typename BaseType::F;
+  using typename BaseType::LocalBasisType;
+
+  using IntegrandType = Integrand;
+
+  explicit StaticLocalElementIntegralFunctional(IntegrandType integrand, const int over_integrate = 0)
+    : BaseType(integrand.parameter_type())
+    , integrand_(std::move(integrand))
+    , over_integrate_(over_integrate)
+  {
+  }
+
+  StaticLocalElementIntegralFunctional(const ThisType& other) = default;
+
+  StaticLocalElementIntegralFunctional(ThisType&& source) noexcept = default;
+
+  std::unique_ptr<BaseType> copy() const override final
+  {
+    return std::make_unique<ThisType>(*this);
+  }
+
+  using BaseType::apply;
+
+  void apply(const LocalBasisType& basis,
+             DynamicVector<F>& result,
+             const XT::Common::Parameter& param = {}) const override final
+  {
+    // prepare integand
+    const auto& element = basis.element();
+    integrand_.bind(element);
+    // prepare storage
+    const auto size = basis.size(param);
+    if (result.size() < size)
+      result.resize(size);
+    result *= 0;
+    // loop over all quadrature points (note the qualified calls into the integrand, which suppress virtual dispatch)
+    const auto integrand_order = integrand_.IntegrandType::order(basis, param) + over_integrate_;
+    const auto quadrature_rule = QuadratureRules<D, d>::rule(element.type(), integrand_order);
+    const auto geometry = element.geometry();
+    for (auto [point_in_reference_element, quadrature_weight] : quadrature_rule) {
+      // integration factors
+      const auto integration_factor = geometry.integrationElement(point_in_reference_element);
+      // evaluate the integrand
+      integrand_.IntegrandType::evaluate(basis, point_in_reference_element, integrand_values_, param);
+      assert(integrand_values_.size() >= size && "This must not happen!");
+      // compute integral
+      for (size_t ii = 0; ii < size; ++ii)
+        result[ii] += integrand_values_[ii] * integration_factor * quadrature_weight;
+    } // loop over all quadrature points
+  } // ... apply(...)
+
+private:
+  mutable IntegrandType integrand_;
+  const int over_integrate_;
+  mutable DynamicVector<F> integrand_values_;
+}; // class StaticLocalElementIntegralFunctional
+
+
+/**
+ * \brief Creates a StaticLocalElementIntegralFunctional, deducing the concrete integrand type.
+ */
+template <class Integrand>
+StaticLocalElementIntegralFunctional<Integrand> make_local_element_integral_functional(Integrand integrand,
+                                                                                       const int over_integrate = 0)
+{
+  return StaticLocalElementIntegralFunctional<Integrand>(std::move(integrand), over_integrate);
+}
 
 
 /**

--- a/dune/gdt/operators/matrix.hh
+++ b/dune/gdt/operators/matrix.hh
@@ -467,7 +467,17 @@ public:
 
   void finalize() override final
   {
-    // clear everything after assembling into the matrix
+    // let the local assemblers merge their pending (scatter buffered) contributions into the matrix ...
+    const auto finalize_local_assemblers = [](auto& data_list) {
+      for (auto& data : data_list)
+        std::get<0>(data)->finalize();
+    };
+    finalize_local_assemblers(element_bilinear_form_data_);
+    finalize_local_assemblers(coupling_intersection_bilinear_form_data_);
+    finalize_local_assemblers(intersection_bilinear_form_data_);
+    finalize_local_assemblers(element_fd_operator_data_);
+    finalize_local_assemblers(intersection_fd_operator_data_);
+    // ... and clear everything after assembling into the matrix
     element_bilinear_form_data_.clear();
     coupling_intersection_bilinear_form_data_.clear();
     intersection_bilinear_form_data_.clear();

--- a/dune/gdt/products.hh
+++ b/dune/gdt/products.hh
@@ -38,7 +38,7 @@ auto L2Product(const GridViewType& grid_view,
   static_assert(XT::Grid::is_view<GridViewType>::value, "");
   using E = XT::Grid::extract_entity_t<GridViewType>;
   auto product = make_bilinear_form<r, 1, r, 1>(grid_view);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalProductIntegrand<E, r>(weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r>(weight), over_integrate);
   return product;
 }
 
@@ -68,7 +68,7 @@ auto H1SemiProduct(const GridViewType& grid_view,
   static_assert(XT::Grid::is_view<GridViewType>::value, "");
   using E = XT::Grid::extract_entity_t<GridViewType>;
   auto product = make_bilinear_form<r, 1, r, 1>(grid_view);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalLaplaceIntegrand<E, r>(weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E, r>(weight), over_integrate);
   return product;
 }
 
@@ -99,8 +99,8 @@ auto H1Product(const GridViewType& grid_view,
   static_assert(XT::Grid::is_view<GridViewType>::value, "");
   using E = XT::Grid::extract_entity_t<GridViewType>;
   auto product = make_bilinear_form<r, 1, r, 1>(grid_view);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalProductIntegrand<E, r>(l2_weight), over_integrate);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalLaplaceIntegrand<E, r>(h1_semi_weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r>(l2_weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E, r>(h1_semi_weight), over_integrate);
   return product;
 }
 
@@ -118,8 +118,8 @@ H1Product(const GridViewType& grid_view,
   static_assert(XT::Grid::is_view<GridViewType>::value, "");
   using E = XT::Grid::extract_entity_t<GridViewType>;
   auto product = make_bilinear_form<r, 1, r, 1>(grid_view);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalProductIntegrand<E, r>(weight), over_integrate);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalLaplaceIntegrand<E, r>(weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r>(weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E, r>(weight), over_integrate);
   return product;
 }
 
@@ -137,8 +137,8 @@ H1Product(const GridViewType& grid_view,
   static_assert(XT::Grid::is_view<GridViewType>::value, "");
   using E = XT::Grid::extract_entity_t<GridViewType>;
   auto product = make_bilinear_form<r, 1, r, 1>(grid_view);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalProductIntegrand<E, r>(weight), over_integrate);
-  product += LocalElementIntegralBilinearForm<E, r>(LocalLaplaceIntegrand<E, r>(weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r>(weight), over_integrate);
+  product += make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E, r>(weight), over_integrate);
   return product;
 }
 

--- a/dune/gdt/spaces/basis/default.hh
+++ b/dune/gdt/spaces/basis/default.hh
@@ -16,6 +16,11 @@
 #ifndef DUNE_GDT_SPACES_BASIS_DEFAULT_HH
 #define DUNE_GDT_SPACES_BASIS_DEFAULT_HH
 
+#include <algorithm>
+#include <map>
+#include <utility>
+#include <vector>
+
 #include <dune/xt/common/memory.hh>
 #include <dune/xt/functions/interfaces/grid-function.hh>
 
@@ -146,23 +151,59 @@ private:
     using BaseType::evaluate;
     using BaseType::jacobians;
 
+    /**
+     * \note Since the shape functions of a finite element are identical for every element of a geometry type, their
+     *       values at a given point in reference coordinates are cached (per geometry type) and shared between all
+     *       elements this basis is bound to over its lifetime -- quadrature points thus trigger an actual shape
+     *       function evaluation only once (review C3/D3). The cache is per localized basis (which is not shared
+     *       between threads), so no synchronization is required.
+     */
     void evaluate(const DomainType& point_in_reference_element,
                   std::vector<RangeType>& result,
                   const XT::Common::Parameter& /*param*/ = {}) const override final
     {
       DUNE_THROW_IF(!current_local_fe_.valid(), Exceptions::not_bound_to_an_element_yet, "");
       this->assert_inside_reference_element(point_in_reference_element);
+      auto& cache = shape_values_cache_[geometry_type_];
+      for (const auto& [cached_point, cached_values] : cache)
+        if (cached_point == point_in_reference_element) {
+          if (result.size() < size_)
+            result.resize(size_);
+          std::copy(cached_values.begin(), cached_values.end(), result.begin());
+          return;
+        }
       current_local_fe_.access().basis().evaluate(point_in_reference_element, result);
-    }
+      if (cache.size() < max_cached_points_per_geometry_type)
+        cache.emplace_back(point_in_reference_element, std::vector<RangeType>(result.begin(), result.begin() + size_));
+    } // ... evaluate(...)
 
+    /**
+     * \note The element-independent shape function jacobians (in reference coordinates) are cached as in evaluate();
+     *       only the geometry transformation is applied per element (review C3/D3).
+     */
     void jacobians(const DomainType& point_in_reference_element,
                    std::vector<DerivativeRangeType>& result,
                    const XT::Common::Parameter& /*param*/ = {}) const override final
     {
       DUNE_THROW_IF(!current_local_fe_.valid(), Exceptions::not_bound_to_an_element_yet, "");
       this->assert_inside_reference_element(point_in_reference_element);
-      // evaluate jacobian of shape functions
-      current_local_fe_.access().basis().jacobian(point_in_reference_element, result);
+      // evaluate jacobian of shape functions (or look them up in the cache)
+      bool found_in_cache = false;
+      auto& cache = shape_jacobians_cache_[geometry_type_];
+      for (const auto& [cached_point, cached_jacobians] : cache)
+        if (cached_point == point_in_reference_element) {
+          if (result.size() < size_)
+            result.resize(size_);
+          std::copy(cached_jacobians.begin(), cached_jacobians.end(), result.begin());
+          found_in_cache = true;
+          break;
+        }
+      if (!found_in_cache) {
+        current_local_fe_.access().basis().jacobian(point_in_reference_element, result);
+        if (cache.size() < max_cached_points_per_geometry_type)
+          cache.emplace_back(point_in_reference_element,
+                             std::vector<DerivativeRangeType>(result.begin(), result.begin() + size_));
+      }
       // Apply transformation:
       // Let f: E -> R^r be a basis function, and g: E' -> E be the mapping from reference to actual element, then f
       // \circ g is a shape function. We have the chain rule J_f = J(f \circ g \circ g^{-1}) = J(f \circ g) J_g^{-1}.
@@ -213,11 +254,18 @@ private:
     }
 
   private:
+    //! bounds the per-geometry-type memory of the shape value/jacobian caches; quadratures, interpolation points and
+    //! visualization lattices stay well below this in practice
+    static constexpr size_t max_cached_points_per_geometry_type = 256;
+
     const DefaultGlobalBasis<GV, r, rC, R>& self_;
     XT::Common::ConstStorageProvider<LocalFiniteElementInterface<D, d, R, r, rC>> current_local_fe_;
     size_t size_;
     int order_;
     Dune::GeometryType geometry_type_;
+    mutable std::map<GeometryType, std::vector<std::pair<DomainType, std::vector<RangeType>>>> shape_values_cache_;
+    mutable std::map<GeometryType, std::vector<std::pair<DomainType, std::vector<DerivativeRangeType>>>>
+        shape_jacobians_cache_;
   }; // class LocalizedDefaultGlobalBasis
 
   const GridViewType& grid_view_;

--- a/dune/gdt/spaces/h1/continuous-flattop.hh
+++ b/dune/gdt/spaces/h1/continuous-flattop.hh
@@ -30,6 +30,7 @@
 #include <dune/gdt/spaces/basis/default.hh>
 #include <dune/gdt/spaces/mapper/continuous.hh>
 #include <dune/gdt/spaces/interface.hh>
+#include <dune/gdt/spaces/shared-core.hh>
 
 namespace Dune {
 namespace GDT {
@@ -39,54 +40,37 @@ namespace GDT {
  * \sa make_local_lagrange_finite_element
  */
 template <class GV, size_t r = 1, class R = double>
-class ContinuousFlatTopSpace : public SpaceInterface<GV, r, 1, R>
+class ContinuousFlatTopSpace
+  : public internal::SpaceWithSharedCore<
+        GV,
+        r,
+        1,
+        R,
+        LocalFlatTopFiniteElementFamily<typename GV::ctype, GV::dimension, R, r>,
+        ContinuousMapper<GV, LocalFiniteElementFamilyInterface<typename GV::ctype, GV::dimension, R, r, 1>>,
+        DefaultGlobalBasis<GV, r, 1, R>>
 {
   using ThisType = ContinuousFlatTopSpace;
-  using BaseType = SpaceInterface<GV, r, 1, R>;
+  using BaseType = internal::SpaceWithSharedCore<
+      GV,
+      r,
+      1,
+      R,
+      LocalFlatTopFiniteElementFamily<typename GV::ctype, GV::dimension, R, r>,
+      ContinuousMapper<GV, LocalFiniteElementFamilyInterface<typename GV::ctype, GV::dimension, R, r, 1>>,
+      DefaultGlobalBasis<GV, r, 1, R>>;
 
 public:
   using BaseType::d;
   using typename BaseType::D;
-  using typename BaseType::GlobalBasisType;
   using typename BaseType::GridViewType;
-  using typename BaseType::LocalFiniteElementFamilyType;
-  using typename BaseType::MapperType;
 
-private:
-  using MapperImplementation = ContinuousMapper<GridViewType, LocalFiniteElementFamilyType>;
-  using GlobalBasisImplementation = DefaultGlobalBasis<GridViewType, r, 1, R>;
-
-  /**
-   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
-   * (mapper and basis reference the core's grid view and finite elements, so its address has to be stable anyway),
-   * which makes copy() O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
-   */
-  struct Core
-  {
-    Core(GridViewType grd_vw, const int order, const D& ovrlp)
-      : grid_view(std::move(grd_vw))
-      , fe_order(order)
-      , overlap(ovrlp)
-      , local_finite_elements(std::make_unique<LocalFlatTopFiniteElementFamily<D, d, R, r>>(overlap))
-    {
-    }
-
-    const GridViewType grid_view;
-    const int fe_order;
-    const D overlap;
-    std::unique_ptr<const LocalFlatTopFiniteElementFamily<D, d, R, r>> local_finite_elements;
-    std::unique_ptr<MapperImplementation> mapper;
-    std::unique_ptr<GlobalBasisImplementation> basis;
-  }; // struct Core
-
-public:
   ContinuousFlatTopSpace(GridViewType grd_vw, const int fe_order, const D& overlap = 0.5)
-    : core_(std::make_shared<Core>(std::move(grd_vw), fe_order, overlap))
+    : BaseType(std::move(grd_vw), fe_order, "ContinuousFlatTopSpace", XT::Common::default_logger_state(), overlap)
   {
     this->update_after_adapt();
   }
 
-  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
   ContinuousFlatTopSpace(const ThisType&) = default;
 
   ContinuousFlatTopSpace(ThisType&&) = default;
@@ -99,28 +83,6 @@ public:
     return new ThisType(*this);
   }
 
-  const GridViewType& grid_view() const override final
-  {
-    return core_->grid_view;
-  }
-
-  const MapperType& mapper() const override final
-  {
-    assert(core_->mapper && "This must not happen!");
-    return *core_->mapper;
-  }
-
-  const GlobalBasisType& basis() const override final
-  {
-    assert(core_->basis && "This must not happen!");
-    return *core_->basis;
-  }
-
-  const LocalFiniteElementFamilyType& finite_elements() const override final
-  {
-    return *core_->local_finite_elements;
-  }
-
   SpaceType type() const override final
   {
     return SpaceType::continuous_lagrange;
@@ -128,12 +90,12 @@ public:
 
   int min_polorder() const override final
   {
-    return core_->fe_order;
+    return this->fe_order();
   }
 
   int max_polorder() const override final
   {
-    return core_->fe_order + 1;
+    return this->fe_order() + 1;
   }
 
   bool continuous(const int diff_order) const override final
@@ -151,31 +113,15 @@ public:
     return true;
   }
 
-  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() override final
   {
     // check: the mapper does not work for non-conforming intersections
-    if (d == 3 && core_->grid_view.indexSet().types(0).size() != 1)
+    if (d == 3 && this->grid_view().indexSet().types(0).size() != 1)
       DUNE_THROW(Exceptions::space_error,
                  "in ContinuousFlatTopSpace: non-conforming intersections are not (yet) "
                  "supported, and more than one element type in 3d leads to non-conforming intersections!");
-    // create/update mapper ...
-    if (core_->mapper)
-      core_->mapper->update_after_adapt();
-    else
-      core_->mapper =
-          std::make_unique<MapperImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
-    // ... and basis
-    if (core_->basis)
-      core_->basis->update_after_adapt();
-    else
-      core_->basis =
-          std::make_unique<GlobalBasisImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
-    this->create_communicator();
-  } // ... update_after_adapt(...)
-
-private:
-  std::shared_ptr<Core> core_;
+    this->create_or_update_core();
+  }
 }; // class ContinuousFlatTopSpace
 
 

--- a/dune/gdt/spaces/h1/continuous-flattop.hh
+++ b/dune/gdt/spaces/h1/continuous-flattop.hh
@@ -56,28 +56,38 @@ private:
   using MapperImplementation = ContinuousMapper<GridViewType, LocalFiniteElementFamilyType>;
   using GlobalBasisImplementation = DefaultGlobalBasis<GridViewType, r, 1, R>;
 
+  /**
+   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
+   * (mapper and basis reference the core's grid view and finite elements, so its address has to be stable anyway),
+   * which makes copy() O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
+   */
+  struct Core
+  {
+    Core(GridViewType grd_vw, const int order, const D& ovrlp)
+      : grid_view(std::move(grd_vw))
+      , fe_order(order)
+      , overlap(ovrlp)
+      , local_finite_elements(std::make_unique<LocalFlatTopFiniteElementFamily<D, d, R, r>>(overlap))
+    {
+    }
+
+    const GridViewType grid_view;
+    const int fe_order;
+    const D overlap;
+    std::unique_ptr<const LocalFlatTopFiniteElementFamily<D, d, R, r>> local_finite_elements;
+    std::unique_ptr<MapperImplementation> mapper;
+    std::unique_ptr<GlobalBasisImplementation> basis;
+  }; // struct Core
+
 public:
   ContinuousFlatTopSpace(GridViewType grd_vw, const int fe_order, const D& overlap = 0.5)
-    : grid_view_(grd_vw)
-    , fe_order_(fe_order)
-    , overlap_(overlap)
-    , local_finite_elements_(std::make_unique<LocalFlatTopFiniteElementFamily<D, d, R, r>>(overlap_))
-    , mapper_(nullptr)
-    , basis_(nullptr)
+    : core_(std::make_shared<Core>(std::move(grd_vw), fe_order, overlap))
   {
     this->update_after_adapt();
   }
 
-  ContinuousFlatTopSpace(const ThisType& other)
-    : grid_view_(other.grid_view_)
-    , fe_order_(other.fe_order_)
-    , overlap_(other.overlap_)
-    , local_finite_elements_(std::make_unique<LocalFlatTopFiniteElementFamily<D, d, R, r>>(overlap_))
-    , mapper_(nullptr)
-    , basis_(nullptr)
-  {
-    this->update_after_adapt();
-  }
+  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
+  ContinuousFlatTopSpace(const ThisType&) = default;
 
   ContinuousFlatTopSpace(ThisType&&) = default;
 
@@ -91,24 +101,24 @@ public:
 
   const GridViewType& grid_view() const override final
   {
-    return grid_view_;
+    return core_->grid_view;
   }
 
   const MapperType& mapper() const override final
   {
-    assert(mapper_ && "This must not happen!");
-    return *mapper_;
+    assert(core_->mapper && "This must not happen!");
+    return *core_->mapper;
   }
 
   const GlobalBasisType& basis() const override final
   {
-    assert(basis_ && "This must not happen!");
-    return *basis_;
+    assert(core_->basis && "This must not happen!");
+    return *core_->basis;
   }
 
   const LocalFiniteElementFamilyType& finite_elements() const override final
   {
-    return *local_finite_elements_;
+    return *core_->local_finite_elements;
   }
 
   SpaceType type() const override final
@@ -118,12 +128,12 @@ public:
 
   int min_polorder() const override final
   {
-    return fe_order_;
+    return core_->fe_order;
   }
 
   int max_polorder() const override final
   {
-    return fe_order_ + 1;
+    return core_->fe_order + 1;
   }
 
   bool continuous(const int diff_order) const override final
@@ -141,33 +151,31 @@ public:
     return true;
   }
 
+  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() override final
   {
     // check: the mapper does not work for non-conforming intersections
-    if (d == 3 && grid_view_.indexSet().types(0).size() != 1)
+    if (d == 3 && core_->grid_view.indexSet().types(0).size() != 1)
       DUNE_THROW(Exceptions::space_error,
                  "in ContinuousFlatTopSpace: non-conforming intersections are not (yet) "
                  "supported, and more than one element type in 3d leads to non-conforming intersections!");
     // create/update mapper ...
-    if (mapper_)
-      mapper_->update_after_adapt();
+    if (core_->mapper)
+      core_->mapper->update_after_adapt();
     else
-      mapper_ = std::make_unique<MapperImplementation>(grid_view_, *local_finite_elements_, fe_order_);
+      core_->mapper =
+          std::make_unique<MapperImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
     // ... and basis
-    if (basis_)
-      basis_->update_after_adapt();
+    if (core_->basis)
+      core_->basis->update_after_adapt();
     else
-      basis_ = std::make_unique<GlobalBasisImplementation>(grid_view_, *local_finite_elements_, fe_order_);
+      core_->basis =
+          std::make_unique<GlobalBasisImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
     this->create_communicator();
   } // ... update_after_adapt(...)
 
 private:
-  const GridViewType grid_view_;
-  const int fe_order_;
-  const D overlap_;
-  std::unique_ptr<const LocalFlatTopFiniteElementFamily<D, d, R, r>> local_finite_elements_;
-  std::unique_ptr<MapperImplementation> mapper_;
-  std::unique_ptr<GlobalBasisImplementation> basis_;
+  std::shared_ptr<Core> core_;
 }; // class ContinuousFlatTopSpace
 
 

--- a/dune/gdt/spaces/h1/continuous-lagrange.hh
+++ b/dune/gdt/spaces/h1/continuous-lagrange.hh
@@ -68,32 +68,41 @@ private:
   using MapperImplementation = ContinuousMapper<GridViewType, LocalFiniteElementFamilyType>;
   using GlobalBasisImplementation = DefaultGlobalBasis<GridViewType, r, 1, R>;
 
+  /**
+   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
+   * (mapper and basis reference the core's grid view and finite elements, so its address has to be stable anyway),
+   * which makes copy() O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
+   */
+  struct Core
+  {
+    Core(GridViewType grd_vw, const int order)
+      : grid_view(std::move(grd_vw))
+      , fe_order(order)
+      , local_finite_elements(std::make_unique<LocalLagrangeFiniteElementFamily<D, d, R, r>>())
+    {
+    }
+
+    const GridViewType grid_view;
+    const int fe_order;
+    std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements;
+    std::unique_ptr<MapperImplementation> mapper;
+    std::unique_ptr<GlobalBasisImplementation> basis;
+  }; // struct Core
+
 public:
   ContinuousLagrangeSpace(GridViewType grd_vw,
                           const int order,
                           const std::string& logging_prefix = "",
                           const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType(logging_prefix.empty() ? "ContinuousLagrangeSpace" : logging_prefix, logging_state)
-    , grid_view_(grd_vw)
-    , fe_order_(order)
-    , local_finite_elements_(std::make_unique<LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    , mapper_(nullptr)
-    , basis_(nullptr)
+    , core_(std::make_shared<Core>(std::move(grd_vw), order))
   {
-    LOG_(info) << "ContinuousLagrangeSpace(&grd_vw=" << &grd_vw << ", order=" << fe_order_ << ")" << std::endl;
+    LOG_(info) << "ContinuousLagrangeSpace(order=" << order << ")" << std::endl;
     this->update_after_adapt();
   }
 
-  ContinuousLagrangeSpace(const ThisType& other)
-    : BaseType(other)
-    , grid_view_(other.grid_view_)
-    , fe_order_(other.fe_order_)
-    , local_finite_elements_(std::make_unique<LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    , mapper_(nullptr)
-    , basis_(nullptr)
-  {
-    this->update_after_adapt();
-  }
+  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
+  ContinuousLagrangeSpace(const ThisType&) = default;
 
   ContinuousLagrangeSpace(ThisType&&) noexcept = default;
 
@@ -108,24 +117,24 @@ public:
 
   const GridViewType& grid_view() const final
   {
-    return grid_view_;
+    return core_->grid_view;
   }
 
   const MapperType& mapper() const final
   {
-    assert(mapper_ && "This must not happen!");
-    return *mapper_;
+    assert(core_->mapper && "This must not happen!");
+    return *core_->mapper;
   }
 
   const GlobalBasisType& basis() const final
   {
-    assert(basis_ && "This must not happen!");
-    return *basis_;
+    assert(core_->basis && "This must not happen!");
+    return *core_->basis;
   }
 
   const LocalFiniteElementFamilyType& finite_elements() const final
   {
-    return *local_finite_elements_;
+    return *core_->local_finite_elements;
   }
 
   SpaceType type() const final
@@ -135,12 +144,12 @@ public:
 
   int min_polorder() const final
   {
-    return fe_order_;
+    return core_->fe_order;
   }
 
   int max_polorder() const final
   {
-    return fe_order_;
+    return core_->fe_order;
   }
 
   bool continuous(const int diff_order) const final
@@ -158,34 +167,31 @@ public:
     return true;
   }
 
+  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() final
   {
     // check: the mapper does not work for non-conforming intersections
-    if (d == 3 && grid_view_.indexSet().types(0).size() != 1)
+    if (d == 3 && core_->grid_view.indexSet().types(0).size() != 1)
       DUNE_THROW(Exceptions::space_error,
                  "in ContinuousLagrangeSpace: non-conforming intersections are not (yet) "
                  "supported, and more than one element type in 3d leads to non-conforming intersections!");
     // create/update mapper ...
-    if (mapper_)
-      mapper_->update_after_adapt();
+    if (core_->mapper)
+      core_->mapper->update_after_adapt();
     else
-      mapper_ = std::make_unique<MapperImplementation>(grid_view_, *local_finite_elements_, fe_order_);
+      core_->mapper =
+          std::make_unique<MapperImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
     // ... and basis
-    if (basis_)
-      basis_->update_after_adapt();
+    if (core_->basis)
+      core_->basis->update_after_adapt();
     else
-      basis_ = std::make_unique<GlobalBasisImplementation>(grid_view_, *local_finite_elements_, fe_order_);
+      core_->basis =
+          std::make_unique<GlobalBasisImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
     this->create_communicator();
   } // ... update_after_adapt(...)
 
 private:
-  const GridViewType grid_view_;
-  const int fe_order_;
-  int min_polorder_;
-  int max_polorder_;
-  std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements_;
-  std::unique_ptr<MapperImplementation> mapper_;
-  std::unique_ptr<GlobalBasisImplementation> basis_;
+  std::shared_ptr<Core> core_;
 }; // class ContinuousLagrangeSpace
 
 

--- a/dune/gdt/spaces/h1/continuous-lagrange.hh
+++ b/dune/gdt/spaces/h1/continuous-lagrange.hh
@@ -31,6 +31,7 @@
 #include <dune/gdt/spaces/basis/default.hh>
 #include <dune/gdt/spaces/mapper/continuous.hh>
 #include <dune/gdt/spaces/interface.hh>
+#include <dune/gdt/spaces/shared-core.hh>
 
 namespace Dune {
 namespace GDT {
@@ -51,57 +52,41 @@ namespace GDT {
  * \sa make_local_lagrange_finite_element
  */
 template <class GV, size_t r = 1, class R = double>
-class ContinuousLagrangeSpace : public SpaceInterface<GV, r, 1, R>
+class ContinuousLagrangeSpace
+  : public internal::SpaceWithSharedCore<
+        GV,
+        r,
+        1,
+        R,
+        LocalLagrangeFiniteElementFamily<typename GV::ctype, GV::dimension, R, r>,
+        ContinuousMapper<GV, LocalFiniteElementFamilyInterface<typename GV::ctype, GV::dimension, R, r, 1>>,
+        DefaultGlobalBasis<GV, r, 1, R>>
 {
   using ThisType = ContinuousLagrangeSpace;
-  using BaseType = SpaceInterface<GV, r, 1, R>;
+  using BaseType = internal::SpaceWithSharedCore<
+      GV,
+      r,
+      1,
+      R,
+      LocalLagrangeFiniteElementFamily<typename GV::ctype, GV::dimension, R, r>,
+      ContinuousMapper<GV, LocalFiniteElementFamilyInterface<typename GV::ctype, GV::dimension, R, r, 1>>,
+      DefaultGlobalBasis<GV, r, 1, R>>;
 
 public:
   using BaseType::d;
-  using typename BaseType::D;
-  using typename BaseType::GlobalBasisType;
   using typename BaseType::GridViewType;
-  using typename BaseType::LocalFiniteElementFamilyType;
-  using typename BaseType::MapperType;
 
-private:
-  using MapperImplementation = ContinuousMapper<GridViewType, LocalFiniteElementFamilyType>;
-  using GlobalBasisImplementation = DefaultGlobalBasis<GridViewType, r, 1, R>;
-
-  /**
-   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
-   * (mapper and basis reference the core's grid view and finite elements, so its address has to be stable anyway),
-   * which makes copy() O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
-   */
-  struct Core
-  {
-    Core(GridViewType grd_vw, const int order)
-      : grid_view(std::move(grd_vw))
-      , fe_order(order)
-      , local_finite_elements(std::make_unique<LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    {
-    }
-
-    const GridViewType grid_view;
-    const int fe_order;
-    std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements;
-    std::unique_ptr<MapperImplementation> mapper;
-    std::unique_ptr<GlobalBasisImplementation> basis;
-  }; // struct Core
-
-public:
   ContinuousLagrangeSpace(GridViewType grd_vw,
                           const int order,
                           const std::string& logging_prefix = "",
                           const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
-    : BaseType(logging_prefix.empty() ? "ContinuousLagrangeSpace" : logging_prefix, logging_state)
-    , core_(std::make_shared<Core>(std::move(grd_vw), order))
+    : BaseType(
+          std::move(grd_vw), order, logging_prefix.empty() ? "ContinuousLagrangeSpace" : logging_prefix, logging_state)
   {
     LOG_(info) << "ContinuousLagrangeSpace(order=" << order << ")" << std::endl;
     this->update_after_adapt();
   }
 
-  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
   ContinuousLagrangeSpace(const ThisType&) = default;
 
   ContinuousLagrangeSpace(ThisType&&) noexcept = default;
@@ -115,28 +100,6 @@ public:
     return new ThisType(*this);
   }
 
-  const GridViewType& grid_view() const final
-  {
-    return core_->grid_view;
-  }
-
-  const MapperType& mapper() const final
-  {
-    assert(core_->mapper && "This must not happen!");
-    return *core_->mapper;
-  }
-
-  const GlobalBasisType& basis() const final
-  {
-    assert(core_->basis && "This must not happen!");
-    return *core_->basis;
-  }
-
-  const LocalFiniteElementFamilyType& finite_elements() const final
-  {
-    return *core_->local_finite_elements;
-  }
-
   SpaceType type() const final
   {
     return SpaceType::continuous_lagrange;
@@ -144,12 +107,12 @@ public:
 
   int min_polorder() const final
   {
-    return core_->fe_order;
+    return this->fe_order();
   }
 
   int max_polorder() const final
   {
-    return core_->fe_order;
+    return this->fe_order();
   }
 
   bool continuous(const int diff_order) const final
@@ -167,31 +130,15 @@ public:
     return true;
   }
 
-  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() final
   {
     // check: the mapper does not work for non-conforming intersections
-    if (d == 3 && core_->grid_view.indexSet().types(0).size() != 1)
+    if (d == 3 && this->grid_view().indexSet().types(0).size() != 1)
       DUNE_THROW(Exceptions::space_error,
                  "in ContinuousLagrangeSpace: non-conforming intersections are not (yet) "
                  "supported, and more than one element type in 3d leads to non-conforming intersections!");
-    // create/update mapper ...
-    if (core_->mapper)
-      core_->mapper->update_after_adapt();
-    else
-      core_->mapper =
-          std::make_unique<MapperImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
-    // ... and basis
-    if (core_->basis)
-      core_->basis->update_after_adapt();
-    else
-      core_->basis =
-          std::make_unique<GlobalBasisImplementation>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
-    this->create_communicator();
-  } // ... update_after_adapt(...)
-
-private:
-  std::shared_ptr<Core> core_;
+    this->create_or_update_core();
+  }
 }; // class ContinuousLagrangeSpace
 
 

--- a/dune/gdt/spaces/hdiv/raviart-thomas.hh
+++ b/dune/gdt/spaces/hdiv/raviart-thomas.hh
@@ -71,34 +71,59 @@ private:
   using MapperImplementation = ContinuousMapper<GV, LocalFiniteElementFamilyType>;
   using GlobalBasisImplementation = RaviartThomasGlobalBasis<GV, R>;
 
+  /**
+   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
+   * (mapper and basis reference the core's grid view, finite elements and FE data, so its address has to be stable
+   * anyway), which makes copy() O(1) instead of a full rebuild over the whole grid view (review A3/C7/D4).
+   */
+  struct Core
+  {
+    Core(GridViewType grd_vw,
+         const int ord,
+         const std::string& logging_prefix,
+         const std::array<bool, 3>& logging_state)
+      : grid_view(std::move(grd_vw))
+      , order(ord)
+      , local_finite_elements()
+      , element_indices(grid_view)
+      , fe_data()
+      , mapper(grid_view, local_finite_elements, order)
+      , basis(grid_view,
+              order,
+              local_finite_elements,
+              element_indices,
+              fe_data,
+              logging_prefix.empty() ? "" : logging_prefix + "_basis",
+              logging_state)
+    {
+    }
+
+    const GridViewType grid_view;
+    const int order;
+    const LocalRaviartThomasFiniteElementFamily<D, d, R> local_finite_elements;
+    FiniteVolumeMapper<GV> element_indices;
+    std::vector<DynamicVector<R>> fe_data;
+    MapperImplementation mapper;
+    GlobalBasisImplementation basis;
+  }; // struct Core
+
 public:
   RaviartThomasSpace(GridViewType grd_vw,
                      const int order,
                      const std::string& logging_prefix = "",
                      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType(logging_prefix.empty() ? "RtSpace" : logging_prefix, logging_state)
-    , grid_view_(grd_vw)
-    , order_(order)
-    , local_finite_elements_()
-    , element_indices_(grid_view_)
-    , fe_data_()
-    , mapper_(grid_view_, local_finite_elements_, order_ /*, logging_prefix.empty() ? "" : logging_prefix + "_mapper"*/)
-    , basis_(grid_view_,
-             order_,
-             local_finite_elements_,
-             element_indices_,
-             fe_data_,
-             logging_prefix.empty() ? "" : logging_prefix + "_basis",
-             logging_state)
+    , core_(std::make_shared<Core>(std::move(grd_vw), order, logging_prefix, logging_state))
   {
-    LOG_(info) << "RaviartThomasSpace(grid_view=" << &grd_vw << ", order=" << order << ")" << std::endl;
-    DUNE_THROW_IF(order_ != 0, Exceptions::space_error, "Higher orders are not testet yet!");
+    LOG_(info) << "RaviartThomasSpace(order=" << order << ")" << std::endl;
+    DUNE_THROW_IF(core_->order != 0, Exceptions::space_error, "Higher orders are not testet yet!");
     this->update_after_adapt();
-    LOG_(debug) << "   element_indices_.size() = " << element_indices_.size()
-                << "\n   fe_data_.size() = " << fe_data_.size() << std::endl;
+    LOG_(debug) << "   element_indices.size() = " << core_->element_indices.size()
+                << "\n   fe_data.size() = " << core_->fe_data.size() << std::endl;
   }
 
-  RaviartThomasSpace(const ThisType& other) = delete;
+  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
+  RaviartThomasSpace(const ThisType&) = default;
 
   RaviartThomasSpace(ThisType&&) noexcept = default;
 
@@ -106,30 +131,29 @@ public:
 
   ThisType& operator=(ThisType&&) = delete;
 
-  /// \todo propagete logging, if desired
   BaseType* copy() const override final
   {
-    return new ThisType(this->grid_view_, this->order_);
+    return new ThisType(*this);
   }
 
   const GridViewType& grid_view() const override final
   {
-    return grid_view_;
+    return core_->grid_view;
   }
 
   const MapperType& mapper() const override final
   {
-    return mapper_;
+    return core_->mapper;
   }
 
   const GlobalBasisType& basis() const override final
   {
-    return basis_;
+    return core_->basis;
   }
 
   const LocalFiniteElementFamilyType& finite_elements() const override final
   {
-    return local_finite_elements_;
+    return core_->local_finite_elements;
   }
 
   SpaceType type() const override final
@@ -139,12 +163,12 @@ public:
 
   int min_polorder() const override final
   {
-    return order_;
+    return core_->order;
   }
 
   int max_polorder() const override final
   {
-    return order_;
+    return core_->order;
   }
 
   bool continuous(const int /*diff_order*/) const override final
@@ -163,19 +187,20 @@ public:
   }
 
 protected:
+  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() override final
   {
     LOG_(info) << "update_after_adapt()" << std::endl;
-    element_indices_.update_after_adapt();
+    core_->element_indices.update_after_adapt();
     // check: the mapper does not work for non-conforming intersections
-    if (d == 3 && grid_view_.indexSet().types(0).size() != 1)
+    if (d == 3 && core_->grid_view.indexSet().types(0).size() != 1)
       DUNE_THROW(Exceptions::space_error,
                  "in RaviartThomasSpace: non-conforming intersections are not (yet) "
                  "supported, and more than one element type in 3d leads to non-conforming intersections!");
     // compute scaling to ensure basis*integrationElementNormal = 1
     std::map<GeometryType, DynamicVector<R>> geometry_to_scaling_factors_map;
-    for (const auto& geometry_type : grid_view_.indexSet().types(0)) {
-      const auto& finite_element = local_finite_elements_.get(geometry_type, order_);
+    for (const auto& geometry_type : core_->grid_view.indexSet().types(0)) {
+      const auto& finite_element = core_->local_finite_elements.get(geometry_type, core_->order);
       const auto& reference_element = ReferenceElements<D, d>::general(geometry_type);
       const auto num_intersections = reference_element.size(1);
       geometry_to_scaling_factors_map.insert(std::make_pair(geometry_type, DynamicVector<R>(num_intersections, R(1.))));
@@ -191,16 +216,16 @@ protected:
     }
     // compute switches (as signs of the scaling factor) to ensure continuity of the normal component (therefore we need
     // unique indices for codim 0  entities, which cannot be achieved by the grid layers index set for mixed grids)
-    fe_data_.resize(element_indices_.size());
-    for (auto&& entity : elements(grid_view_)) {
+    core_->fe_data.resize(core_->element_indices.size());
+    for (auto&& entity : elements(core_->grid_view)) {
       const auto geometry_type = entity.type();
-      const auto& finite_element = local_finite_elements_.get(geometry_type, order_);
+      const auto& finite_element = core_->local_finite_elements.get(geometry_type, core_->order);
       const auto& coeffs = finite_element.coefficients();
-      const auto element_index = element_indices_.global_index(entity, 0);
-      fe_data_[element_index] = geometry_to_scaling_factors_map.at(geometry_type);
-      auto& local_switches = fe_data_[element_index];
-      for (auto&& intersection : intersections(grid_view_, entity)) {
-        if (intersection.neighbor() && element_index < element_indices_.global_index(intersection.outside(), 0)) {
+      const auto element_index = core_->element_indices.global_index(entity, 0);
+      core_->fe_data[element_index] = geometry_to_scaling_factors_map.at(geometry_type);
+      auto& local_switches = core_->fe_data[element_index];
+      for (auto&& intersection : intersections(core_->grid_view, entity)) {
+        if (intersection.neighbor() && element_index < core_->element_indices.global_index(intersection.outside(), 0)) {
           const auto intersection_index = XT::Common::numeric_cast<unsigned int>(intersection.indexInInside());
           for (size_t ii = 0; ii < coeffs.size(); ++ii) {
             const auto& local_key = coeffs.local_key(ii);
@@ -212,19 +237,13 @@ protected:
       }
     }
     // update mapper, basis and communicator
-    mapper_.update_after_adapt();
-    basis_.update_after_adapt();
+    core_->mapper.update_after_adapt();
+    core_->basis.update_after_adapt();
     this->create_communicator();
   } // ... update_after_adapt(...)
 
 private:
-  const GridViewType grid_view_;
-  const int order_;
-  const LocalRaviartThomasFiniteElementFamily<D, d, R> local_finite_elements_;
-  FiniteVolumeMapper<GV> element_indices_;
-  std::vector<DynamicVector<R>> fe_data_;
-  MapperImplementation mapper_;
-  GlobalBasisImplementation basis_;
+  std::shared_ptr<Core> core_;
 }; // class RaviartThomasSpace
 
 

--- a/dune/gdt/spaces/interface.hh
+++ b/dune/gdt/spaces/interface.hh
@@ -161,7 +161,7 @@ public:
       auto element_basis = this->basis().localize();
       element_restriction_FE_data = element_basis->default_data(element.type());
       element_basis->restore(element, element_restriction_FE_data);
-      auto lhs = LocalElementIntegralBilinearForm<E, r, rC, R, R>(LocalProductIntegrand<E, r, R, R>())
+      auto lhs = make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r, R, R>())
                      .apply2(*element_basis, *element_basis);
       DynamicVector<R> rhs(element_basis->size(), 0.);
       for (auto&& child_element : descendantElements(element, element.level() + 1)) {

--- a/dune/gdt/spaces/l2/discontinuous-lagrange.hh
+++ b/dune/gdt/spaces/l2/discontinuous-lagrange.hh
@@ -78,30 +78,38 @@ private:
   using MapperImplementation = DiscontinuousMapper<GridViewType, LocalFiniteElementFamilyType>;
   using GlobalBasisImplementation = DefaultGlobalBasis<GridViewType, r, 1, R>;
 
+  /**
+   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
+   * (mapper and basis reference the core's grid view and finite elements, so its address has to be stable anyway),
+   * which makes copy() O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
+   */
+  struct Core
+  {
+    Core(GridViewType grd_vw, const int ord)
+      : grid_view(std::move(grd_vw))
+      , order(ord)
+      , local_finite_elements(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())
+    {
+    }
+
+    const GridViewType grid_view;
+    const int order;
+    std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements;
+    std::unique_ptr<MapperImplementation> mapper;
+    std::unique_ptr<GlobalBasisImplementation> basis;
+  }; // struct Core
+
 public:
   DiscontinuousLagrangeSpace(GridViewType grd_vw, const int order = 1, const bool dimws_glbl_mppng = false)
     : BaseType()
-    , grid_view_(grd_vw)
-    , order_(order)
     , dimwise_global_mapping((r == 1) ? false : dimws_glbl_mppng) // does not make sense in the scalar case
-    , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    , mapper_(nullptr)
-    , basis_(nullptr)
+    , core_(std::make_shared<Core>(std::move(grd_vw), order))
   {
     this->update_after_adapt();
   }
 
-  DiscontinuousLagrangeSpace(const ThisType& other)
-    : BaseType(other)
-    , grid_view_(other.grid_view_)
-    , order_(other.order_)
-    , dimwise_global_mapping(other.dimwise_global_mapping)
-    , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    , mapper_(nullptr)
-    , basis_(nullptr)
-  {
-    this->update_after_adapt();
-  }
+  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
+  DiscontinuousLagrangeSpace(const ThisType&) = default;
 
   DiscontinuousLagrangeSpace(ThisType&&) noexcept = default;
 
@@ -116,24 +124,24 @@ public:
 
   const GridViewType& grid_view() const override final
   {
-    return grid_view_;
+    return core_->grid_view;
   }
 
   const MapperType& mapper() const override final
   {
-    assert(mapper_ && "This must not happen!");
-    return *mapper_;
+    assert(core_->mapper && "This must not happen!");
+    return *core_->mapper;
   }
 
   const GlobalBasisType& basis() const override final
   {
-    assert(basis_ && "This must not happen!");
-    return *basis_;
+    assert(core_->basis && "This must not happen!");
+    return *core_->basis;
   }
 
   const LocalFiniteElementFamilyType& finite_elements() const override final
   {
-    return *local_finite_elements_;
+    return *core_->local_finite_elements;
   }
 
   SpaceType type() const override final
@@ -143,12 +151,12 @@ public:
 
   int min_polorder() const override final
   {
-    return order_;
+    return core_->order;
   }
 
   int max_polorder() const override final
   {
-    return order_;
+    return core_->order;
   }
 
   bool continuous(const int /*diff_order*/) const override final
@@ -166,33 +174,29 @@ public:
     return true;
   }
 
+  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() override final
   {
     // create/update mapper ...
-    if (mapper_)
-      mapper_->update_after_adapt();
+    if (core_->mapper)
+      core_->mapper->update_after_adapt();
     else
-      mapper_ =
-          std::make_unique<MapperImplementation>(grid_view_, *local_finite_elements_, order_, dimwise_global_mapping);
+      core_->mapper = std::make_unique<MapperImplementation>(
+          core_->grid_view, *core_->local_finite_elements, core_->order, dimwise_global_mapping);
     // ... and basis
-    if (basis_)
-      basis_->update_after_adapt();
+    if (core_->basis)
+      core_->basis->update_after_adapt();
     else
-      basis_ = std::make_unique<GlobalBasisImplementation>(grid_view_, *local_finite_elements_, order_);
+      core_->basis =
+          std::make_unique<GlobalBasisImplementation>(core_->grid_view, *core_->local_finite_elements, core_->order);
     this->create_communicator();
   } // ... update_after_adapt(...)
-
-private:
-  const GridViewType grid_view_;
-  const int order_;
 
 public:
   const bool dimwise_global_mapping;
 
 private:
-  std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements_;
-  std::unique_ptr<MapperImplementation> mapper_;
-  std::unique_ptr<GlobalBasisImplementation> basis_;
+  std::shared_ptr<Core> core_;
 }; // class DiscontinuousLagrangeSpace
 
 

--- a/dune/gdt/spaces/l2/discontinuous-lagrange.hh
+++ b/dune/gdt/spaces/l2/discontinuous-lagrange.hh
@@ -33,6 +33,7 @@
 #include <dune/gdt/spaces/basis/default.hh>
 #include <dune/gdt/spaces/mapper/discontinuous.hh>
 #include <dune/gdt/spaces/interface.hh>
+#include <dune/gdt/spaces/shared-core.hh>
 
 namespace Dune {
 namespace GDT {
@@ -61,54 +62,36 @@ namespace GDT {
  * \sa make_discontinuous_lagrange_space
  */
 template <class GV, size_t r = 1, class R = double>
-class DiscontinuousLagrangeSpace : public SpaceInterface<GV, r, 1, R>
+class DiscontinuousLagrangeSpace
+  : public internal::SpaceWithSharedCore<
+        GV,
+        r,
+        1,
+        R,
+        LocalLagrangeFiniteElementFamily<typename GV::ctype, GV::dimension, R, r>,
+        DiscontinuousMapper<GV, LocalFiniteElementFamilyInterface<typename GV::ctype, GV::dimension, R, r, 1>>,
+        DefaultGlobalBasis<GV, r, 1, R>>
 {
   using ThisType = DiscontinuousLagrangeSpace;
-  using BaseType = SpaceInterface<GV, r, 1, R>;
+  using BaseType = internal::SpaceWithSharedCore<
+      GV,
+      r,
+      1,
+      R,
+      LocalLagrangeFiniteElementFamily<typename GV::ctype, GV::dimension, R, r>,
+      DiscontinuousMapper<GV, LocalFiniteElementFamilyInterface<typename GV::ctype, GV::dimension, R, r, 1>>,
+      DefaultGlobalBasis<GV, r, 1, R>>;
 
 public:
-  using BaseType::d;
-  using typename BaseType::D;
-  using typename BaseType::GlobalBasisType;
   using typename BaseType::GridViewType;
-  using typename BaseType::LocalFiniteElementFamilyType;
-  using typename BaseType::MapperType;
 
-private:
-  using MapperImplementation = DiscontinuousMapper<GridViewType, LocalFiniteElementFamilyType>;
-  using GlobalBasisImplementation = DefaultGlobalBasis<GridViewType, r, 1, R>;
-
-  /**
-   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
-   * (mapper and basis reference the core's grid view and finite elements, so its address has to be stable anyway),
-   * which makes copy() O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
-   */
-  struct Core
-  {
-    Core(GridViewType grd_vw, const int ord)
-      : grid_view(std::move(grd_vw))
-      , order(ord)
-      , local_finite_elements(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    {
-    }
-
-    const GridViewType grid_view;
-    const int order;
-    std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements;
-    std::unique_ptr<MapperImplementation> mapper;
-    std::unique_ptr<GlobalBasisImplementation> basis;
-  }; // struct Core
-
-public:
   DiscontinuousLagrangeSpace(GridViewType grd_vw, const int order = 1, const bool dimws_glbl_mppng = false)
-    : BaseType()
+    : BaseType(std::move(grd_vw), order, "DiscontinuousLagrangeSpace", XT::Common::default_logger_state())
     , dimwise_global_mapping((r == 1) ? false : dimws_glbl_mppng) // does not make sense in the scalar case
-    , core_(std::make_shared<Core>(std::move(grd_vw), order))
   {
     this->update_after_adapt();
   }
 
-  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
   DiscontinuousLagrangeSpace(const ThisType&) = default;
 
   DiscontinuousLagrangeSpace(ThisType&&) noexcept = default;
@@ -122,28 +105,6 @@ public:
     return new ThisType(*this);
   }
 
-  const GridViewType& grid_view() const override final
-  {
-    return core_->grid_view;
-  }
-
-  const MapperType& mapper() const override final
-  {
-    assert(core_->mapper && "This must not happen!");
-    return *core_->mapper;
-  }
-
-  const GlobalBasisType& basis() const override final
-  {
-    assert(core_->basis && "This must not happen!");
-    return *core_->basis;
-  }
-
-  const LocalFiniteElementFamilyType& finite_elements() const override final
-  {
-    return *core_->local_finite_elements;
-  }
-
   SpaceType type() const override final
   {
     return SpaceType::discontinuous_lagrange;
@@ -151,12 +112,12 @@ public:
 
   int min_polorder() const override final
   {
-    return core_->order;
+    return this->fe_order();
   }
 
   int max_polorder() const override final
   {
-    return core_->order;
+    return this->fe_order();
   }
 
   bool continuous(const int /*diff_order*/) const override final
@@ -174,29 +135,13 @@ public:
     return true;
   }
 
-  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() override final
   {
-    // create/update mapper ...
-    if (core_->mapper)
-      core_->mapper->update_after_adapt();
-    else
-      core_->mapper = std::make_unique<MapperImplementation>(
-          core_->grid_view, *core_->local_finite_elements, core_->order, dimwise_global_mapping);
-    // ... and basis
-    if (core_->basis)
-      core_->basis->update_after_adapt();
-    else
-      core_->basis =
-          std::make_unique<GlobalBasisImplementation>(core_->grid_view, *core_->local_finite_elements, core_->order);
-    this->create_communicator();
-  } // ... update_after_adapt(...)
+    this->create_or_update_core(dimwise_global_mapping);
+  }
 
 public:
   const bool dimwise_global_mapping;
-
-private:
-  std::shared_ptr<Core> core_;
 }; // class DiscontinuousLagrangeSpace
 
 

--- a/dune/gdt/spaces/l2/finite-volume.hh
+++ b/dune/gdt/spaces/l2/finite-volume.hh
@@ -62,26 +62,37 @@ private:
   using MapperImplementation = FiniteVolumeMapper<GridViewType, r, 1>;
   using GlobalBasisImplementation = FiniteVolumeGlobalBasis<GridViewType, r, R>;
 
+  /**
+   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
+   * (mapper and basis reference the core's grid view, so its address has to be stable anyway), which makes copy()
+   * O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
+   */
+  struct Core
+  {
+    Core(GridViewType grd_vw)
+      : grid_view(std::move(grd_vw))
+      , local_finite_elements(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())
+      , mapper(grid_view)
+      , basis(grid_view)
+    {
+    }
+
+    const GridViewType grid_view;
+    std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements;
+    MapperImplementation mapper;
+    GlobalBasisImplementation basis;
+  }; // struct Core
+
 public:
   FiniteVolumeSpace(GridViewType grd_vw)
     : BaseType()
-    , grid_view_(grd_vw)
-    , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    , mapper_(grid_view_)
-    , basis_(grid_view_)
+    , core_(std::make_shared<Core>(std::move(grd_vw)))
   {
     this->update_after_adapt();
   }
 
-  FiniteVolumeSpace(const ThisType& other)
-    : BaseType(other)
-    , grid_view_(other.grid_view_)
-    , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())
-    , mapper_(grid_view_)
-    , basis_(grid_view_)
-  {
-    this->update_after_adapt();
-  }
+  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
+  FiniteVolumeSpace(const ThisType&) = default;
 
   FiniteVolumeSpace(ThisType&&) noexcept = default;
 
@@ -96,22 +107,22 @@ public:
 
   const GridViewType& grid_view() const override final
   {
-    return grid_view_;
+    return core_->grid_view;
   }
 
   const MapperType& mapper() const override final
   {
-    return mapper_;
+    return core_->mapper;
   }
 
   const GlobalBasisType& basis() const override final
   {
-    return basis_;
+    return core_->basis;
   }
 
   const LocalFiniteElementFamilyType& finite_elements() const override final
   {
-    return *local_finite_elements_;
+    return *core_->local_finite_elements;
   }
 
   SpaceType type() const override final
@@ -170,11 +181,12 @@ public:
     }
   } // ... restrict_to(...)
 
+  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() override final
   {
     // update mapper and basis
-    mapper_.update_after_adapt();
-    basis_.update_after_adapt();
+    core_->mapper.update_after_adapt();
+    core_->basis.update_after_adapt();
     this->create_communicator();
   }
 
@@ -205,10 +217,7 @@ public:
   } // ... prolong_onto(...)
 
 private:
-  const GridViewType grid_view_;
-  std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, r>> local_finite_elements_;
-  MapperImplementation mapper_;
-  GlobalBasisImplementation basis_;
+  std::shared_ptr<Core> core_;
 }; // class FiniteVolumeSpace< ..., r, 1 >
 
 

--- a/dune/gdt/spaces/shared-core.hh
+++ b/dune/gdt/spaces/shared-core.hh
@@ -1,0 +1,137 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+/**
+ * \file  shared-core.hh
+ * \brief Common base for spaces whose immutable state lives in a core shared between copies.
+ **/
+#ifndef DUNE_GDT_SPACES_SHARED_CORE_HH
+#define DUNE_GDT_SPACES_SHARED_CORE_HH
+
+#include <memory>
+#include <utility>
+
+#include <dune/gdt/spaces/interface.hh>
+
+namespace Dune {
+namespace GDT {
+namespace internal {
+
+
+/**
+ * \brief Base for spaces whose grid view, finite element family and lazily created mapper and basis live in a Core
+ *        that is shared between all copies of a space.
+ *
+ * Since mapper and basis reference the core's grid view and finite elements, the core's address has to be stable
+ * anyway; sharing it makes copy() O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4),
+ * and moving a space no longer leaves mapper and basis dangling. update_after_adapt() (via create_or_update_core())
+ * updates the shared core in place, so all copies stay consistent with the adapted grid.
+ */
+template <class GV, size_t r, size_t rC, class R, class FiniteElementFamily, class MapperImpl, class BasisImpl>
+class SpaceWithSharedCore : public SpaceInterface<GV, r, rC, R>
+{
+  using BaseType = SpaceInterface<GV, r, rC, R>;
+
+public:
+  using typename BaseType::GlobalBasisType;
+  using typename BaseType::GridViewType;
+  using typename BaseType::LocalFiniteElementFamilyType;
+  using typename BaseType::MapperType;
+
+protected:
+  struct Core
+  {
+    template <class... FamilyArgs>
+    Core(GridViewType grd_vw, const int order, FamilyArgs&&... family_args)
+      : grid_view(std::move(grd_vw))
+      , fe_order(order)
+      , local_finite_elements(std::make_unique<const FiniteElementFamily>(std::forward<FamilyArgs>(family_args)...))
+    {
+    }
+
+    const GridViewType grid_view;
+    const int fe_order;
+    std::unique_ptr<const FiniteElementFamily> local_finite_elements;
+    std::unique_ptr<MapperImpl> mapper;
+    std::unique_ptr<BasisImpl> basis;
+  }; // struct Core
+
+  template <class... FamilyArgs>
+  SpaceWithSharedCore(GridViewType grd_vw,
+                      const int order,
+                      const std::string& logging_prefix,
+                      const std::array<bool, 3>& logging_state,
+                      FamilyArgs&&... family_args)
+    : BaseType(logging_prefix, logging_state)
+    , core_(std::make_shared<Core>(std::move(grd_vw), order, std::forward<FamilyArgs>(family_args)...))
+  {
+  }
+
+  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
+  SpaceWithSharedCore(const SpaceWithSharedCore&) = default;
+
+  SpaceWithSharedCore(SpaceWithSharedCore&&) noexcept = default;
+
+  /**
+   * Creates mapper and basis on the first call, updates them (in the shared core, i.e. for all copies of the space)
+   * on subsequent calls; extra_mapper_args are only used on creation. To be called from update_after_adapt().
+   */
+  template <class... ExtraMapperArgs>
+  void create_or_update_core(ExtraMapperArgs&&... extra_mapper_args)
+  {
+    if (core_->mapper)
+      core_->mapper->update_after_adapt();
+    else
+      core_->mapper = std::make_unique<MapperImpl>(core_->grid_view,
+                                                   *core_->local_finite_elements,
+                                                   core_->fe_order,
+                                                   std::forward<ExtraMapperArgs>(extra_mapper_args)...);
+    if (core_->basis)
+      core_->basis->update_after_adapt();
+    else
+      core_->basis = std::make_unique<BasisImpl>(core_->grid_view, *core_->local_finite_elements, core_->fe_order);
+    this->create_communicator();
+  } // ... create_or_update_core(...)
+
+  int fe_order() const
+  {
+    return core_->fe_order;
+  }
+
+public:
+  const GridViewType& grid_view() const final
+  {
+    return core_->grid_view;
+  }
+
+  const MapperType& mapper() const final
+  {
+    assert(core_->mapper && "This must not happen!");
+    return *core_->mapper;
+  }
+
+  const GlobalBasisType& basis() const final
+  {
+    assert(core_->basis && "This must not happen!");
+    return *core_->basis;
+  }
+
+  const LocalFiniteElementFamilyType& finite_elements() const final
+  {
+    return *core_->local_finite_elements;
+  }
+
+protected:
+  std::shared_ptr<Core> core_;
+}; // class SpaceWithSharedCore
+
+
+} // namespace internal
+} // namespace GDT
+} // namespace Dune
+
+#endif // DUNE_GDT_SPACES_SHARED_CORE_HH

--- a/dune/gdt/spaces/skeleton/finite-volume.hh
+++ b/dune/gdt/spaces/skeleton/finite-volume.hh
@@ -59,26 +59,37 @@ private:
   using MapperImplementation = FiniteVolumeSkeletonMapper<GridViewType, 1, 1>;
   using GlobalBasisImplementation = FiniteVolumeGlobalBasis<GridViewType, 1, R>;
 
+  /**
+   * Holds everything the read-only interface of this space exposes. The core is shared between all copies of a space
+   * (mapper and basis reference the core's grid view, so its address has to be stable anyway), which makes copy()
+   * O(1) instead of a full mapper rebuild over the whole grid view (review A3/C7/D4).
+   */
+  struct Core
+  {
+    Core(GridViewType grd_vw)
+      : grid_view(std::move(grd_vw))
+      , local_finite_elements(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, 1>>())
+      , mapper(grid_view)
+      , basis(grid_view)
+    {
+    }
+
+    const GridViewType grid_view;
+    std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, 1>> local_finite_elements;
+    MapperImplementation mapper;
+    GlobalBasisImplementation basis;
+  }; // struct Core
+
 public:
   FiniteVolumeSkeletonSpace(GridViewType grd_vw)
     : BaseType()
-    , grid_view_(grd_vw)
-    , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, 1>>())
-    , mapper_(grid_view_)
-    , basis_(grid_view_)
+    , core_(std::make_shared<Core>(std::move(grd_vw)))
   {
     this->update_after_adapt();
   }
 
-  FiniteVolumeSkeletonSpace(const ThisType& other)
-    : BaseType(other)
-    , grid_view_(other.grid_view_)
-    , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, 1>>())
-    , mapper_(grid_view_)
-    , basis_(grid_view_)
-  {
-    this->update_after_adapt();
-  }
+  /// \note Shares the core (grid view, finite elements, mapper and basis) with other, \sa Core.
+  FiniteVolumeSkeletonSpace(const ThisType&) = default;
 
   FiniteVolumeSkeletonSpace(ThisType&&) noexcept = default;
 
@@ -93,23 +104,23 @@ public:
 
   const GridViewType& grid_view() const override final
   {
-    return grid_view_;
+    return core_->grid_view;
   }
 
   const MapperType& mapper() const override final
   {
-    return mapper_;
+    return core_->mapper;
   }
 
   const GlobalBasisType& basis() const override final
   {
-    return basis_;
+    return core_->basis;
   }
 
   const LocalFiniteElementFamilyType& finite_elements() const override final
   {
     DUNE_THROW(Exceptions::space_error, "Not implemented yet for skeleton space!");
-    return *local_finite_elements_;
+    return *core_->local_finite_elements;
   }
 
   SpaceType type() const override final
@@ -149,11 +160,12 @@ public:
     DUNE_THROW(Exceptions::space_error, "Not implemented yet for skeleton space!");
   }
 
+  /// \note Updates the shared core, i.e. all copies of this space see the updated mapper and basis.
   void update_after_adapt() override final
   {
     // update mapper and basis
-    mapper_.update_after_adapt();
-    basis_.update_after_adapt();
+    core_->mapper.update_after_adapt();
+    core_->basis.update_after_adapt();
     this->create_communicator();
   }
 
@@ -167,10 +179,7 @@ public:
   }
 
 private:
-  const GridViewType grid_view_;
-  std::unique_ptr<const LocalLagrangeFiniteElementFamily<D, d, R, 1>> local_finite_elements_;
-  MapperImplementation mapper_;
-  GlobalBasisImplementation basis_;
+  std::shared_ptr<Core> core_;
 }; // class FiniteVolumeSkeletonSpace< ..., 1, 1 >
 
 

--- a/dune/gdt/test/misc/static_integral_forms.cc
+++ b/dune/gdt/test/misc/static_integral_forms.cc
@@ -1,0 +1,101 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <memory>
+
+#include <dune/xt/functions/constant.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/gdt/local/bilinear-forms/integrals.hh>
+#include <dune/gdt/local/functionals/integrals.hh>
+#include <dune/gdt/local/integrands/laplace.hh>
+#include <dune/gdt/local/integrands/product.hh>
+#include <dune/gdt/spaces/h1/continuous-lagrange.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+using E = XT::Grid::extract_entity_t<GV>;
+
+
+/// The statically dispatched integral forms have to yield exactly the results of their type-erased counterparts.
+struct StaticIntegralFormsTest : public ::testing::Test
+{
+  void SetUp() override
+  {
+    grid_provider_ = std::make_unique<XT::Grid::GridProvider<G>>(XT::Grid::make_cube_grid<G>(0., 1., 4u));
+    space_ = std::make_unique<ContinuousLagrangeSpace<GV>>(grid_provider_->leaf_view(), /*order=*/2);
+  }
+
+  template <class DynamicVariant, class StaticVariant>
+  void expect_same_local_matrices(const DynamicVariant& dynamic_form, const StaticVariant& static_form)
+  {
+    auto basis = space_->basis().localize();
+    const auto max_size = space_->mapper().max_local_size();
+    DynamicMatrix<double> expected(max_size, max_size, 0.);
+    DynamicMatrix<double> actual(max_size, max_size, 0.);
+    for (auto&& element : elements(space_->grid_view())) {
+      basis->bind(element);
+      dynamic_form.apply2(*basis, *basis, expected);
+      static_form.apply2(*basis, *basis, actual);
+      for (size_t ii = 0; ii < basis->size(); ++ii)
+        for (size_t jj = 0; jj < basis->size(); ++jj)
+          EXPECT_DOUBLE_EQ(expected[ii][jj], actual[ii][jj]);
+    }
+  } // ... expect_same_local_matrices(...)
+
+  std::unique_ptr<XT::Grid::GridProvider<G>> grid_provider_;
+  std::unique_ptr<ContinuousLagrangeSpace<GV>> space_;
+}; // struct StaticIntegralFormsTest
+
+
+TEST_F(StaticIntegralFormsTest, laplace_bilinear_form_matches_type_erased_variant)
+{
+  const LocalElementIntegralBilinearForm<E> dynamic_form(LocalLaplaceIntegrand<E>());
+  const auto static_form = make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E>());
+  this->expect_same_local_matrices(dynamic_form, static_form);
+}
+
+TEST_F(StaticIntegralFormsTest, product_bilinear_form_matches_type_erased_variant)
+{
+  const LocalElementIntegralBilinearForm<E> dynamic_form(LocalElementProductIntegrand<E>());
+  const auto static_form = make_local_element_integral_bilinear_form(LocalElementProductIntegrand<E>());
+  this->expect_same_local_matrices(dynamic_form, static_form);
+}
+
+TEST_F(StaticIntegralFormsTest, static_bilinear_form_works_through_the_type_erased_interface)
+{
+  const LocalElementIntegralBilinearForm<E> dynamic_form(LocalLaplaceIntegrand<E>());
+  const auto static_form = make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E>());
+  // erase the type, as operators and assemblers do
+  const auto erased_copy = static_form.copy();
+  this->expect_same_local_matrices(dynamic_form, *erased_copy);
+}
+
+TEST_F(StaticIntegralFormsTest, functional_matches_type_erased_variant)
+{
+  const auto integrand = LocalElementProductIntegrand<E>().with_ansatz(XT::Functions::ConstantGridFunction<E>(1.));
+  const LocalElementIntegralFunctional<E> dynamic_functional(integrand);
+  const auto static_functional = make_local_element_integral_functional(integrand);
+  auto basis = space_->basis().localize();
+  const auto max_size = space_->mapper().max_local_size();
+  DynamicVector<double> expected(max_size, 0.);
+  DynamicVector<double> actual(max_size, 0.);
+  for (auto&& element : elements(space_->grid_view())) {
+    basis->bind(element);
+    dynamic_functional.apply(*basis, expected);
+    static_functional.apply(*basis, actual);
+    for (size_t ii = 0; ii < basis->size(); ++ii)
+      EXPECT_DOUBLE_EQ(expected[ii], actual[ii]);
+  }
+} // TEST_F(StaticIntegralFormsTest, functional_matches_type_erased_variant)

--- a/dune/gdt/test/misc/static_integral_forms.cc
+++ b/dune/gdt/test/misc/static_integral_forms.cc
@@ -61,21 +61,21 @@ struct StaticIntegralFormsTest : public ::testing::Test
 
 TEST_F(StaticIntegralFormsTest, laplace_bilinear_form_matches_type_erased_variant)
 {
-  const LocalElementIntegralBilinearForm<E> dynamic_form(LocalLaplaceIntegrand<E>());
+  const LocalElementIntegralBilinearForm<E> dynamic_form{LocalLaplaceIntegrand<E>()};
   const auto static_form = make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E>());
   this->expect_same_local_matrices(dynamic_form, static_form);
 }
 
 TEST_F(StaticIntegralFormsTest, product_bilinear_form_matches_type_erased_variant)
 {
-  const LocalElementIntegralBilinearForm<E> dynamic_form(LocalElementProductIntegrand<E>());
+  const LocalElementIntegralBilinearForm<E> dynamic_form{LocalElementProductIntegrand<E>()};
   const auto static_form = make_local_element_integral_bilinear_form(LocalElementProductIntegrand<E>());
   this->expect_same_local_matrices(dynamic_form, static_form);
 }
 
 TEST_F(StaticIntegralFormsTest, static_bilinear_form_works_through_the_type_erased_interface)
 {
-  const LocalElementIntegralBilinearForm<E> dynamic_form(LocalLaplaceIntegrand<E>());
+  const LocalElementIntegralBilinearForm<E> dynamic_form{LocalLaplaceIntegrand<E>()};
   const auto static_form = make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E>());
   // erase the type, as operators and assemblers do
   const auto erased_copy = static_form.copy();

--- a/dune/gdt/tools/grid-quality-estimates.hh
+++ b/dune/gdt/tools/grid-quality-estimates.hh
@@ -50,9 +50,9 @@ double estimate_inverse_inequality_constant(const SpaceInterface<GV, r>& space)
     basis->bind(element);
     const double h = XT::Grid::diameter(element);
     auto H1_product_matrix = XT::LA::convert_to<XT::LA::CommonDenseMatrix<double>>(
-        LocalElementIntegralBilinearForm<E, r>(LocalLaplaceIntegrand<E, r>()).apply2(*basis, *basis));
+        make_local_element_integral_bilinear_form(LocalLaplaceIntegrand<E, r>()).apply2(*basis, *basis));
     auto L2_product_matrix = XT::LA::convert_to<XT::LA::CommonDenseMatrix<double>>(
-        LocalElementIntegralBilinearForm<E, r>(LocalProductIntegrand<E, r>()).apply2(*basis, *basis));
+        make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r>()).apply2(*basis, *basis));
     auto evs =
         XT::LA::make_generalized_eigen_solver(H1_product_matrix,
                                               L2_product_matrix,
@@ -96,7 +96,7 @@ double estimate_combined_inverse_trace_inequality_constant(const SpaceInterface<
           L2_face_product_matrix.add_to_entry(ii, jj, tmp_L2_face_product_matrix[ii][jj]);
     }
     auto L2_element_product_matrix = XT::LA::convert_to<XT::LA::CommonDenseMatrix<double>>(
-        LocalElementIntegralBilinearForm<E, r>(LocalProductIntegrand<E, r>(1.)).apply2(*basis, *basis));
+        make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r>(1.)).apply2(*basis, *basis));
     auto evs = XT::LA::make_generalized_eigen_solver(
                    L2_face_product_matrix,
                    L2_element_product_matrix,

--- a/dune/gdt/tools/local-mass-matrix.hh
+++ b/dune/gdt/tools/local-mass-matrix.hh
@@ -90,8 +90,8 @@ public:
   {
     local_basis_->bind(element);
     const size_t id = element_mapper_.global_index(element, 0);
-    const LocalElementIntegralBilinearForm<E, r, rC, F, F> local_l2_bilinear_form(
-        LocalProductIntegrand<E, r, F, F>(1.));
+    const auto local_l2_bilinear_form =
+        make_local_element_integral_bilinear_form(LocalProductIntegrand<E, r, F, F>(1.));
     auto matrix =
         XT::LA::convert_to<XT::LA::CommonDenseMatrix<F>>(local_l2_bilinear_form.apply2(*local_basis_, *local_basis_));
     auto inverse = XT::LA::invert_matrix(matrix);


### PR DESCRIPTION
## Summary

Implements the four big re-architecture items D1–D4 from the adversarial review of the PDE-solver core (#305, `docs/reviews/2026-07-adversarial-cpp-review.md`), **stacked on top of #306**. One concern per commit; review sections are cited in each commit message.

### D1 — Statically dispatched assembly kernel (A1)
- **`feat(local)`**: `StaticLocalElementIntegralBilinearForm<Integrand>` / `StaticLocalElementIntegralFunctional<Integrand>` keep the concrete integrand as a template parameter and by value, and call it via qualified (non-virtual, inlinable) calls in the quadrature loop. Type erasure is confined to the API boundary: both still implement the local-form interfaces, so they compose with the existing operators/assemblers at one virtual call per element instead of several per quadrature point. The type-erased classes remain as the fallback; users opt in via `make_local_element_integral_bilinear_form` / `..._functional`.
- **`perf(gdt)`**: internal sites whose integrand type is statically known (L2/H1 products, local mass matrices, grid quality estimates, `restrict_to`'s L2 projection) now use the static variants — so the static path is exercised by the existing norm/product/EOC tests.
- **`test(local)`**: new test comparing static vs. type-erased forms entrywise over a 2d grid, including through the erased interface.

### D2 — Locks off the DoF-write path (A2)
- **`fix(local)`**: the program-wide `static std::mutex` in `LocalDofVector::operator[]` is gone. It serialized every mutable DoF access on any vector in any thread while `set_entry`/`add_to_entry`/`get_unchecked_ref` on the same class wrote the same entries unlocked — catastrophic for scaling and illusory for safety. The actual contract (caller ensures exclusive access) is now documented.
- **`perf(assembler)`**: the three matrix assemblers stage contributions in per-functor (hence per-thread) COO scatter buffers. The walker calls `finalize()` on every functor copy sequentially after the walk, so the merge into the global matrix is lock-free in the common case; buffers over ~6 MiB flush mid-walk through `add_to_entry`, whose internal (now thread-striped, see #306) locking keeps that safe. `MatrixOperator::finalize()` forwards to its local assemblers before discarding them. The functional (vector) assemblers are intentionally left direct: they can be driven via `assemble_range` (bare `walk_range` without `finalize()`), where deferred scatter would silently drop contributions.

### D3 — Shape-value cache + synchronized FE cache (C3, A7)
- **`fix(local/fe)`**: `ThreadSafeDefaultLocalFiniteElementFamily::get()`'s broken double-checked locking (unsynchronized `count()` against writers under the lock) replaced by a `std::shared_mutex` — shared lock for lookups, exclusive lock + re-check for creation. This gives the FE cache the single, properly synchronized home the shared cores below rely on.
- **`perf(spaces)`**: `LocalizedDefaultGlobalBasis` caches shape values and reference jacobians per geometry type, keyed by the exact point in reference coordinates — repeated evaluations at the same reference quadrature points become a lookup + copy; jacobians still apply the per-element geometry transform. The cache lives in the localized (per-thread) basis, needs no synchronization, and is size-capped with fallback to direct evaluation.

### D4 — Borrow-not-copy local views, O(1) space copies (A3, C7)
- **`refactor(spaces)`** (one commit per space): `ContinuousLagrangeSpace`, `DiscontinuousLagrangeSpace`, `ContinuousFlatTopSpace`, `FiniteVolume(Skeleton)Space` and `RaviartThomasSpace` move grid view, finite elements, mapper and basis into a `shared_ptr`-held `Core` shared between copies — `copy()` (per-thread assembler clones!) is now O(1) instead of a full mapper rebuild over the grid view. `update_after_adapt()` updates the shared core in place, so all copies stay consistent with the adapted grid. Side effect: mapper/basis now reference core members instead of space members, so moving a space no longer dangles them. `RaviartThomasSpace::copy()` previously reconstructed the whole space from scratch.
- **`refactor(local)`**: `ConstLocalDiscreteFunction` borrows the space instead of `space_.copy()` — every `local_function()` call was O(#grid elements), making per-element usage silently O(N²) (review A3's "'local' views are secretly O(N)").
- **`fix(local)`**: removed `LocalDiscreteFunction`'s dead-but-armed element-bound constructor (delegates to a base constructor and a `localize(element)` overload that do not exist — uncompilable on first instantiation).

### Ordering
The commits are ordered so the branch is consistent at every step: the FE-cache synchronization lands first (the shared cores and borrowing views make the cache concurrently shared), then the space cores, then the local-view borrow, then D2, D1 and the shape-value cache.

## Verification

No full local build is possible in the authoring environment; beyond the CI matrix (debug + release_coverage, which compiles all test binaries including the new `static_integral_forms` test and runs the full ctest suite), every touched class template was **explicitly instantiated and syntax-checked locally** (`g++ -fsyntax-only`) against dune 2.10 headers, together with a broad consumer sweep (interpolations, norms, prolongations, products, vector functionals, bilinear forms, matrix operator assembly, Oswald interpolation, advection-dg/fv, Dirichlet constraints, Bochner). That check caught (and this branch fixes) a most-vexing-parse in the new test and the uninstantiable `LocalDiscreteFunction` constructor. Formatting checked with the pre-commit pinned clang-format 22.1.5.

Known limitations / follow-up candidates:
- The intersection/coupling integral forms have no static-dispatch variants yet (same mechanical pattern as the element ones).
- The striped container mutexes still exist (the scatter buffers merely bypass them on the hot path); removing them outright requires auditing all remaining concurrent `add_to_entry` users.
- The A5 consolidation items (assembler/space/tableau de-duplication) and D5–D10 are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qn8MAbXcKc5rRCk8gpPA8a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qn8MAbXcKc5rRCk8gpPA8a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster, statically dispatched local integral forms and matching helper constructors.
  * Introduced shared-core space handling for several space types, improving copy behavior and keeping adapted copies consistent.

* **Bug Fixes**
  * Improved matrix assembly flushing so pending contributions are applied reliably at finalize time.
  * Reduced repeated basis and Jacobian computations with caching.
  * Clarified thread-safety behavior for local DoF access and improved finite-element caching under concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->