### PR TITLE
ci: switch C++ coverage to clang-22 + llvm-cov/lcov (issue #314)

### DIFF
--- a/.ci/lcov_area_summary.py
+++ b/.ci/lcov_area_summary.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Aggregate an lcov-format .info file into the per-area table used in issue #314.
+
+Prints a markdown table with one row per source area (dune/xt/la, dune/gdt/local, ...)
+listing lines / hits / misses / partials and two coverage numbers:
+
+* "codecov %" counts a partial line (a hit line whose BRDA branch records are not all
+  taken) as not covered -- this is how Codecov's headline treats partials today, so this
+  column is comparable to the numbers in issue #314.
+* "line %" counts every executed line as covered regardless of branch data -- this is
+  what an lcov upload without branch records (lcov's default) would report.
+
+For a line-only .info (no BRDA records) the two columns coincide. stdlib only.
+
+Usage: lcov_area_summary.py <coverage.info> [--root <sourcedir>]
+"""
+
+import argparse
+import sys
+from collections import defaultdict
+
+# Same rows, same order as the table in issue #314 (longest prefix wins; anything
+# unmatched lands in "everything else").
+AREAS = [
+    "dune/xt/la",
+    "dune/gdt/local",
+    "dune/gdt/test",
+    "dune/xt/common",
+    "dune/xt/functions",
+    "dune/xt/test",
+    "dune/gdt/operators",
+    "dune/gdt/spaces",
+    "dune/xt/grid",
+    "dune/gdt/tools",
+    "dune/gdt/interpolations",
+]
+OTHER = "everything else"
+
+
+def parse_info(path):
+    """Return {file: {line: [exec_count, branches_total, branches_taken]}}."""
+    files = defaultdict(lambda: defaultdict(lambda: [0, 0, 0]))
+    current = None
+    with open(path) as fh:
+        for raw in fh:
+            record = raw.strip()
+            if record.startswith("SF:"):
+                current = record[3:]
+            elif record == "end_of_record":
+                current = None
+            elif current is None:
+                continue
+            elif record.startswith("DA:"):
+                line, count = record[3:].split(",")[:2]
+                files[current][int(line)][0] += int(count)
+            elif record.startswith("BRDA:"):
+                line, _block, _branch, taken = record[5:].split(",")
+                entry = files[current][int(line)]
+                entry[1] += 1
+                if taken != "-" and int(taken) > 0:
+                    entry[2] += 1
+    return files
+
+
+def area_of(path, root):
+    if root and path.startswith(root):
+        path = path[len(root):].lstrip("/")
+    for area in sorted(AREAS, key=len, reverse=True):
+        if path.startswith(area + "/") or path == area:
+            return area
+    return OTHER
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("info")
+    parser.add_argument("--root", default="", help="source dir prefix to strip from SF: paths")
+    args = parser.parse_args()
+
+    stats = {area: [0, 0, 0, 0] for area in AREAS + [OTHER]}  # lines, hits, misses, partials
+    for path, lines in parse_info(args.info).items():
+        acc = stats[area_of(path, args.root)]
+        for count, br_total, br_taken in lines.values():
+            acc[0] += 1
+            if count == 0:
+                acc[2] += 1
+            elif br_total > 0 and br_taken < br_total:
+                acc[3] += 1
+            else:
+                acc[1] += 1
+
+    def fmt(name, lines, hits, misses, partials):
+        codecov = f"{100 * hits / lines:.2f}%" if lines else "n/a"
+        line_only = f"{100 * (hits + partials) / lines:.2f}%" if lines else "n/a"
+        return f"| {name} | {lines} | {hits} | {misses} | {partials} | {codecov} | {line_only} |"
+
+    print(f"### {args.info}")
+    print()
+    print("| Area | Lines | Hits | Misses | Partials | codecov % | line % |")
+    print("|---|---:|---:|---:|---:|---:|---:|")
+    totals = [0, 0, 0, 0]
+    for area in AREAS + [OTHER]:
+        row = stats[area]
+        if row[0] == 0 and area != OTHER:
+            continue
+        totals = [a + b for a, b in zip(totals, row)]
+        print(fmt(f"`{area}`", *row))
+    print(fmt("**total**", *totals))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.ci/lcov_area_summary.py
+++ b/.ci/lcov_area_summary.py
@@ -64,7 +64,7 @@ def parse_info(path):
 
 def area_of(path, root):
     if root and path.startswith(root):
-        path = path[len(root):].lstrip("/")
+        path = path[len(root) :].lstrip("/")
     for area in sorted(AREAS, key=len, reverse=True):
         if path.startswith(area + "/") or path == area:
             return area
@@ -74,10 +74,14 @@ def area_of(path, root):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("info")
-    parser.add_argument("--root", default="", help="source dir prefix to strip from SF: paths")
+    parser.add_argument(
+        "--root", default="", help="source dir prefix to strip from SF: paths"
+    )
     args = parser.parse_args()
 
-    stats = {area: [0, 0, 0, 0] for area in AREAS + [OTHER]}  # lines, hits, misses, partials
+    stats = {
+        area: [0, 0, 0, 0] for area in AREAS + [OTHER]
+    }  # lines, hits, misses, partials
     for path, lines in parse_info(args.info).items():
         acc = stats[area_of(path, args.root)]
         for count, br_total, br_taken in lines.values():

--- a/.ci/llvm_cov_export.bash
+++ b/.ci/llvm_cov_export.bash
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Turns the raw llvm source-based coverage profiles written by an instrumented test run
+# (clang22-release_coverage preset: -fprofile-instr-generate -fcoverage-mapping, with
+# LLVM_PROFILE_FILE pointing into <builddir>/profraw/) into two lcov-format reports:
+#
+#   <builddir>/coverage-cpp.info           - with BRDA branch records (llvm-cov's true
+#                                            branch coverage, no gcov artefacts)
+#   <builddir>/coverage-cpp-lineonly.info  - the same report with all branch records
+#                                            stripped (what an lcov-default upload would
+#                                            look like: line coverage only, no partials)
+#
+# Both variants exist so the clang/lcov numbers can be compared against the current
+# gcc/gcovr/Codecov evaluation (issue #314) with and without the "partials" dimension.
+#
+# Usage: llvm_cov_export.bash <builddir> <sourcedir> <llvm-major-version>
+
+set -euo pipefail
+
+builddir="$1"
+sourcedir="$2"
+llvm_version="$3"
+
+profdata="llvm-profdata-${llvm_version}"
+llvmcov="llvm-cov-${llvm_version}"
+objdump="llvm-objdump-${llvm_version}"
+
+cd "${builddir}"
+
+shopt -s nullglob
+profraw_files=(profraw/*.profraw)
+if [[ ${#profraw_files[@]} -eq 0 ]]; then
+  echo "error: no .profraw files under ${builddir}/profraw -- did the instrumented tests run" \
+    "with LLVM_PROFILE_FILE set (ctest --preset=clang22-release_coverage)?" >&2
+  exit 1
+fi
+echo "merging ${#profraw_files[@]} profraw file(s)"
+# --failure-mode=all: a single corrupt profile (e.g. from a test killed mid-write by the
+# ctest timeout) must not discard the whole run; only fail if nothing merges.
+"${profdata}" merge -sparse --failure-mode=all -o coverage.profdata "${profraw_files[@]}"
+
+# Every binary compiled with -fcoverage-mapping carries a __llvm_covmap section; llvm-cov
+# hard-errors on objects without one, so filter the candidate set (test executables, the
+# dune libraries and the Python binding modules all live under the build tree) down to
+# instrumented ELF files first. vcpkg's dependency tree is built uninstrumented (default
+# gcc) and CMake's compiler-probe artefacts live under CMakeFiles/, so both are pruned.
+mapfile -t candidates < <(find . \
+  \( -path ./vcpkg_installed -o -name CMakeFiles -o -path ./profraw \) -prune -false -o \
+  -type f \( -perm -u+x -o -name '*.so*' \) -print | sort)
+objects=()
+for f in "${candidates[@]}"; do
+  # cheap ELF magic check before the (slower) section scan
+  [[ "$(head -c 4 "${f}" 2> /dev/null)" == $'\x7fELF' ]] || continue
+  if "${objdump}" --section-headers "${f}" 2> /dev/null | grep -q '__llvm_covmap'; then
+    objects+=("${f}")
+  fi
+done
+if [[ ${#objects[@]} -eq 0 ]]; then
+  echo "error: no instrumented binaries (with a __llvm_covmap section) found under ${builddir}" >&2
+  exit 1
+fi
+echo "exporting coverage from ${#objects[@]} instrumented binaries"
+
+# Mirror the gcovr call's --filter <sourcedir>/dune/: only our own sources, no vcpkg
+# headers, no config.h from the build tree. llvm-cov takes one positional binary plus
+# -object for the rest, and trailing positional SOURCES paths restrict the report
+# (llvm-cov's regex engine has no negative lookahead, so -ignore-filename-regex cannot
+# express "everything outside dune/").
+object_args=()
+for obj in "${objects[@]:1}"; do
+  object_args+=(-object "${obj}")
+done
+"${llvmcov}" export -format=lcov -instr-profile=coverage.profdata -num-threads=4 \
+  "${objects[0]}" "${object_args[@]}" "${sourcedir}/dune" > coverage-cpp.info
+
+# BRF/BRH are per-record branch summaries, BRDA the branch data lines; stripping them
+# yields the lcov-default (line-only) view. grep exits 1 on no matches only with -q, but
+# guard anyway in case a future llvm-cov emits no branch records at all.
+grep -vE '^(BRDA|BRF|BRH)' coverage-cpp.info > coverage-cpp-lineonly.info || true
+
+echo "wrote ${builddir}/coverage-cpp.info and ${builddir}/coverage-cpp-lineonly.info"

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -295,9 +295,11 @@ jobs:
     - name: Publish lcov area summaries to the job summary
       if: ${{ matrix.coverage_llvm }}
       run: |
-        python3 .ci/lcov_area_summary.py build/${{ matrix.preset }}/coverage-cpp.info --root "$PWD" >> "$GITHUB_STEP_SUMMARY"
-        echo >> "$GITHUB_STEP_SUMMARY"
-        python3 .ci/lcov_area_summary.py build/${{ matrix.preset }}/coverage-cpp-lineonly.info --root "$PWD" >> "$GITHUB_STEP_SUMMARY"
+        {
+          python3 .ci/lcov_area_summary.py build/${{ matrix.preset }}/coverage-cpp.info --root "$PWD"
+          echo
+          python3 .ci/lcov_area_summary.py build/${{ matrix.preset }}/coverage-cpp-lineonly.info --root "$PWD"
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload lcov reports as artifact
       if: ${{ matrix.coverage_llvm }}

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -142,10 +142,21 @@ jobs:
         # the stock debug build (no instrumentation)
         - preset: debug
           coverage: false
+          coverage_llvm: false
         # the release build compiled with gcov instrumentation (release_coverage
         # preset) so it can report C++ (and, via the bindings, Python) coverage
         - preset: release_coverage
           coverage: true
+          coverage_llvm: false
+        # measurement experiment (issue #314 / PR #277): the same release build
+        # compiled with clang-22's native source-based coverage instead of gcov
+        # (-fprofile-instr-generate -fcoverage-mapping), exported to lcov format via
+        # llvm-profdata/llvm-cov. Produces artifacts + a job summary for comparison
+        # against the gcc/gcovr leg above; deliberately NOT uploaded to Codecov, so
+        # the commit's Codecov report stays a pure gcc baseline for the A/B.
+        - preset: clang22-release_coverage
+          coverage: false
+          coverage_llvm: true
     env:
       # Compiler-level cache. Unlike the build/ cache (keyed on the vcpkg/preset
       # hash), the ccache survives manifest changes and partial rebuilds, so the
@@ -179,6 +190,22 @@ jobs:
         # those tests. gcovr/coverage.py are pulled on the fly by uv inside the
         # CMake coverage_cpp / coverage_python targets (coverage leg only).
         sudo apt-get install -y ninja-build ccache xvfb
+
+    - name: Install Clang 22
+      # Only the clang22-* leg needs clang-22; skip the (slow) apt repo add elsewhere.
+      # The clang22-* presets compile the project with clang-22/clang++-22 (the vcpkg
+      # dependencies still build with the runner's default gcc, exactly as the existing
+      # clang-* presets do). clang-22 is not in the stock ubuntu-24.04 apt repositories,
+      # so add the official LLVM apt repo via the upstream llvm.sh helper; llvm-22
+      # provides the llvm-profdata-22/llvm-cov-22/llvm-objdump-22 tools the
+      # coverage_cpp_llvm target runs.
+      if: startsWith(matrix.preset, 'clang22')
+      run: |
+        wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+        chmod +x /tmp/llvm.sh
+        sudo /tmp/llvm.sh 22
+        sudo apt-get install -y clang-22 llvm-22
+        clang-22 --version
 
     - name: Set up uv
       # Both legs run the Python test suite, which the ctest xt_test_python /
@@ -256,6 +283,31 @@ jobs:
       # written by the pytest ctest runs and writes build/<preset>/coverage-python.xml.
       if: ${{ matrix.coverage }}
       run: cmake --build --preset=${{ matrix.preset }} --target coverage_python
+
+    - name: Collect C++ coverage (llvm source-based -> lcov)
+      # merges the .profraw files written by the instrumented test run (see the
+      # clang22-release_coverage test preset's LLVM_PROFILE_FILE) and exports two
+      # lcov-format reports (with and without branch records) plus per-area summary
+      # tables -- see .ci/llvm_cov_export.bash / .ci/lcov_area_summary.py.
+      if: ${{ matrix.coverage_llvm }}
+      run: cmake --build --preset=${{ matrix.preset }} --target coverage_cpp_llvm
+
+    - name: Publish lcov area summaries to the job summary
+      if: ${{ matrix.coverage_llvm }}
+      run: |
+        python3 .ci/lcov_area_summary.py build/${{ matrix.preset }}/coverage-cpp.info --root "$PWD" >> "$GITHUB_STEP_SUMMARY"
+        echo >> "$GITHUB_STEP_SUMMARY"
+        python3 .ci/lcov_area_summary.py build/${{ matrix.preset }}/coverage-cpp-lineonly.info --root "$PWD" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload lcov reports as artifact
+      if: ${{ matrix.coverage_llvm }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: clang22-lcov-coverage
+        path: |
+          ${{ github.workspace }}/build/${{ matrix.preset }}/coverage-cpp.info
+          ${{ github.workspace }}/build/${{ matrix.preset }}/coverage-cpp-lineonly.info
+        if-no-files-found: error
 
     - name: Upload C++ coverage to Codecov
       if: ${{ matrix.coverage }}

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -139,23 +139,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # the stock debug build (no instrumentation)
+        # the stock debug build (no instrumentation), compiled with the runner's
+        # default gcc -- kept on gcc deliberately so both major compilers still
+        # build and run the full suite
         - preset: debug
-          coverage: false
           coverage_llvm: false
-        # the release build compiled with gcov instrumentation (release_coverage
-        # preset) so it can report C++ (and, via the bindings, Python) coverage
-        - preset: release_coverage
-          coverage: true
-          coverage_llvm: false
-        # measurement experiment (issue #314 / PR #277): the same release build
-        # compiled with clang-22's native source-based coverage instead of gcov
-        # (-fprofile-instr-generate -fcoverage-mapping), exported to lcov format via
-        # llvm-profdata/llvm-cov. Produces artifacts + a job summary for comparison
-        # against the gcc/gcovr leg above; deliberately NOT uploaded to Codecov, so
-        # the commit's Codecov report stays a pure gcc baseline for the A/B.
+        # the coverage leg: the release build compiled with clang-22's native
+        # source-based coverage (-fprofile-instr-generate -fcoverage-mapping),
+        # exported to lcov format via llvm-profdata/llvm-cov (see
+        # .ci/llvm_cov_export.bash) and uploaded to Codecov. This replaced the
+        # previous gcc --coverage / gcovr pipeline: gcovr cannot read clang's
+        # gcov-style data (PR #277), and llvm's own branch data is free of the
+        # gcov template/exception noise that motivated issue #314's Track A (see
+        # PR #318 for the side-by-side measurement).
         - preset: clang22-release_coverage
-          coverage: false
           coverage_llvm: true
     env:
       # Compiler-level cache. Unlike the build/ cache (keyed on the vcpkg/preset
@@ -187,8 +184,8 @@ jobs:
       run: |
         sudo apt-get update
         # xvfb gives the Python binding tests a headless display; both legs run
-        # those tests. gcovr/coverage.py are pulled on the fly by uv inside the
-        # CMake coverage_cpp / coverage_python targets (coverage leg only).
+        # those tests. coverage.py is pulled on the fly by uv inside the CMake
+        # coverage_python target (coverage leg only).
         sudo apt-get install -y ninja-build ccache xvfb
 
     - name: Install Clang 22
@@ -232,9 +229,9 @@ jobs:
       id: configure_cmake
       # Route every compile through ccache. Passing the launcher as a cache
       # variable (not just an env var) is harmless on the fresh build/ tree here
-      # (build/ is no longer cached). The gcov instrumentation lives in the
-      # release_coverage preset (see CMakePresets.json), so nothing extra is
-      # injected here.
+      # (build/ is no longer cached). The source-based coverage instrumentation
+      # lives in the clang22-release_coverage preset (see CMakePresets.json), so
+      # nothing extra is injected here.
       run: >
         cmake --preset=${{ matrix.preset }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
@@ -272,16 +269,11 @@ jobs:
       run: |
         xvfb-run -a ctest --preset=${{ matrix.preset }} --parallel ${{ needs.config.outputs.ctest_parallel }}
 
-    - name: Collect C++ coverage (coverage_cpp target -> Cobertura XML)
-      # gcovr is run by the CMake coverage_cpp target (pulled on the fly via uv);
-      # it writes build/<preset>/coverage-cpp.xml.
-      if: ${{ matrix.coverage }}
-      run: cmake --build --preset=${{ matrix.preset }} --target coverage_cpp
-
     - name: Collect Python coverage (coverage_python target -> XML)
       # the CMake coverage_python target combines the two coverage.py data files
       # written by the pytest ctest runs and writes build/<preset>/coverage-python.xml.
-      if: ${{ matrix.coverage }}
+      # coverage.py data is compiler-independent, so it rides on the coverage leg.
+      if: ${{ matrix.coverage_llvm }}
       run: cmake --build --preset=${{ matrix.preset }} --target coverage_python
 
     - name: Collect C++ coverage (llvm source-based -> lcov)
@@ -312,14 +304,17 @@ jobs:
         if-no-files-found: error
 
     - name: Upload C++ coverage to Codecov
-      if: ${{ matrix.coverage }}
+      # uploads the lcov report incl. llvm's branch records (Codecov counts a hit
+      # line with untaken branches as a partial). The line-only variant is kept as
+      # an artifact; switching the upload to it is a one-filename change.
+      if: ${{ matrix.coverage_llvm }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         # OIDC (id-token) auth instead of an upload token; see job permissions.
         use_oidc: true
-        files: ${{ github.workspace }}/build/${{ matrix.preset }}/coverage-cpp.xml
+        files: ${{ github.workspace }}/build/${{ matrix.preset }}/coverage-cpp.info
         flags: cpp
-        # We already produced the Cobertura XML with gcovr above; stop the action
+        # We already produced the lcov report with llvm-cov above; stop the action
         # from searching the tree and from running its own coverage plugins (the
         # gcov plugin would otherwise re-run gcov over the whole build tree).
         disable_search: true
@@ -329,7 +324,7 @@ jobs:
         fail_ci_if_error: true
 
     - name: Upload Python coverage to Codecov
-      if: ${{ matrix.coverage }}
+      if: ${{ matrix.coverage_llvm }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         use_oidc: true

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -178,14 +178,17 @@
     },
     {
       "name": "clang22-release_coverage",
-      "displayName": "Release Config with llvm source-based coverage (Clang 22)",
+      "displayName":
+        "Release Config with llvm source-based coverage (Clang 22)",
       "inherits": [
         "clang22-base",
         "release"
       ],
       "cacheVariables": {
-        "CMAKE_C_FLAGS": "-Wall -Wextra -Wpedantic -fprofile-instr-generate -fcoverage-mapping",
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_C_FLAGS":
+          "-Wall -Wextra -Wpedantic -fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_CXX_FLAGS":
+          "-Wall -Wextra -Wpedantic -fprofile-instr-generate -fcoverage-mapping",
         "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate",
         "CMAKE_SHARED_LINKER_FLAGS": "-fprofile-instr-generate",
         "DXT_LLVM_VERSION": "22"
@@ -320,7 +323,8 @@
         "test-base"
       ],
       "environment": {
-        "LLVM_PROFILE_FILE": "${sourceDir}/build/clang22-release_coverage/profraw/%m.profraw"
+        "LLVM_PROFILE_FILE":
+          "${sourceDir}/build/clang22-release_coverage/profraw/%m.profraw"
       },
       "execution": {
         "noTestsAction": "error",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -163,6 +163,33 @@
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++"
       }
+    },
+    {
+      "name": "clang22-base",
+      "hidden": true,
+      "inherits": [
+        "ninja-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-22",
+        "CMAKE_CXX_COMPILER": "clang++-22",
+        "DXT_TEST_TIMEOUT": "2400"
+      }
+    },
+    {
+      "name": "clang22-release_coverage",
+      "displayName": "Release Config with llvm source-based coverage (Clang 22)",
+      "inherits": [
+        "clang22-base",
+        "release"
+      ],
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-Wall -Wextra -Wpedantic -fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -fprofile-instr-generate -fcoverage-mapping",
+        "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fprofile-instr-generate",
+        "DXT_LLVM_VERSION": "22"
+      }
     }
   ],
   "buildPresets": [
@@ -203,6 +230,10 @@
     {
       "name": "clang-release",
       "configurePreset": "clang-release"
+    },
+    {
+      "name": "clang22-release_coverage",
+      "configurePreset": "clang22-release_coverage"
     }
   ],
   "testPresets": [
@@ -280,6 +311,22 @@
       "inherits": [
         "test-base"
       ]
+    },
+    {
+      "name": "clang22-release_coverage",
+      "displayName": "Clang 22 Release Coverage Tests",
+      "configurePreset": "clang22-release_coverage",
+      "inherits": [
+        "test-base"
+      ],
+      "environment": {
+        "LLVM_PROFILE_FILE": "${sourceDir}/build/clang22-release_coverage/profraw/%m.profraw"
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false,
+        "timeout": 2400
+      }
     }
   ]
 }

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -338,11 +338,12 @@ macro(DXT_ADD_PYTHON_TESTS)
     # lcov-format reports, one with llvm's branch records and one line-only, plus a per-area markdown summary of each
     # for comparison against the gcc/gcovr numbers (issue #314). DXT_LLVM_VERSION picks the llvm-profdata/llvm-cov/
     # llvm-objdump suffix; the preset sets it explicitly, the default matches the current clang22-* presets.
-    set(DXT_LLVM_VERSION "22" CACHE STRING "major version suffix of the llvm-profdata/llvm-cov/llvm-objdump binaries")
+    set(DXT_LLVM_VERSION
+        "22"
+        CACHE STRING "major version suffix of the llvm-profdata/llvm-cov/llvm-objdump binaries")
     add_custom_target(
       coverage_cpp_llvm
-      COMMAND ${CMAKE_SOURCE_DIR}/.ci/llvm_cov_export.bash ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}
-              ${DXT_LLVM_VERSION}
+      COMMAND ${CMAKE_SOURCE_DIR}/.ci/llvm_cov_export.bash ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR} ${DXT_LLVM_VERSION}
       COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/.ci/lcov_area_summary.py ${CMAKE_BINARY_DIR}/coverage-cpp.info
               --root ${CMAKE_SOURCE_DIR}
       COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/.ci/lcov_area_summary.py

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -333,6 +333,23 @@ macro(DXT_ADD_PYTHON_TESTS)
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       VERBATIM USES_TERMINAL)
   endif()
+  if(NOT TARGET coverage_cpp_llvm)
+    # llvm source-based coverage (clang22-release_coverage preset: -fprofile-instr-generate -fcoverage-mapping) ->
+    # lcov-format reports, one with llvm's branch records and one line-only, plus a per-area markdown summary of each
+    # for comparison against the gcc/gcovr numbers (issue #314). DXT_LLVM_VERSION picks the llvm-profdata/llvm-cov/
+    # llvm-objdump suffix; the preset sets it explicitly, the default matches the current clang22-* presets.
+    set(DXT_LLVM_VERSION "22" CACHE STRING "major version suffix of the llvm-profdata/llvm-cov/llvm-objdump binaries")
+    add_custom_target(
+      coverage_cpp_llvm
+      COMMAND ${CMAKE_SOURCE_DIR}/.ci/llvm_cov_export.bash ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}
+              ${DXT_LLVM_VERSION}
+      COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/.ci/lcov_area_summary.py ${CMAKE_BINARY_DIR}/coverage-cpp.info
+              --root ${CMAKE_SOURCE_DIR}
+      COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/.ci/lcov_area_summary.py
+              ${CMAKE_BINARY_DIR}/coverage-cpp-lineonly.info --root ${CMAKE_SOURCE_DIR}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      VERBATIM USES_TERMINAL)
+  endif()
   if(NOT TARGET coverage_python)
     # combine the two coverage.py data files written by the pytest CTest runs and emit one XML.
     add_custom_target(

--- a/dune/gdt/operators/oswald-interpolation.hh
+++ b/dune/gdt/operators/oswald-interpolation.hh
@@ -248,13 +248,21 @@ auto make_oswald_interpolation_operator(
 /**
  * \brief Creates an OswaldInterpolationOperator using the default ISTL dense vector type.
  */
-template <class AssemblyGridView, class RGV, size_t r, size_t rC, class F>
-auto make_oswald_interpolation_operator(
-    const AssemblyGridView& assembly_grid_view,
-    const SpaceInterface<RGV, r, rC, F>& range_space,
-    const XT::Grid::BoundaryInfo<XT::Grid::extract_intersection_t<AssemblyGridView>>& boundary_info,
-    const std::string& logging_prefix = "",
-    const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+// The boundary-info intersection type is a deduced template parameter (IntersectionType) rather than the spelled-out
+// BoundaryInfo<extract_intersection_t<AssemblyGridView>>. This matters for clang: an explicit-argument call selecting
+// the manual vector-type overload above, e.g. make_oswald_interpolation_operator<V>(...), also makes this overload a
+// candidate with AssemblyGridView = V. Spelling the parameter as BoundaryInfo<extract_intersection_t<V>> =
+// BoundaryInfo<std::false_type> completes that class while substituting the deduced arguments during overload
+// resolution, firing its hard static_assert(is_intersection<...>) (which is not in the immediate SFINAE context, so a
+// requires-clause cannot prevent it -- deduction substitutes the parameter types first). Deducing IntersectionType from
+// the actual argument keeps the parameter a valid BoundaryInfo, so this spurious candidate is instead rejected cleanly
+// because grid_view does not convert to const V&. gcc never formed the candidate to begin with.
+template <class AssemblyGridView, class RGV, size_t r, size_t rC, class F, class IntersectionType>
+auto make_oswald_interpolation_operator(const AssemblyGridView& assembly_grid_view,
+                                        const SpaceInterface<RGV, r, rC, F>& range_space,
+                                        const XT::Grid::BoundaryInfo<IntersectionType>& boundary_info,
+                                        const std::string& logging_prefix = "",
+                                        const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
 {
   using V = XT::LA::IstlDenseVector<F>;
   return make_oswald_interpolation_operator<V>(

--- a/dune/xt/grid/integrals.hh
+++ b/dune/xt/grid/integrals.hh
@@ -38,9 +38,9 @@ RangeType element_integral(
 {
   static_assert(XT::Grid::is_entity<Element>::value, "element has to be a codim-0 grid entity");
   RangeType result(0.), local_result;
-  const auto quadrature_rule = QuadratureRules<typename Element::Geometry::ctype, Element::dimension>::rule(
-      element.type(), polynomial_order_of_the_function);
-  for (auto [point_in_reference_element, quadrature_weight] : quadrature_rule) {
+  for (auto [point_in_reference_element, quadrature_weight] :
+       QuadratureRules<typename Element::Geometry::ctype, Element::dimension>::rule(element.type(),
+                                                                                    polynomial_order_of_the_function)) {
     const auto integration_factor = element.geometry().integrationElement(point_in_reference_element);
     local_result = function(point_in_reference_element);
     local_result *= quadrature_weight * integration_factor;
@@ -69,16 +69,15 @@ double element_integral(const Element& element,
 template <class RangeType, class IntersectionType>
 RangeType intersection_integral(
     const IntersectionType& intersection,
-    std::function<RangeType(const FieldVector<typename IntersectionType::ctype, IntersectionType::mydimension>&
-                                point_in_reference_intersection)> function,
+    std::function<RangeType(const FieldVector<typename IntersectionType::Geometry::ctype,
+                                              IntersectionType::mydimension>& point_in_reference_intersection)>
+        function,
     const int polynomial_order_of_the_function)
 {
   static_assert(XT::Grid::is_intersection<IntersectionType>::value, "intersection has to be a codim-1 grid entity");
   RangeType result(0.), local_result;
-  const auto quadrature_rule_intersection =
-      QuadratureRules<typename IntersectionType::ctype, IntersectionType::mydimension>::rule(
-          intersection.type(), polynomial_order_of_the_function);
-  for (auto&& quadrature_point : quadrature_rule_intersection) {
+  for (auto&& quadrature_point : QuadratureRules<typename IntersectionType::ctype, IntersectionType::mydimension>::rule(
+           intersection.type(), polynomial_order_of_the_function)) {
     const auto point_in_reference_intersection = quadrature_point.position();
     const auto quadrature_weight = quadrature_point.weight();
     const auto integration_factor = intersection.geometry().integrationElement(point_in_reference_intersection);


### PR DESCRIPTION
## What

Switches the CI coverage pipeline from gcc `--coverage`/gcovr/Cobertura to **clang-22 native source-based coverage** (`-fprofile-instr-generate -fcoverage-mapping` → `llvm-profdata merge` → `llvm-cov export -format=lcov`), uploaded to Codecov in lcov format. The `debug` leg stays on the runner's default gcc, so both major compilers keep building and running the full suite.

This started as a measurement experiment for #314 ("does the evaluation change under clang 22 + lcov?"). The first commits ran the clang/lcov pipeline **alongside** the untouched gcc leg, so one commit produced both reports; the resulting comparison is posted on #314 (headline: 59.92% under gcc/gcov/gcovr → 74.14% branch-aware / 77.92% line-only under clang-22, with partials collapsing from 3,126 noisy gcov artifacts to 1,273 genuine untaken branches). Based on those results, the final commit makes the clang pipeline *the* coverage leg and drops the gcc `release_coverage` leg.

The source-based pipeline was chosen deliberately over `llvm-cov gcov`: PR #277 showed gcovr aborts on clang's gcov-style data, which is why that PR's coverage leg had to revert to gcc.

## Changes

- **`CMakePresets.json`**: `clang22-base` (taken from #277) plus a `clang22-release_coverage` configure/build/test preset triple. The test preset sets `LLVM_PROFILE_FILE` to `build/clang22-release_coverage/profraw/%m.profraw` — one online-merged profile per binary signature (safe under `ctest --parallel`), inherited by the pytest children so the instrumented Python bindings are captured too.
- **`.ci/llvm_cov_export.bash`**: `llvm-profdata-22 merge` over the profraw files, then `llvm-cov-22 export -format=lcov` across every `__llvm_covmap`-carrying binary in the build tree, restricted to `dune/` sources (mirrors gcovr's `--filter`). Emits `coverage-cpp.info` (with llvm's true branch records) and `coverage-cpp-lineonly.info` (the lcov-default view: no branch data, hence no partials).
- **`.ci/lcov_area_summary.py`**: aggregates an `.info` file into the same per-area table as #314 (lines/hits/misses/partials), with coverage computed both codecov-style (partials not covered) and line-only. Both tables land in the job summary on every coverage run.
- **`cmake/modules/DuneXTTesting.cmake`**: `coverage_cpp_llvm` custom target driving the two scripts; llvm tool suffix selectable via a new `DXT_LLVM_VERSION` cache variable (set by the preset). The gcovr-based `coverage_cpp` target remains for local gcc use.
- **`.github/workflows/non_docker_build.yml`**: matrix is now `debug` (gcc) + `clang22-release_coverage` (coverage leg); Clang 22 / llvm-22 install step from #277; both summary tables in the job summary; both `.info` files as artifact; Codecov gets the branch-enabled `coverage-cpp.info` (flags: `cpp`) and the compiler-independent `coverage-python.xml` (flags: `python`). Switching the upload to the line-only variant is a one-filename change.
- **`dune/gdt/operators/oswald-interpolation.hh`, `dune/xt/grid/integrals.hh`**: clang-22 compile fixes taken verbatim from #277's branch (become no-ops once #277 merges).

## Notes

- Once this lands, the Codecov headline moves from the ~60% scale to the ~74% scale purely from the tooling change; the per-area numbers in #314 are superseded by the first `main` upload (comparison table in the #314 comment).
- `parsers.gcov.branch_detection` in `.codecov.yml` does not apply to lcov uploads; the branch-vs-line-only decision is now made by which `.info` file is uploaded.
- llvm-cov warns about ~14k functions with mismatched data when merging across the ~260 instrumented binaries (template/comdat hash mismatches); numbers are slightly conservative but stable.

Related: #314, #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qGJozx99LV6BaEehe92Eo