### PR TITLE
sonar: explicitly declare test directories

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,6 +14,11 @@ sonar.organization=dune-gdt
 
 sonar.exclusions=dune/xt/functions/expression/mathexpr.cc,dune/xt/functions/expression/mathexpr.hh,dune/xt/test/gtest/**
 
+# Explicitly declare the test directories so SonarCloud analyzes them as test
+# code (test rule profile, excluded from coverage-of-sources expectations)
+# rather than as main sources.
+sonar.tests=dune/gdt/test,dune/xt/test,python/gdt/test,python/xt/test
+
 # Test files are intentionally repetitive (multiple similar test methods are expected).
 # Exclude them from copy-paste detection so structural test patterns don't trip the gate.
 sonar.cpd.exclusions=dune/gdt/test/**,dune/xt/test/**


### PR DESCRIPTION
## Summary
- Add `sonar.tests` to `sonar-project.properties`, explicitly listing `dune/gdt/test`, `dune/xt/test`, `python/gdt/test`, and `python/xt/test` as SonarCloud test directories, so they're analyzed under the test rule profile instead of as main sources.

## Test plan
- N/A (configuration-only change; no build/test impact). Verified the listed paths exist and contain the project's test sources.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCG99tZo9zwqoJ1sGg96Sf)_