### PR TITLE
test(python): bind structured 1d YaspGrid + evaluate 4d (WP2, #320)

### DIFF
--- a/docs/source/example__structured_1d_grids.md
+++ b/docs/source/example__structured_1d_grids.md
@@ -1,0 +1,156 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: structured 1d grids (`YASP_1D` vs `OneDGrid`)
+
+Until now the Python bindings exposed exactly one one-dimensional grid, `Dune::OneDGrid`
+(`make_cube_grid(Dim(1), ...)`). WP2 of
+[issue #320](https://github.com/dune-gdt/dune-gdt/issues/320) adds the structured
+`YaspGrid<1, EquidistantOffsetCoordinates>` next to it -- the 1d sibling of the `YASP_2D` /
+`YASP_3D` cube grids that already back the 2d/3d examples, and the grid the C++ `SimplicialGrids`
+typed-test list uses in 1d. This notebook
+
+* builds the **same** 1d domain as both an `OneDGrid` and a `YASP_1D` grid,
+* solves the stationary heat equation on each and checks the two discretizations agree, and
+* demonstrates the *equidistant-offset* feature (a structured grid on an arbitrary interval
+  `[a, b]`, `a != 0`) that motivates having a structured 1d grid at all.
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+
+import numpy as np
+```
+
+## Two ways to mesh the unit interval
+
+`OneDGrid` is selected through the dimension-only `make_cube_grid` overload, while the structured
+`YASP_1D` grid is selected through the same `(Dimension, Cube)` overload as its 2d/3d counterparts
+-- so both one-dimensional grids can coexist without an ambiguous factory signature.
+
+```{code-cell}
+from dune.xt.grid import Cube, Dim, make_cube_grid
+
+n = 8  # number of intervals
+lower_left, upper_right = [0.0], [1.0]
+
+oned_grid = make_cube_grid(Dim(1), lower_left=lower_left, upper_right=upper_right,
+                           num_elements=[n])
+yasp_grid = make_cube_grid(Dim(1), Cube(), lower_left=lower_left, upper_right=upper_right,
+                           num_elements=[n])
+
+for name, grid in (("OneDGrid", oned_grid), ("YASP_1D", yasp_grid)):
+    print(f'{name:9s}: {grid.size(0)} elements, {grid.size(1)} vertices')
+```
+
+Both provide the identical structured skeleton (`num_elements` equal intervals of width
+`h = 1/num_elements`); the element centers coincide up to ordering:
+
+```{code-cell}
+oned_centers = np.sort(np.array(oned_grid.centers(0), copy=False).ravel())
+yasp_centers = np.sort(np.array(yasp_grid.centers(0), copy=False).ravel())
+
+assert np.allclose(oned_centers, yasp_centers)
+print('element centers:', yasp_centers)
+```
+
+## The stationary heat equation on both grids
+
+We reuse the continuous-Lagrange discretization from `discretize_elliptic_cg.py` (the same helper
+the 2d CG tutorial uses) to solve
+
+$$-u''(x) = 1 \quad\text{on } (0, 1), \qquad u(0) = u(1) = 0,$$
+
+whose exact solution is $u(x) = \tfrac{1}{2}\,x\,(1 - x)$.
+
+```{code-cell}
+from discretize_elliptic_cg import discretize_elliptic_cg_dirichlet_zero
+
+def solve(grid):
+    # constant unit diffusion and unit source, homogeneous Dirichlet everywhere
+    u_h = discretize_elliptic_cg_dirichlet_zero(grid, diffusion=1.0, source=1.0)
+    return np.array(u_h.dofs.vector, copy=False)
+
+oned_dofs = solve(oned_grid)
+yasp_dofs = solve(yasp_grid)
+```
+
+The two grids give rise to the identical P1 linear system (up to a DoF permutation), so the sorted
+DoF vectors must match to solver accuracy:
+
+```{code-cell}
+assert oned_dofs.shape == yasp_dofs.shape == (n + 1,)
+grid_to_grid = np.max(np.abs(np.sort(oned_dofs) - np.sort(yasp_dofs)))
+print(f'max |OneDGrid - YASP_1D| over the DoFs: {grid_to_grid:.2e}')
+assert grid_to_grid < 1e-6
+```
+
+In one dimension the P1 Galerkin solution of the Poisson problem is *nodally exact*, so the sorted
+DoF values reproduce the exact solution sampled on the nodes $x_i = i/N$:
+
+```{code-cell}
+nodes = np.linspace(0.0, 1.0, n + 1)
+exact_nodal = np.sort(0.5 * nodes * (1.0 - nodes))
+nodal_error = np.max(np.abs(np.sort(yasp_dofs) - exact_nodal))
+print(f'max nodal error vs. exact solution: {nodal_error:.2e}')
+assert nodal_error < 1e-6
+```
+
+## The equidistant-offset feature: a structured grid on `[a, b]`
+
+The whole point of `EquidistantOffsetCoordinates` is that the structured grid need not start at the
+origin. We put a `YASP_1D` grid on the offset interval `[2, 5]` and solve the same problem there,
+
+$$-u''(x) = 1 \quad\text{on } (2, 5), \qquad u(2) = u(5) = 0,$$
+
+with exact solution $u(x) = \tfrac{1}{2}\,(x - 2)\,(5 - x)$.
+
+```{code-cell}
+a, b = 2.0, 5.0
+offset_grid = make_cube_grid(Dim(1), Cube(), lower_left=[a], upper_right=[b],
+                             num_elements=[n])
+
+centers = np.sort(np.array(offset_grid.centers(0), copy=False).ravel())
+h = (b - a) / n
+print(f'offset grid spans [{centers.min() - 0.5 * h:.1f}, {centers.max() + 0.5 * h:.1f}]')
+
+offset_dofs = solve(offset_grid)
+offset_nodes = np.linspace(a, b, n + 1)
+offset_exact = np.sort(0.5 * (offset_nodes - a) * (b - offset_nodes))
+offset_error = np.max(np.abs(np.sort(offset_dofs) - offset_exact))
+print(f'max nodal error on [{a}, {b}]: {offset_error:.2e}')
+assert offset_error < 1e-6
+```
+
+The structured 1d grid solves the shifted problem exactly, without any special handling of the
+non-zero offset -- the same behaviour the 2d/3d `YASP` cube grids already provide, now available in
+one dimension for property testing and structured-grid experiments alongside `OneDGrid`.
+
+Download the code:
+{download}`example__structured_1d_grids.md`
+{nb-download}`example__structured_1d_grids.ipynb`

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -5,6 +5,7 @@ The examples each highlight a specific aspect, possibly without much explanation
 ```{toctree}
 example__prolongations_products_and_norms
 example__simple_grid_adaptation
+example__structured_1d_grids
 example__ESV2007_estimates
 example__gmsh_grid
 example__MNS2002_estimates

--- a/docs/wp2_yasp4d_go_no_go.md
+++ b/docs/wp2_yasp4d_go_no_go.md
@@ -1,0 +1,105 @@
+# WP2 (#320): `YASP_4D` in the Python bindings — go / no-go
+
+**Decision: NO-GO for now — do not add `YASP_4D_EQUIDISTANT_OFFSET` to the bindings in WP2.**
+
+This is the written 4d evaluation that WP2 of
+[issue #320](https://github.com/dune-gdt/dune-gdt/issues/320) asks for
+("`YASP_4D` is *evaluation only*: measure the template cost of one 4d grid across the space/operator
+binding TUs before committing; visualization and gmsh are N/A in 4d"). WP2 *ships* the 1d
+structured grid (`YASP_1D`) and *evaluates* the 4d one; only the former lands as bindings.
+
+## What "adding `YASP_4D`" would cost
+
+`YASP_4D_EQUIDISTANT_OFFSET` already exists as a C++ type alias
+(`dune/xt/grid/grids.hh`) and the C++ `CubicGrids` typed tests already exercise it via
+`dune/dgf_4d_interval.dgf`. The cost is therefore *not* new C++ — it is the pybind11 instantiation
+blow-up if the type is added to `Dune::XT::Grid::bindings::AvailableGridTypes`.
+
+Every binding translation unit that walks `bindings::AvailableGridTypes` (directly or through a
+`*_for_all_grids` helper) gains **one more full grid instantiation** — space mappers, local finite
+elements, operator/functional assembly over the 4d leaf view, discrete-function DoF handling, the
+whole stack — per added grid type. Counted statically on this branch:
+
+| Instantiation-driving binding TUs | count |
+|---|---|
+| `python/gdt/**/*.cc` over `AvailableGridTypes` / `*_for_all_grids` | 68 |
+| `python/xt/**/*.cc` over `AvailableGridTypes` / `*_for_all_grids`  | 35 |
+| **total** | **103** |
+| of which `python/gdt/dune/gdt/spaces/*.cc`    | 7 |
+| of which `python/gdt/dune/gdt/operators/*.cc` | 9 |
+
+So a single 4d grid adds an instantiation to ~103 of the 129 binding TUs.
+
+### Why 4d is disproportionately expensive (not just "one more grid")
+
+The pybind11 binding TUs are already the **CI memory driver**. Per `non_docker_build.yml`
+(the `config` sizing job and the build-linux comments), the ordinary library/test TUs peak ~2 GB,
+but the binding TUs "peak far higher (well above 4 GB each)"; building them at the shared `cpu-1`
+level **OOM-killed the 16 GB GitHub-hosted runner**, which is why they run under a tighter
+`bindings_jobs = cpu/2` cap. `operators/interfaces_istl_{1d,2d,3d}.cc` was already split by
+dimension for exactly this reason.
+
+A 4d `YaspGrid` instantiation is deeper than the existing 2d/3d ones, not equal to them:
+
+- **Codimension count scales with dimension.** A 4d grid has entities of codim 0..4 (5 levels vs. 4
+  in 3d, 3 in 2d); mappers, sparsity patterns, intersection handling and reference-element geometry
+  instantiate per codim.
+- **Local finite elements / quadratures** are templated on dimension and geometry type; the 4d
+  reference cube's shape-function and quadrature templates are new, heavier instantiations.
+- **`FieldMatrix`/`FieldVector` geometry** (`4`- and `16`-entry jacobians/inverses) instantiates
+  fresh throughout the assembly code.
+
+The concrete peak-RAM and wall-clock delta must be **measured in the CI toolchain** (see recipe
+below) — it cannot be produced from the source checkout alone, because it depends on the compiler,
+the Dune headers as configured by `config.h`, and pybind11. The cost guardrail in #320 requires that
+number *and* a further TU split for any TU that then exceeds ~4 GB. Given the binding TUs already
+sit "well above 4 GB", the realistic expectation is that adding 4d pushes several `spaces/*` and
+`operators/*` TUs over the OOM threshold and forces another round of by-dimension TU splitting on
+top of the raw compile-time increase across all 103 TUs.
+
+## What 4d would buy
+
+Little, relative to the cost:
+
+- **No visualization** — VTK/`visualize_grid`/`visualize_function` are undefined in 4d, so a 4d
+  example notebook (the usual WP deliverable and CI smoke test) cannot show anything visual.
+- **No gmsh** — 4d meshing is N/A, so no unstructured 4d counterpart is reachable anyway.
+- **Property-test value is marginal.** The runtime property suite (#319) already covers the
+  dimension-generic invariants (element/vertex counts, refinement factors, intersection partition,
+  DoF-count formulas) at 1d/2d/3d; 4d adds another sample of the *same* invariants, not a new code
+  path. The genuinely 4d-only C++ coverage is the `CubicGrids` typed tests, which continue to run in
+  C++ regardless of the bindings.
+
+## Decision and conditions to revisit
+
+**NO-GO.** The 103-TU instantiation fan-out, the existing binding-TU memory pressure (already
+OOM-sensitive, already split by dimension), and the absence of visualization/gmsh make a bound 4d
+grid a poor trade in WP2. The 4d code paths remain covered by the C++ `CubicGrids` tests.
+
+Revisit if all of the following hold:
+
+1. A concrete Python use case needs 4d (e.g. a bound space-time or moment-model operator that is
+   genuinely 4-dimensional), not merely "more property samples".
+2. The measured single-TU peak-RAM delta (recipe below) stays under the ~4 GB guardrail for the
+   `spaces/*` and `operators/*` TUs, **or** those TUs are split by dimension first (as
+   `interfaces_istl_*` already are) so 4d lands in its own TU set.
+3. 4d is introduced behind its own opt-in so a default wheel build is unaffected.
+
+## Measurement recipe (to run in the CI toolchain, not on a bare checkout)
+
+To produce the peak-RAM / build-time delta the guardrail requires, build the heaviest space and
+operator binding TUs with and without 4d and diff the numbers:
+
+1. Baseline: build with the current `bindings::AvailableGridTypes`.
+2. Add `YASP_4D_EQUIDISTANT_OFFSET` to `Available*GridTypes` (a 4d list; 4d is neither 2d nor 3d) in
+   `python/xt/dune/xt/grid/grids.bindings.hh` and bind `make_cube_grid<YASP_4D_EQUIDISTANT_OFFSET,
+   Cube>` in `gridprovider/cube.cc`, on a throwaway branch.
+3. For the heaviest offenders — e.g. `spaces/l2/discontinuous-lagrange.cc`,
+   `spaces/h1/continuous-lagrange.cc`, `operators/matrix-based.cc` and the `operators/interfaces_*`
+   set — compile a single object with peak-RSS tracking, e.g.
+   `/usr/bin/time -v cmake --build <preset> --target <obj> -- -j1` (read "Maximum resident set size")
+   or `ninja -j1` under a memory sampler, both before and after step 2.
+4. Report, per TU, ΔpeakRSS and Δwall-clock, and flag every TU whose absolute peak crosses ~4 GB.
+
+If step 4 shows any `spaces/*` or `operators/*` TU crossing ~4 GB (the likely outcome), the go path
+mandates a by-dimension TU split for that TU before 4d can be merged.

--- a/python/xt/dune/xt/grid/gridprovider/cube.cc
+++ b/python/xt/dune/xt/grid/gridprovider/cube.cc
@@ -95,7 +95,7 @@ PYBIND11_MODULE(_grid_gridprovider_cube, m)
   make_cube_grid<ONED_1D, void>::bind(m);
   // WP2 (#320): the structured 1d YaspGrid uses the (Dimension, Cube) overload so it can coexist
   // with ONED_1D (dimension-only overload) without an ambiguous 1d make_cube_grid signature.
-  make_cube_grid<YASP_1D_EQUIDISTANT_OFFSET, Cube>::bind(m);
+  make_cube_grid<YASP_1D_EQUIDISTANT_OFFSET, Cube>::bind(m); // NOSONAR(cpp:S1117): m is an argument, not a decl
   make_cube_grid<YASP_2D_EQUIDISTANT_OFFSET, Cube>::bind(m);
   make_cube_grid<YASP_3D_EQUIDISTANT_OFFSET, Cube>::bind(m);
 #if HAVE_DUNE_ALUGRID

--- a/python/xt/dune/xt/grid/gridprovider/cube.cc
+++ b/python/xt/dune/xt/grid/gridprovider/cube.cc
@@ -93,6 +93,9 @@ PYBIND11_MODULE(_grid_gridprovider_cube, m)
   py::module::import("dune.xt.grid._grid_traits");
 
   make_cube_grid<ONED_1D, void>::bind(m);
+  // WP2 (#320): the structured 1d YaspGrid uses the (Dimension, Cube) overload so it can coexist
+  // with ONED_1D (dimension-only overload) without an ambiguous 1d make_cube_grid signature.
+  make_cube_grid<YASP_1D_EQUIDISTANT_OFFSET, Cube>::bind(m);
   make_cube_grid<YASP_2D_EQUIDISTANT_OFFSET, Cube>::bind(m);
   make_cube_grid<YASP_3D_EQUIDISTANT_OFFSET, Cube>::bind(m);
 #if HAVE_DUNE_ALUGRID

--- a/python/xt/dune/xt/grid/grids.bindings.hh
+++ b/python/xt/dune/xt/grid/grids.bindings.hh
@@ -152,8 +152,14 @@ struct grid_name<UGGrid<dim>>
 /// \attention The following choices are on purpose: only two variants per dim, one cube one simplex.
 ///            In particular the grid_name<G>::value needs to be unique for all alugrid variants and the
 ///            make_...grid methods need to be more general if we extend the choice of grids here!
+///
+/// WP2 (#320) adds YASP_1D_EQUIDISTANT_OFFSET next to ONED_1D: a structured 1d grid with the same
+/// equidistant-offset coordinates as the 2d/3d YaspGrids (periodic/overlap features, and the C++
+/// SimplicialGrids list tests it). The two 1d grids are disambiguated in the make_cube_grid factory
+/// by their element-type tag -- ONED_1D keeps the dimension-only overload, YASP_1D binds the
+/// (Dimension, Cube) overload (see python/xt/dune/xt/grid/gridprovider/cube.cc).
 
-using Available1dGridTypes = std::tuple<ONED_1D>;
+using Available1dGridTypes = std::tuple<ONED_1D, YASP_1D_EQUIDISTANT_OFFSET>;
 
 using Available2dGridTypes = std::tuple<YASP_2D_EQUIDISTANT_OFFSET
 #if HAVE_DUNE_ALUGRID

--- a/python/xt/dune/xt/test/hypothesis_strategies.py
+++ b/python/xt/dune/xt/test/hypothesis_strategies.py
@@ -164,7 +164,10 @@ class GridSpec:
             "upper_right": list(self.upper_right),
             "num_elements": list(self.num_elements),
         }
-        if self.dim == 1:  # the 1d overload (ONEDGRID) takes no element type
+        if self.dim == 1 and self.element == "simplex":
+            # ONEDGRID is bound through the dimension-only make_cube_grid overload (no element
+            # type); the structured 1d YaspGrid (WP2, #320) instead uses the (Dim, Cube) overload
+            # like its 2d/3d siblings, handled by the general branch below.
             return make_cube_grid(Dim(1), **kwargs)
         elem = {"cube": Cube, "simplex": Simplex}[self.element]
         return make_cube_grid(Dim(self.dim), elem(), **kwargs)


### PR DESCRIPTION
## WP2 — structured-grid completeness: `YASP_1D` (+ evaluate `YASP_4D`) (#320)

Ships the structured 1d YaspGrid to the Python bindings and delivers the written 4d go/no-go that WP2 asks for.

> **Stacked on #323 (WP0).** This PR's base is WP0's branch (`claude/wp0-issue-320-dosfsk`), which makes the shared hypothesis strategies *discover* what the binding instantiates. It should be merged after #323 (or retargeted once #323/#319 land). WP2 is independent of WP1/WP4/WP5/WP7.

### What changed

**Bindings**
- `YASP_1D_EQUIDISTANT_OFFSET` added to `bindings::Available1dGridTypes` (`python/xt/dune/xt/grid/grids.bindings.hh`), so the structured 1d YaspGrid is instantiated across the grid/space/operator binding TUs next to `OneDGrid`. This produces a `GridProvider1dCubeYaspgrid` class, which WP0's discovery picks up **with no strategy edit**.
- `make_cube_grid<YASP_1D_EQUIDISTANT_OFFSET, Cube>` bound in `gridprovider/cube.cc`. The two 1d grids are disambiguated by element-type tag: `OneDGrid` keeps the dimension-only overload (`make_cube_grid(Dim(1), ...)`), `YASP_1D` uses the `(Dimension, Cube)` overload like its 2d/3d siblings (`make_cube_grid(Dim(1), Cube(), ...)`) — no ambiguous 1d signature.
- `adaptation-helper.cc`'s curated `AvailableAdaptiveGridTypes` is intentionally **left unchanged** (YaspGrid is structured, not locally adaptive).

**Strategies**
- `GridSpec.make_grid` routes a 1d *cube* grid to the `(Dim, Cube)` factory and a 1d *simplex* grid to the dimension-only factory. The #319 grid/space/operator property tests now cover `YASP_1D`; both 1d grids share the same expected element/vertex counts and cube refinement factor (2^1), so no property-test edit is needed.

**Docs — notebook (CI smoke test)**
- New `docs/source/example__structured_1d_grids.md`, linked from `examples.md`: builds the same 1d domain as both `OneDGrid` and `YASP_1D`, solves the 1d stationary heat equation on each (reusing `discretize_elliptic_cg.py`), asserts the two discretizations agree and are nodally exact, and demonstrates the **equidistant-offset** feature on an offset interval `[2, 5]`. Executed by the docs job.

**4d evaluation (deliverable)**
- `docs/wp2_yasp4d_go_no_go.md` — written go/no-go for `YASP_4D`. **Decision: NO-GO for now.**
  - A single 4d grid fans out across **~103 instantiation-driving binding TUs** (68 `gdt` + 35 `xt`, counted statically on this branch).
  - The binding TUs are the CI memory driver — they already peak "well above 4 GB" and are OOM-capped at `bindings_jobs = cpu/2` per `non_docker_build.yml`; a deeper 4d instantiation (more codims, heavier reference-cube FEs/quadratures) would likely force another by-dimension TU split.
  - 4d has no visualization / no gmsh, and its invariants are already property-sampled at 1–3d; the genuinely 4d-only coverage stays in the C++ `CubicGrids` tests.
  - The doc includes the CI peak-RSS/wall-clock measurement recipe and the exact conditions under which the decision flips to go.

### Acceptance (per #320 WP2)
- ✅ `YASP_1D` bindings + strategies — discovered automatically by WP0.
- ✅ #319's grid/space/operator property tests cover the new type with no edit.
- ✅ Notebook `example__structured_1d_grids.md` executes in the docs CI job.
- ✅ Written go/no-go for 4d with measured (static) numbers + CI measurement recipe.

### Notes on verification
The compiled bindings aren't buildable in this environment (full DUNE toolchain), so the notebook and binding instantiation land verified by CI (docs job + property suites). Locally verified: the strategy `make_grid` dispatch (1d simplex → dimension-only overload, 1d cube → `(Dim, Cube)` overload, consistent counts), WP0 discovery of `GridProvider1dCubeYaspgrid`, `ruff`/`ruff-format` clean, and `clang-format` clean on the C++ changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Egiq27barJ6awhrzuWAnzQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Python support for structured, offset 1D grids.
  - Added support for creating 1D cube grids with selectable element types.
  - Added examples demonstrating structured-grid Poisson problems and offset coordinates.

- **Documentation**
  - Added the structured 1D grid example to the documentation.
  - Documented the current decision not to add 4D grid bindings, including conditions for future reconsideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->