### PR TITLE
test(python): discover binding combinations for hypothesis strategies (WP0, #320)

### DIFF
--- a/python/gdt/test/test_hypothesis_interpolation.py
+++ b/python/gdt/test/test_hypothesis_interpolation.py
@@ -20,10 +20,20 @@ symbolically and compare against the C++-computed linear combination.
 """
 
 import numpy as np
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from dune.xt.test.hypothesis_strategies import grid_specs, polynomials
+from dune.xt.test.hypothesis_strategies import (
+    GRID_COMBINATIONS,
+    grid_specs,
+    polynomials,
+)
+
+# Skip cleanly on builds that bind no grids at all (nothing to draw from otherwise).
+pytestmark = pytest.mark.skipif(
+    not GRID_COMBINATIONS, reason="no grid bindings available in this build"
+)
 
 
 def _l2_norm2(grid, grid_function):

--- a/python/gdt/test/test_hypothesis_operators.py
+++ b/python/gdt/test/test_hypothesis_operators.py
@@ -29,7 +29,12 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from dune.xt.test.hypothesis_strategies import grid_specs
+from dune.xt.test.hypothesis_strategies import GRID_COMBINATIONS, grid_specs
+
+# Skip cleanly on builds that bind no grids at all (nothing to draw from otherwise).
+pytestmark = pytest.mark.skipif(
+    not GRID_COMBINATIONS, reason="no grid bindings available in this build"
+)
 
 
 def _assemble(grid, space, integrand):

--- a/python/gdt/test/test_hypothesis_spaces.py
+++ b/python/gdt/test/test_hypothesis_spaces.py
@@ -28,7 +28,21 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from dune.xt.test.hypothesis_strategies import grid_specs
+from dune.xt.test.hypothesis_strategies import GRID_COMBINATIONS, grid_specs, has_grid
+
+# Skip cleanly on builds that bind no grids at all; element-specific tests below add their own
+# guard so a build without, e.g., ALUGrid (no simplex grids) skips just those.
+pytestmark = pytest.mark.skipif(
+    not GRID_COMBINATIONS, reason="no grid bindings available in this build"
+)
+
+_needs_cube = pytest.mark.skipif(
+    not has_grid(element="cube"), reason="no cube grid bindings available in this build"
+)
+_needs_simplex = pytest.mark.skipif(
+    not has_grid(element="simplex"),
+    reason="no simplex grid bindings available in this build",
+)
 
 
 # binomial(order + dim, dim): dimension of P_k on a d-simplex
@@ -44,6 +58,7 @@ def _cg_orders(spec, top=3):
     return st.integers(1, min(top, 2) if spec.element == "simplex" else top)
 
 
+@_needs_cube
 @given(spec=grid_specs(elements=("cube",)), order=st.integers(1, 3))
 def test_cg_dof_count_on_cube_grids(spec, order):
     from dune.gdt import ContinuousLagrangeSpace
@@ -54,6 +69,7 @@ def test_cg_dof_count_on_cube_grids(spec, order):
     assert space.min_polorder == space.max_polorder == order
 
 
+@_needs_simplex
 @given(spec=grid_specs(elements=("simplex",)))
 def test_p1_cg_dofs_are_the_vertices_on_simplicial_grids(spec):
     from dune.gdt import ContinuousLagrangeSpace

--- a/python/xt/dune/xt/test/hypothesis_strategies.py
+++ b/python/xt/dune/xt/test/hypothesis_strategies.py
@@ -21,22 +21,126 @@ This module ships with the dune.xt wheel (like dune.xt.test.grid_types) so both 
 the dune-gdt pytest suites can import the same strategies.
 """
 
+import importlib
+import re
 from dataclasses import dataclass, field
 from itertools import product as _cartesian
 
 import numpy as np
 from hypothesis import strategies as st
 
-# The bindings pre-instantiate exactly these grid types (see the GridProvider* binding names):
-# 1d ONEDGRID, 2d/3d cube YASPGRID and 2d/3d simplex ALUGRID (conforming). This tuple *is* the
-# runtime-reachable slice of the compile-time grid lists used by the C++ typed tests.
-GRID_COMBINATIONS = (
-    (1, "simplex"),  # GridProvider1dSimplexOnedgrid
-    (2, "cube"),  # GridProvider2dCubeYaspgrid
-    (2, "simplex"),  # GridProvider2dSimplexAluconformgrid
-    (3, "cube"),  # GridProvider3dCubeYaspgrid
-    (3, "simplex"),  # GridProvider3dSimplexAluconformgrid
-)
+# --- binding discovery ------------------------------------------------------------------
+#
+# Rather than hard-coding which grid/container combinations the wheel was built with, we probe
+# the compiled modules for the classes they actually expose. A binding adds an instantiation ->
+# the class appears in dune.xt.grid / dune.xt.la -> the strategies below pick it up with no edit
+# here; a build without an optional dependency (Eigen, ALUGrid, ISTL, ...) simply omits those
+# classes and the dependent tests skip. This is the WP0 plumbing that #320's later work packages
+# rely on to have their new combinations property-tested automatically.
+
+
+def _import_optional(module_name):
+    """Import a compiled binding module, returning None if the wheel does not provide it."""
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        return None
+
+
+# GridProvider bindings are named `to_camel_case("grid_provider_" + grid_name)` (see
+# python/xt/dune/xt/grid/gridprovider.hh), where grid_name is "<dim>d_<element>_<impl>grid"
+# (python/xt/dune/xt/grid/grids.bindings.hh), e.g. GridProvider2dCubeYaspgrid,
+# GridProvider1dSimplexOnedgrid, GridProvider2dSimplexAluconformgrid. to_camel_case only
+# upper-cases the first letter of each underscore-separated word, so the element is a single
+# capitalised word and the implementation follows as one more capitalised word.
+_GRID_PROVIDER_RE = re.compile(r"^GridProvider(\d+)d([A-Z][a-z]+)([A-Z][A-Za-z0-9]*)$")
+
+
+@dataclass(frozen=True)
+class GridBinding:
+    """One compiled `GridProvider*` class, parsed back into its structural coordinates."""
+
+    dim: int
+    element: str  # "cube", "simplex", ... (lower case, as in the grid_name)
+    impl: str  # grid implementation, e.g. "yaspgrid", "onedgrid", "aluconformgrid"
+    class_name: str
+
+    @property
+    def grid_name(self):
+        return f"{self.dim}d_{self.element}_{self.impl}"
+
+
+def _parse_grid_provider_name(name):
+    """Return (dim, element, impl) for a GridProvider* class name, or None if it is not one."""
+    match = _GRID_PROVIDER_RE.match(name)
+    if match is None:
+        return None
+    return int(match.group(1)), match.group(2).lower(), match.group(3).lower()
+
+
+def discover_grid_bindings(module=None):
+    """All GridProvider* classes the dune.xt.grid binding exposes, as GridBinding descriptors.
+
+    Pass an explicit module (e.g. a stub) to test the parsing without the compiled wheel.
+    """
+    grid = module if module is not None else _import_optional("dune.xt.grid")
+    if grid is None:
+        return ()
+    bindings = []
+    for name in dir(grid):
+        parsed = _parse_grid_provider_name(name)
+        if parsed is None or not isinstance(getattr(grid, name), type):
+            continue
+        dim, element, impl = parsed
+        bindings.append(
+            GridBinding(dim=dim, element=element, impl=impl, class_name=name)
+        )
+    return tuple(sorted(bindings, key=lambda b: (b.dim, b.element, b.impl)))
+
+
+def discover_grid_combinations(module=None):
+    """The de-duplicated (dim, element) grid slice the bindings make reachable at runtime."""
+    return tuple(sorted({(b.dim, b.element) for b in discover_grid_bindings(module)}))
+
+
+def _discover_container_types(suffix, module=None):
+    la = module if module is not None else _import_optional("dune.xt.la")
+    if la is None:
+        return ()
+    result = []
+    for name in sorted(dir(la)):
+        # `CommonVectorSizeT` is an integer index container, not a floating point payload, and
+        # ends in "SizeT" rather than the suffix -- so it is naturally excluded from vectors.
+        if name == suffix or not name.endswith(suffix):
+            continue
+        obj = getattr(la, name)
+        if isinstance(obj, type):
+            result.append(obj)
+    return tuple(result)
+
+
+def discover_vector_types(module=None):
+    """Double-valued LA vector container classes exposed by dune.xt.la (Common/Istl/Eigen)."""
+    return _discover_container_types("Vector", module)
+
+
+def discover_matrix_types(module=None):
+    """LA matrix container classes exposed by dune.xt.la (dense Common, sparse Istl/Eigen)."""
+    return _discover_container_types("Matrix", module)
+
+
+# The runtime-reachable slice of the compile-time grid lists used by the C++ typed tests, e.g.
+# on a full build: (1, "simplex") ONEDGRID, (2|3, "cube") YASPGRID, (2|3, "simplex") ALUGRID.
+GRID_COMBINATIONS = discover_grid_combinations()
+
+
+def has_grid(dim=None, element=None):
+    """Whether the current build binds a grid with the given dimension and/or element type."""
+    return any(
+        (dim is None or d == dim) and (element is None or e == element)
+        for (d, e) in GRID_COMBINATIONS
+    )
+
 
 # Number of simplices a DGF cube is split into by make_cube_grid per dimension.
 SIMPLICES_PER_CUBE = {1: 1, 2: 2, 3: 6}

--- a/python/xt/test/test_hypothesis_grid_provider.py
+++ b/python/xt/test/test_hypothesis_grid_provider.py
@@ -18,9 +18,15 @@ grid that violates a property instead of a fixed fixture failing wholesale.
 """
 
 import numpy as np
+import pytest
 from hypothesis import given
 
-from dune.xt.test.hypothesis_strategies import grid_specs
+from dune.xt.test.hypothesis_strategies import GRID_COMBINATIONS, grid_specs
+
+# Skip cleanly on builds that bind no grids at all (nothing to draw from otherwise).
+pytestmark = pytest.mark.skipif(
+    not GRID_COMBINATIONS, reason="no grid bindings available in this build"
+)
 
 
 @given(spec=grid_specs())

--- a/python/xt/test/test_hypothesis_la_container.py
+++ b/python/xt/test/test_hypothesis_la_container.py
@@ -29,18 +29,16 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 import dune.xt.la as la
-from dune.xt.test.hypothesis_strategies import finite_floats, vector_data
+from dune.xt.test.hypothesis_strategies import (
+    discover_vector_types,
+    finite_floats,
+    vector_data,
+)
 
 # The available backends depend on the build configuration (e.g. Eigen may be disabled), so
-# collect whatever this build provides instead of hard-coding the list.
-VECTOR_CLASSES = [
-    cls
-    for cls in (
-        getattr(la, name, None)
-        for name in ("CommonVector", "IstlVector", "EigenVector")
-    )
-    if cls is not None
-]
+# discover whatever this build provides from dune.xt.la instead of hard-coding the list. Any
+# vector backend a future work package binds is picked up here without editing this file.
+VECTOR_CLASSES = list(discover_vector_types())
 
 # relative tolerance for comparisons against numpy: both sides accumulate in double, but not
 # necessarily in the same order, so exact equality only holds for order-independent quantities

--- a/python/xt/test/test_hypothesis_strategies.py
+++ b/python/xt/test/test_hypothesis_strategies.py
@@ -1,0 +1,215 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""WP0 (#320): the binding-discovery helpers behind the shared hypothesis strategies.
+
+`dune.xt.test.hypothesis_strategies` no longer hard-codes which grid/container combinations the
+wheel was built with; it probes the compiled `dune.xt.grid` / `dune.xt.la` modules instead. The
+parsing and filtering that drives that probe is pure Python and is unit-tested here against stub
+modules, so it runs without the compiled bindings. A second group of tests exercises the real
+bindings when they are importable and asserts the discovered slice is self-consistent.
+"""
+
+import types
+
+import pytest
+
+from dune.xt.test import hypothesis_strategies as hs
+
+
+def _stub_module(class_names):
+    """A stand-in for a compiled binding module exposing the given names as classes."""
+    module = types.SimpleNamespace()
+    for name in class_names:
+        setattr(module, name, type(name, (), {}))
+    return module
+
+
+# The full-build GridProvider* class names and the (dim, element) slice they encode.
+_FULL_BUILD_GRID_CLASSES = {
+    "GridProvider1dSimplexOnedgrid": (1, "simplex", "onedgrid"),
+    "GridProvider2dCubeYaspgrid": (2, "cube", "yaspgrid"),
+    "GridProvider2dSimplexAluconformgrid": (2, "simplex", "aluconformgrid"),
+    "GridProvider3dCubeYaspgrid": (3, "cube", "yaspgrid"),
+    "GridProvider3dSimplexAluconformgrid": (3, "simplex", "aluconformgrid"),
+}
+
+
+@pytest.mark.parametrize(("name", "expected"), _FULL_BUILD_GRID_CLASSES.items())
+def test_parse_grid_provider_name_extracts_coordinates(name, expected):
+    assert hs._parse_grid_provider_name(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "GridProviderFactory",  # a factory, not a provider instantiation
+        "CouplingGridProvider2dCubeYaspgrid",  # does not start with GridProvider
+        "CommonVector",  # unrelated class
+        "GridProvider",  # no dimension/element
+        "GridProvider2dCube",  # no implementation word
+    ],
+)
+def test_parse_grid_provider_name_rejects_non_providers(name):
+    assert hs._parse_grid_provider_name(name) is None
+
+
+def test_grid_binding_reconstructs_the_grid_name():
+    binding = hs.GridBinding(
+        dim=2, element="cube", impl="yaspgrid", class_name="GridProvider2dCubeYaspgrid"
+    )
+    assert binding.grid_name == "2d_cube_yaspgrid"
+
+
+def test_discover_grid_bindings_parses_and_sorts_a_full_build():
+    module = _stub_module(list(_FULL_BUILD_GRID_CLASSES) + ["GridProviderFactory"])
+    bindings = hs.discover_grid_bindings(module)
+    assert [b.grid_name for b in bindings] == [
+        "1d_simplex_onedgrid",
+        "2d_cube_yaspgrid",
+        "2d_simplex_aluconformgrid",
+        "3d_cube_yaspgrid",
+        "3d_simplex_aluconformgrid",
+    ]
+
+
+def test_discover_grid_combinations_matches_the_previously_hard_coded_tuple():
+    # This is exactly the tuple WP0 replaced; discovery must reproduce it on a full build.
+    module = _stub_module(_FULL_BUILD_GRID_CLASSES)
+    assert hs.discover_grid_combinations(module) == (
+        (1, "simplex"),
+        (2, "cube"),
+        (2, "simplex"),
+        (3, "cube"),
+        (3, "simplex"),
+    )
+
+
+def test_discover_grid_combinations_deduplicates_and_sorts():
+    # Two cube implementations for the same dimension collapse to a single (dim, element).
+    module = _stub_module(
+        ["GridProvider2dCubeYaspgrid", "GridProvider2dCubeAlunonconformgrid"]
+    )
+    assert hs.discover_grid_combinations(module) == ((2, "cube"),)
+
+
+def test_discovery_picks_up_a_newly_bound_combination_without_edits():
+    # A later work package binding, e.g., a 2d cube ALUGrid must appear automatically.
+    baseline = _stub_module(_FULL_BUILD_GRID_CLASSES)
+    extended = _stub_module(
+        list(_FULL_BUILD_GRID_CLASSES) + ["GridProvider2dCubeAluconformgrid"]
+    )
+    new = set(hs.discover_grid_combinations(extended)) - set(
+        hs.discover_grid_combinations(baseline)
+    )
+    # (2, "cube") already exists via YASP, so the *combination* set is unchanged...
+    assert new == set()
+    # ...but the richer binding list does gain the new implementation.
+    impls = {b.class_name for b in hs.discover_grid_bindings(extended)}
+    assert "GridProvider2dCubeAluconformgrid" in impls
+
+
+def test_import_optional_returns_none_for_a_missing_module():
+    # An absent optional dependency must degrade to None (not raise), so a build without, e.g.,
+    # Eigen still imports the strategies module and its dependent tests simply skip.
+    assert hs._import_optional("dune.xt._definitely_not_a_real_module") is None
+
+
+def test_grid_combinations_is_always_a_tuple():
+    # Computed at import time from whatever the build exposes (possibly empty); importing the
+    # strategies module must never fail, whether or not the compiled grids are present.
+    assert isinstance(hs.GRID_COMBINATIONS, tuple)
+
+
+def test_discover_vector_types_excludes_the_index_container():
+    module = _stub_module(
+        [
+            "CommonVector",
+            "IstlVector",
+            "EigenVector",
+            "CommonVectorSizeT",  # size_t index vector: not a float payload container
+            "CommonDenseMatrix",
+        ]
+    )
+    names = [c.__name__ for c in hs.discover_vector_types(module)]
+    assert names == ["CommonVector", "EigenVector", "IstlVector"]
+
+
+def test_discover_matrix_types_excludes_the_sparsity_pattern():
+    module = _stub_module(
+        [
+            "CommonDenseMatrix",
+            "IstlSparseMatrix",
+            "EigenSparseMatrix",
+            "SparsityPatternDefault",  # not a container
+            "CommonVector",
+        ]
+    )
+    names = [c.__name__ for c in hs.discover_matrix_types(module)]
+    assert names == ["CommonDenseMatrix", "EigenSparseMatrix", "IstlSparseMatrix"]
+
+
+def test_discovery_ignores_non_class_attributes():
+    def make_common_vector():  # a factory function, not a container class
+        return None
+
+    module = types.SimpleNamespace()
+    module.CommonVector = type("CommonVector", (), {})
+    module.make_common_vector = make_common_vector
+    assert [c.__name__ for c in hs.discover_vector_types(module)] == ["CommonVector"]
+
+
+# --- against the real bindings, when this build actually provides them --------------------
+
+
+@pytest.fixture(scope="module")
+def grid_module():
+    return pytest.importorskip("dune.xt.grid")
+
+
+@pytest.fixture(scope="module")
+def la_module():
+    return pytest.importorskip("dune.xt.la")
+
+
+def test_real_grid_combinations_are_nonempty_and_well_formed(grid_module):
+    combinations = hs.discover_grid_combinations(grid_module)
+    assert combinations, (
+        "a build with dune.xt.grid must expose at least one grid provider"
+    )
+    assert combinations == hs.GRID_COMBINATIONS
+    for dim, element in combinations:
+        assert isinstance(dim, int) and dim >= 1
+        assert element in ("cube", "simplex", "prism", "mixed")
+
+
+def test_has_grid_is_consistent_with_the_discovered_combinations(grid_module):
+    for dim, element in hs.GRID_COMBINATIONS:
+        assert hs.has_grid(dim=dim, element=element)
+        assert hs.has_grid(dim=dim)
+        assert hs.has_grid(element=element)
+    assert not hs.has_grid(dim=99)
+
+
+def test_real_vector_and_matrix_types_are_exposed_classes(la_module):
+    vectors = hs.discover_vector_types(la_module)
+    assert vectors, "a build with dune.xt.la must expose at least one vector container"
+    for cls in vectors:
+        assert isinstance(cls, type)
+        assert getattr(la_module, cls.__name__) is cls
+        assert not cls.__name__.endswith("SizeT")
+    for cls in hs.discover_matrix_types(la_module):
+        assert isinstance(cls, type)
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)


### PR DESCRIPTION
## WP0 — strategy plumbing (#320)

Makes the shared hypothesis strategies **discover** what the installed binding actually instantiates instead of hard-coding the tuple, so every later work package's additions are picked up by the property suite automatically.

> **Stacked on #319.** This PR's base is #319's branch (`claude/python-cpp-hypothesis-tests-6m91tz`), which introduces `dune.xt.test.hypothesis_strategies`. It should be merged after #319 (or retargeted to `main` once #319 lands).

### What changed

`dune.xt.test.hypothesis_strategies` no longer hard-codes which grid/container combinations the wheel was built with; it probes the compiled `dune.xt.grid` / `dune.xt.la` modules:

- **`discover_grid_bindings` / `discover_grid_combinations`** parse the `GridProvider*` class names — `to_camel_case("grid_provider_" + "<dim>d_<element>_<impl>grid")`, e.g. `GridProvider2dCubeYaspgrid` — back into `(dim, element, impl)` descriptors. `GRID_COMBINATIONS` is now computed from them at import time and reproduces the previous five-entry tuple on a full build (1d ONEDGRID, 2d/3d cube YASP, 2d/3d simplex conforming ALU).
- **`discover_vector_types` / `discover_matrix_types`** collect the LA container classes exposed by `dune.xt.la`, excluding the `size_t` index vector (`CommonVectorSizeT`) and the sparsity pattern. `test_hypothesis_la_container.py` now consumes `discover_vector_types()` instead of its own hard-coded `("CommonVector", "IstlVector", "EigenVector")` list.
- **`has_grid` + module-level `skipif` guards** on the grid/space/interpolation/operator suites so builds without optional grids (no ALUGrid, etc.) skip cleanly rather than erroring on an empty `sampled_from`.

### Acceptance (per #320 WP0)

- ✅ Adding a binding combination requires no strategy edit — a new `GridProvider*` or LA container class is discovered automatically (covered by `test_discovery_picks_up_a_newly_bound_combination_without_edits`).
- ✅ Suite skips cleanly on builds without optional grids (`has_grid` guards + module `pytestmark`).
- ✅ Discovery reproduces the previously hard-coded tuple exactly on a full build.
- ✅ No notebook (WP0 is plumbing only).

### Tests

New `python/xt/test/test_hypothesis_strategies.py`:

- Pure-Python unit tests of the name parsing and container filtering against **stub modules**, so they run without the compiled bindings (20 pass, verified locally).
- `importorskip`-guarded tests exercising the **real** `dune.xt.grid` / `dune.xt.la` bindings when present, asserting `GRID_COMBINATIONS` is non-empty, well-formed, and consistent with `has_grid`.

Existing hypothesis suites are unchanged in behaviour on a full build; `ruff` / `ruff-format` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx8vhgRvY9brB3kiKF4Tjf)_