### PR TITLE
feat(python): bind UG grids incl. prism and mixed-element factories (WP3, #320)

### DIFF
--- a/docs/source/example__mixed_and_prism_grids.md
+++ b/docs/source/example__mixed_and_prism_grids.md
@@ -1,0 +1,132 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: mixed-element and prism grids
+
+Most grid managers hold a single geometry type: `YaspGrid` is all cubes, `ALUGrid` is all cubes
+*or* all simplices. `UGGrid` is the exception -- it can hold a mesh that mixes cubes and simplices
+(and, in 3d, prisms). The `dune-gdt` C++ test suite exercises those element types through the
+`make_mixed_grid` / `make_prism_grid` fixtures (`dune/gdt/test/spaces/base.hh`); this example uses
+the matching Python factories `dune.xt.grid.make_mixed_grid` / `make_prism_grid`, which build the
+same meshes and are only available when the wheel was compiled with `UGGrid`.
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+import numpy as np
+```
+
+## 1: a mixed cube/simplex grid in 2d
+
+`make_mixed_grid(Dim(2))` inserts two quadrilaterals and two triangles that together tile a small
+polygonal domain:
+
+```{code-cell}
+from dune.xt.grid import Dim, make_mixed_grid, visualize_grid
+
+grid = make_mixed_grid(Dim(2))
+print(f"{grid.size(0)} elements, {grid.size(grid.dimension)} vertices")
+```
+
+The number of elements *per geometry type* is what distinguishes a mixed grid from the structured
+ones. `dune.xt.test.hypothesis_strategies.element_geometry_counts` walks the leaf view and
+classifies each element by its corner count (3 corners -> triangle/simplex, 4 corners ->
+quadrilateral/cube):
+
+```{code-cell}
+from dune.xt.test.hypothesis_strategies import element_geometry_counts
+
+element_geometry_counts(grid)
+```
+
+We can look at the mesh directly; the two triangles and two quadrilaterals share a common edge
+skeleton:
+
+```{code-cell}
+_ = visualize_grid(grid)
+```
+
+## 2: assembling and solving on the mixed grid
+
+A discontinuous Galerkin (interior penalty) discretization is the natural choice here: it assembles
+element by element and couples neighbours across intersections, so it does not care whether two
+adjacent elements are the same geometry type. We refine the grid a couple of times for a finer
+solution -- refinement multiplies the element counts but keeps both geometry types present:
+
+```{code-cell}
+grid.global_refine(2)
+element_geometry_counts(grid)
+```
+
+```{code-cell}
+from discretize_elliptic_ipdg import discretize_elliptic_ipdg_dirichlet_zero
+
+u_h = discretize_elliptic_ipdg_dirichlet_zero(grid, diffusion=1, source=1)
+```
+
+```{code-cell}
+from dune.gdt import visualize_function
+
+_ = visualize_function(u_h)
+```
+
+The size of the DG space is bookkept per element and per geometry type: an order-`k` cube
+contributes `(k + 1)^d` (tensor-product `Q_k`) local degrees of freedom, a simplex contributes
+`binomial(k + d, d)` (`P_k`). Summing over the elements actually present must reproduce the space's
+global DoF count exactly -- this is the mixed-grid generalization of the per-element DG DoF property
+tested in `python/gdt/test/test_hypothesis_mixed_grids.py`:
+
+```{code-cell}
+from dune.gdt import DiscontinuousLagrangeSpace
+from dune.xt.test.hypothesis_strategies import dg_dof_count_on_mixed_grid
+
+order = 1
+space = DiscontinuousLagrangeSpace(grid, order=order)
+expected = dg_dof_count_on_mixed_grid(grid, order)
+print(f"space.num_DoFs = {space.num_DoFs}, expected = {expected}")
+assert space.num_DoFs == expected
+```
+
+## 3: a prism grid in 3d
+
+In three dimensions `UGGrid` additionally supports prisms (a triangle extruded along a line).
+`make_prism_grid(Dim(3))` builds a single prism, which we refine once to obtain several:
+
+```{code-cell}
+from dune.xt.grid import make_prism_grid
+
+prism_grid = make_prism_grid(Dim(3), num_refinements=1)
+element_geometry_counts(prism_grid)
+```
+
+All elements are prisms (6 corners each), a geometry type that is unreachable from Python with any
+of the other bound grid managers.
+
+Download the code:
+{download}`example__mixed_and_prism_grids.md`
+{nb-download}`example__mixed_and_prism_grids.ipynb`

--- a/docs/source/example__mixed_and_prism_grids.md
+++ b/docs/source/example__mixed_and_prism_grids.md
@@ -32,13 +32,33 @@ Most grid managers hold a single geometry type: `YaspGrid` is all cubes, `ALUGri
 (and, in 3d, prisms). The `dune-gdt` C++ test suite exercises those element types through the
 `make_mixed_grid` / `make_prism_grid` fixtures (`dune/gdt/test/spaces/base.hh`); this example uses
 the matching Python factories `dune.xt.grid.make_mixed_grid` / `make_prism_grid`, which build the
-same meshes and are only available when the wheel was compiled with `UGGrid`.
+same meshes.
+
+`UGGrid` is an optional dependency (the `uggrid` vcpkg feature). The cell below detects whether the
+installed wheel was built with it; if not, the demonstration cells further down are skipped with a
+note instead of failing, so this page still builds. (The property tests in
+`python/gdt/test/test_hypothesis_mixed_grids.py` exercise the same factories whenever the build
+provides them.)
 
 ```{code-cell}
 # wurlitzer: display dune's output in the notebook
 %load_ext wurlitzer
 
 import numpy as np
+
+from dune.xt.grid import Dim, visualize_grid
+
+try:
+    from dune.xt.grid import make_mixed_grid, make_prism_grid
+
+    HAVE_UGGRID = True
+except ImportError:
+    HAVE_UGGRID = False
+    print(
+        "This wheel was built without the 'uggrid' vcpkg feature, so make_mixed_grid /\n"
+        "make_prism_grid are not available and the cells below are skipped. Rebuild with the\n"
+        "'uggrid' feature enabled (see CMakePresets.json) to run the full example."
+    )
 ```
 
 ## 1: a mixed cube/simplex grid in 2d
@@ -47,10 +67,9 @@ import numpy as np
 polygonal domain:
 
 ```{code-cell}
-from dune.xt.grid import Dim, make_mixed_grid, visualize_grid
-
-grid = make_mixed_grid(Dim(2))
-print(f"{grid.size(0)} elements, {grid.size(grid.dimension)} vertices")
+if HAVE_UGGRID:
+    grid = make_mixed_grid(Dim(2))
+    print(f"{grid.size(0)} elements, {grid.size(grid.dimension)} vertices")
 ```
 
 The number of elements *per geometry type* is what distinguishes a mixed grid from the structured
@@ -61,14 +80,16 @@ quadrilateral/cube):
 ```{code-cell}
 from dune.xt.test.hypothesis_strategies import element_geometry_counts
 
-element_geometry_counts(grid)
+if HAVE_UGGRID:
+    print(element_geometry_counts(grid))
 ```
 
 We can look at the mesh directly; the two triangles and two quadrilaterals share a common edge
 skeleton:
 
 ```{code-cell}
-_ = visualize_grid(grid)
+if HAVE_UGGRID:
+    _ = visualize_grid(grid)
 ```
 
 ## 2: assembling and solving on the mixed grid
@@ -79,20 +100,24 @@ adjacent elements are the same geometry type. We refine the grid a couple of tim
 solution -- refinement multiplies the element counts but keeps both geometry types present:
 
 ```{code-cell}
-grid.global_refine(2)
-element_geometry_counts(grid)
+if HAVE_UGGRID:
+    grid.global_refine(2)
+    print(element_geometry_counts(grid))
 ```
 
 ```{code-cell}
-from discretize_elliptic_ipdg import discretize_elliptic_ipdg_dirichlet_zero
+if HAVE_UGGRID:
+    from discretize_elliptic_ipdg import discretize_elliptic_ipdg_dirichlet_zero
 
-u_h = discretize_elliptic_ipdg_dirichlet_zero(grid, diffusion=1, source=1)
+    u_h = discretize_elliptic_ipdg_dirichlet_zero(grid, diffusion=1, source=1)
+    _ = visualize_grid(grid)
 ```
 
 ```{code-cell}
-from dune.gdt import visualize_function
+if HAVE_UGGRID:
+    from dune.gdt import visualize_function
 
-_ = visualize_function(u_h)
+    _ = visualize_function(u_h)
 ```
 
 The size of the DG space is bookkept per element and per geometry type: an order-`k` cube
@@ -102,14 +127,15 @@ global DoF count exactly -- this is the mixed-grid generalization of the per-ele
 tested in `python/gdt/test/test_hypothesis_mixed_grids.py`:
 
 ```{code-cell}
-from dune.gdt import DiscontinuousLagrangeSpace
-from dune.xt.test.hypothesis_strategies import dg_dof_count_on_mixed_grid
+if HAVE_UGGRID:
+    from dune.gdt import DiscontinuousLagrangeSpace
+    from dune.xt.test.hypothesis_strategies import dg_dof_count_on_mixed_grid
 
-order = 1
-space = DiscontinuousLagrangeSpace(grid, order=order)
-expected = dg_dof_count_on_mixed_grid(grid, order)
-print(f"space.num_DoFs = {space.num_DoFs}, expected = {expected}")
-assert space.num_DoFs == expected
+    order = 1
+    space = DiscontinuousLagrangeSpace(grid, order=order)
+    expected = dg_dof_count_on_mixed_grid(grid, order)
+    print(f"space.num_DoFs = {space.num_DoFs}, expected = {expected}")
+    assert space.num_DoFs == expected
 ```
 
 ## 3: a prism grid in 3d
@@ -118,10 +144,9 @@ In three dimensions `UGGrid` additionally supports prisms (a triangle extruded a
 `make_prism_grid(Dim(3))` builds a single prism, which we refine once to obtain several:
 
 ```{code-cell}
-from dune.xt.grid import make_prism_grid
-
-prism_grid = make_prism_grid(Dim(3), num_refinements=1)
-element_geometry_counts(prism_grid)
+if HAVE_UGGRID:
+    prism_grid = make_prism_grid(Dim(3), num_refinements=1)
+    print(element_geometry_counts(prism_grid))
 ```
 
 All elements are prisms (6 corners each), a geometry type that is unreachable from Python with any

--- a/docs/source/example__mixed_and_prism_grids.md
+++ b/docs/source/example__mixed_and_prism_grids.md
@@ -44,6 +44,8 @@ provides them.)
 # wurlitzer: display dune's output in the notebook
 %load_ext wurlitzer
 
+import math
+
 import numpy as np
 
 from dune.xt.grid import Dim, visualize_grid
@@ -61,6 +63,32 @@ except ImportError:
     )
 ```
 
+A small helper classifies each leaf element by its number of corners (in 2d: 3 -> triangle/simplex,
+4 -> quadrilateral/cube; in 3d a prism has 6) and counts how many of each geometry type the grid
+holds -- this is what makes a mixed grid visibly different from the structured ones:
+
+```{code-cell}
+_GEOMETRY_BY_CORNERS = {
+    (2, 3): "simplex",
+    (2, 4): "cube",
+    (3, 4): "simplex",
+    (3, 6): "prism",
+    (3, 8): "cube",
+}
+
+
+def element_geometry_counts(grid):
+    dim = grid.dimension
+    counts = {}
+
+    def visit(element):
+        geometry_type = _GEOMETRY_BY_CORNERS.get((dim, element.corners.shape[0]), "unknown")
+        counts[geometry_type] = counts.get(geometry_type, 0) + 1
+
+    grid.apply_on_each_element(visit)
+    return counts
+```
+
 ## 1: a mixed cube/simplex grid in 2d
 
 `make_mixed_grid(Dim(2))` inserts two quadrilaterals and two triangles that together tile a small
@@ -70,17 +98,6 @@ polygonal domain:
 if HAVE_UGGRID:
     grid = make_mixed_grid(Dim(2))
     print(f"{grid.size(0)} elements, {grid.size(grid.dimension)} vertices")
-```
-
-The number of elements *per geometry type* is what distinguishes a mixed grid from the structured
-ones. `dune.xt.test.hypothesis_strategies.element_geometry_counts` walks the leaf view and
-classifies each element by its corner count (3 corners -> triangle/simplex, 4 corners ->
-quadrilateral/cube):
-
-```{code-cell}
-from dune.xt.test.hypothesis_strategies import element_geometry_counts
-
-if HAVE_UGGRID:
     print(element_geometry_counts(grid))
 ```
 
@@ -123,17 +140,27 @@ if HAVE_UGGRID:
 The size of the DG space is bookkept per element and per geometry type: an order-`k` cube
 contributes `(k + 1)^d` (tensor-product `Q_k`) local degrees of freedom, a simplex contributes
 `binomial(k + d, d)` (`P_k`). Summing over the elements actually present must reproduce the space's
-global DoF count exactly -- this is the mixed-grid generalization of the per-element DG DoF property
-tested in `python/gdt/test/test_hypothesis_mixed_grids.py`:
+global DoF count exactly -- the mixed-grid generalization of the per-element DG DoF property tested
+in `python/gdt/test/test_hypothesis_mixed_grids.py`:
 
 ```{code-cell}
+def dg_dofs_per_element(geometry_type, order, dim):
+    if geometry_type == "cube":
+        return (order + 1) ** dim  # Q_k
+    if geometry_type == "simplex":
+        return math.comb(order + dim, dim)  # P_k
+    raise NotImplementedError(geometry_type)
+
+
 if HAVE_UGGRID:
     from dune.gdt import DiscontinuousLagrangeSpace
-    from dune.xt.test.hypothesis_strategies import dg_dof_count_on_mixed_grid
 
     order = 1
     space = DiscontinuousLagrangeSpace(grid, order=order)
-    expected = dg_dof_count_on_mixed_grid(grid, order)
+    expected = sum(
+        count * dg_dofs_per_element(geometry_type, order, grid.dimension)
+        for geometry_type, count in element_geometry_counts(grid).items()
+    )
     print(f"space.num_DoFs = {space.num_DoFs}, expected = {expected}")
     assert space.num_DoFs == expected
 ```

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -9,6 +9,7 @@ example__structured_1d_grids
 example__alugrid_variants
 example__ESV2007_estimates
 example__gmsh_grid
+example__mixed_and_prism_grids
 example__MNS2002_estimates
 example__ipdg_stationary_heat_equation
 example__ipdg_heat_equation

--- a/dune/gdt/test/spaces/base.hh
+++ b/dune/gdt/test/spaces/base.hh
@@ -28,6 +28,7 @@
 #include <gtest/gtest.h>
 #include <dune/xt/common/float_cmp.hh>
 #include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/gridprovider/unstructured.hh>
 #include <dune/xt/grid/grids.hh>
 
 #include <dune/gdt/type_traits.hh>
@@ -323,21 +324,9 @@ template <class G,
               typename std::enable_if<XT::Grid::is_grid<G>::value && G::dimension == 3, void>::type>
 XT::Grid::GridProvider<G> make_prism_grid()
 {
-  using D = typename G::ctype;
-  static constexpr size_t d = G::dimension;
-  GridFactory<G> factory;
-  for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
-                        XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
-                        XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
-                        XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
-                        XT::Common::FieldVector<D, d>({-1., -1., -1.}),
-                        XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.})}) {
-    factory.insertVertex(vertex);
-  }
-  factory.insertElement(GeometryTypes::prism, {0, 1, 2, 3, 4, 5});
-  XT::Grid::GridProvider<G> grid(factory.createGrid());
-  grid.global_refine(1);
-  return grid;
+  // The mesh is defined once in dune-xt (shared with the python make_prism_grid binding); refine
+  // once as the space tests below expect (all kinds of orientations, fully inner elements).
+  return XT::Grid::make_prism_grid<G>(/*num_refinements=*/1);
 } // ... make_prism_grid(...)
 
 
@@ -354,52 +343,9 @@ template <
         typename std::enable_if<XT::Grid::is_grid<G>::value && (G::dimension == 2 || G::dimension == 3), void>::type>
 XT::Grid::GridProvider<G> make_mixed_grid()
 {
-  using D = typename G::ctype;
-  static constexpr size_t d = G::dimension;
-  if constexpr (d == 2) {
-    GridFactory<G> factory;
-    for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5}),
-                          XT::Common::FieldVector<D, d>({-1., -1.25}),
-                          XT::Common::FieldVector<D, d>({-1., -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.25}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.}),
-                          XT::Common::FieldVector<D, d>({-1.75, -1.25})}) {
-      factory.insertVertex(vertex);
-    }
-    factory.insertElement(GeometryTypes::cube(2), {3, 0, 4, 1});
-    factory.insertElement(GeometryTypes::cube(2), {4, 1, 5, 2});
-    factory.insertElement(GeometryTypes::simplex(2), {4, 6, 3});
-    factory.insertElement(GeometryTypes::simplex(2), {4, 5, 6});
-    XT::Grid::GridProvider<G> grid(factory.createGrid());
-    grid.global_refine(1);
-    return grid;
-  } else if constexpr (d == 3) {
-    GridFactory<G> factory;
-    for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
-                          XT::Common::FieldVector<D, d>({-1., -1.25, -1.}),
-                          XT::Common::FieldVector<D, d>({-1., -1., -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1., -1.}),
-                          XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1., -1.25, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1., -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.75, -1.25, -1.})}) {
-      factory.insertVertex(vertex);
-    }
-    factory.insertElement(GeometryTypes::cube(3), {3, 0, 4, 1, 9, 6, 10, 7});
-    factory.insertElement(GeometryTypes::cube(3), {4, 1, 5, 2, 10, 7, 11, 8});
-    factory.insertElement(GeometryTypes::simplex(3), {4, 12, 3, 10});
-    factory.insertElement(GeometryTypes::simplex(3), {4, 5, 12, 10});
-    XT::Grid::GridProvider<G> grid(factory.createGrid());
-    grid.global_refine(1);
-    return grid;
-  } else
-    DUNE_THROW(InvalidStateException, "");
+  // The mesh is defined once in dune-xt (shared with the python make_mixed_grid binding); refine
+  // once to obtain conforming intersections and fully inner elements as the space tests expect.
+  return XT::Grid::make_mixed_grid<G>(/*num_refinements=*/1);
 } // ... make_mixed_grid(...)
 
 

--- a/dune/xt/grid/gridprovider/unstructured.hh
+++ b/dune/xt/grid/gridprovider/unstructured.hh
@@ -1,0 +1,106 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#ifndef DUNE_XT_GRID_GRIDPROVIDER_UNSTRUCTURED_HH
+#define DUNE_XT_GRID_GRIDPROVIDER_UNSTRUCTURED_HH
+
+#include <dune/geometry/type.hh>
+
+#include <dune/grid/common/gridfactory.hh>
+
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/grid/gridprovider/provider.hh>
+
+namespace Dune::XT::Grid {
+
+
+/// \brief A grid with mixed cube/simplex elements (2d or 3d), built via the GridFactory.
+///
+/// Only grid managers that can hold more than one geometry type (i.e. UGGrid) can be instantiated
+/// with this; the factory body is therefore only ever compiled for such grids. This is the single
+/// source of truth for the mixed-element mesh used both by the C++ space tests
+/// (dune/gdt/test/spaces/base.hh) and by the python make_mixed_grid binding.
+template <class G>
+GridProvider<G> make_mixed_grid(const unsigned int num_refinements = 0)
+{
+  using D = typename G::ctype;
+  static constexpr size_t d = G::dimension;
+  static_assert(d == 2 || d == 3, "mixed-element grids are only implemented in 2d and 3d");
+  GridFactory<G> factory;
+  if constexpr (d == 2) {
+    for (auto&& vertex : {Common::FieldVector<D, d>({-1., -1.5}),
+                          Common::FieldVector<D, d>({-1., -1.25}),
+                          Common::FieldVector<D, d>({-1., -1.}),
+                          Common::FieldVector<D, d>({-1.5, -1.5}),
+                          Common::FieldVector<D, d>({-1.5, -1.25}),
+                          Common::FieldVector<D, d>({-1.5, -1.}),
+                          Common::FieldVector<D, d>({-1.75, -1.25})}) {
+      factory.insertVertex(vertex);
+    }
+    factory.insertElement(GeometryTypes::cube(2), {3, 0, 4, 1});
+    factory.insertElement(GeometryTypes::cube(2), {4, 1, 5, 2});
+    factory.insertElement(GeometryTypes::simplex(2), {4, 6, 3});
+    factory.insertElement(GeometryTypes::simplex(2), {4, 5, 6});
+  } else {
+    for (auto&& vertex : {Common::FieldVector<D, d>({-1., -1.5, -1.}),
+                          Common::FieldVector<D, d>({-1., -1.25, -1.}),
+                          Common::FieldVector<D, d>({-1., -1., -1.}),
+                          Common::FieldVector<D, d>({-1.5, -1.5, -1.}),
+                          Common::FieldVector<D, d>({-1.5, -1.25, -1.}),
+                          Common::FieldVector<D, d>({-1.5, -1., -1.}),
+                          Common::FieldVector<D, d>({-1., -1.5, -1.5}),
+                          Common::FieldVector<D, d>({-1., -1.25, -1.5}),
+                          Common::FieldVector<D, d>({-1., -1., -1.5}),
+                          Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
+                          Common::FieldVector<D, d>({-1.5, -1.25, -1.5}),
+                          Common::FieldVector<D, d>({-1.5, -1., -1.5}),
+                          Common::FieldVector<D, d>({-1.75, -1.25, -1.})}) {
+      factory.insertVertex(vertex);
+    }
+    factory.insertElement(GeometryTypes::cube(3), {3, 0, 4, 1, 9, 6, 10, 7});
+    factory.insertElement(GeometryTypes::cube(3), {4, 1, 5, 2, 10, 7, 11, 8});
+    factory.insertElement(GeometryTypes::simplex(3), {4, 12, 3, 10});
+    factory.insertElement(GeometryTypes::simplex(3), {4, 5, 12, 10});
+  }
+  GridProvider<G> grid(factory.createGrid());
+  grid.global_refine(num_refinements);
+  return grid;
+} // ... make_mixed_grid(...)
+
+
+/// \brief A 3d grid consisting of a single prism, built via the GridFactory.
+///
+/// As with make_mixed_grid, only UGGrid supports prism elements, so the body is only ever compiled
+/// for such grids. Single source of truth shared by dune/gdt/test/spaces/base.hh and the python
+/// make_prism_grid binding.
+template <class G>
+GridProvider<G> make_prism_grid(const unsigned int num_refinements = 0)
+{
+  using D = typename G::ctype;
+  static constexpr size_t d = G::dimension;
+  static_assert(d == 3, "prism grids are only meaningful in 3d");
+  GridFactory<G> factory;
+  for (auto&& vertex : {Common::FieldVector<D, d>({-1., -1.5, -1.5}),
+                        Common::FieldVector<D, d>({-1., -1., -1.5}),
+                        Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
+                        Common::FieldVector<D, d>({-1., -1.5, -1.}),
+                        Common::FieldVector<D, d>({-1., -1., -1.}),
+                        Common::FieldVector<D, d>({-1.5, -1.5, -1.})}) {
+    factory.insertVertex(vertex);
+  }
+  factory.insertElement(GeometryTypes::prism, {0, 1, 2, 3, 4, 5});
+  GridProvider<G> grid(factory.createGrid());
+  grid.global_refine(num_refinements);
+  return grid;
+} // ... make_prism_grid(...)
+
+
+} // namespace Dune::XT::Grid
+
+#endif // DUNE_XT_GRID_GRIDPROVIDER_UNSTRUCTURED_HH

--- a/python/gdt/dune/gdt/CMakeLists.txt
+++ b/python/gdt/dune/gdt/CMakeLists.txt
@@ -14,13 +14,24 @@
 file(GLOB_RECURSE header "*.hh")
 
 dune_pybindxi_add_module(_discretefunction_bochner EXCLUDE_FROM_ALL ${header} discretefunction/bochner.cc)
-dune_pybindxi_add_module(_discretefunction_discretefunction EXCLUDE_FROM_ALL ${header}
-                         discretefunction/discretefunction.cc)
+dune_pybindxi_add_module(_discretefunction_discretefunction_1d EXCLUDE_FROM_ALL ${header}
+                         discretefunction/discretefunction_1d.cc)
+dune_pybindxi_add_module(_discretefunction_discretefunction_2d EXCLUDE_FROM_ALL ${header}
+                         discretefunction/discretefunction_2d.cc)
+dune_pybindxi_add_module(_discretefunction_discretefunction_3d EXCLUDE_FROM_ALL ${header}
+                         discretefunction/discretefunction_3d.cc)
 dune_pybindxi_add_module(_discretefunction_dof_vector EXCLUDE_FROM_ALL ${header} discretefunction/dof-vector.cc)
 dune_pybindxi_add_module(_functionals_interfaces_common EXCLUDE_FROM_ALL ${header} functionals/interfaces_common.cc)
 dune_pybindxi_add_module(_functionals_interfaces_eigen EXCLUDE_FROM_ALL ${header} functionals/interfaces_eigen.cc)
-dune_pybindxi_add_module(_functionals_interfaces_istl EXCLUDE_FROM_ALL ${header} functionals/interfaces_istl.cc)
-dune_pybindxi_add_module(_functionals_vector_based EXCLUDE_FROM_ALL ${header} functionals/vector-based.cc)
+dune_pybindxi_add_module(_functionals_interfaces_istl_1d EXCLUDE_FROM_ALL ${header}
+                         functionals/interfaces_istl_1d.cc)
+dune_pybindxi_add_module(_functionals_interfaces_istl_2d EXCLUDE_FROM_ALL ${header}
+                         functionals/interfaces_istl_2d.cc)
+dune_pybindxi_add_module(_functionals_interfaces_istl_3d EXCLUDE_FROM_ALL ${header}
+                         functionals/interfaces_istl_3d.cc)
+dune_pybindxi_add_module(_functionals_vector_based_1d EXCLUDE_FROM_ALL ${header} functionals/vector-based_1d.cc)
+dune_pybindxi_add_module(_functionals_vector_based_2d EXCLUDE_FROM_ALL ${header} functionals/vector-based_2d.cc)
+dune_pybindxi_add_module(_functionals_vector_based_3d EXCLUDE_FROM_ALL ${header} functionals/vector-based_3d.cc)
 dune_pybindxi_add_module(_interpolations_boundary EXCLUDE_FROM_ALL ${header} interpolations/boundary.cc)
 dune_pybindxi_add_module(_interpolations_default EXCLUDE_FROM_ALL ${header} interpolations/default.cc)
 dune_pybindxi_add_module(_interpolations_oswald EXCLUDE_FROM_ALL ${header} interpolations/oswald.cc)
@@ -95,7 +106,9 @@ dune_pybindxi_add_module(_local_operators_intersection_indicator EXCLUDE_FROM_AL
                          local/operators/intersection_indicator.cc)
 dune_pybindxi_add_module(_local_operators_intersection_interface EXCLUDE_FROM_ALL ${header}
                          local/operators/intersection_interface.cc)
-dune_pybindxi_add_module(_operators_bilinear_form EXCLUDE_FROM_ALL ${header} operators/bilinear-form.cc)
+dune_pybindxi_add_module(_operators_bilinear_form_1d EXCLUDE_FROM_ALL ${header} operators/bilinear-form_1d.cc)
+dune_pybindxi_add_module(_operators_bilinear_form_2d EXCLUDE_FROM_ALL ${header} operators/bilinear-form_2d.cc)
+dune_pybindxi_add_module(_operators_bilinear_form_3d EXCLUDE_FROM_ALL ${header} operators/bilinear-form_3d.cc)
 dune_pybindxi_add_module(_operators_interfaces_common EXCLUDE_FROM_ALL ${header} operators/interfaces_common.cc)
 dune_pybindxi_add_module(_operators_interfaces_eigen EXCLUDE_FROM_ALL ${header} operators/interfaces_eigen.cc)
 dune_pybindxi_add_module(_operators_interfaces_istl_1d EXCLUDE_FROM_ALL ${header} operators/interfaces_istl_1d.cc)
@@ -103,15 +116,31 @@ dune_pybindxi_add_module(_operators_interfaces_istl_2d EXCLUDE_FROM_ALL ${header
 dune_pybindxi_add_module(_operators_interfaces_istl_3d EXCLUDE_FROM_ALL ${header} operators/interfaces_istl_3d.cc)
 dune_pybindxi_add_module(_operators_laplace_ipdg_flux_reconstruction EXCLUDE_FROM_ALL ${header}
                          operators/laplace_ipdg_flux_reconstruction.cc)
-dune_pybindxi_add_module(_operators_matrix_based_factory EXCLUDE_FROM_ALL ${header} operators/matrix-based_factory.cc)
-dune_pybindxi_add_module(_operators_operator EXCLUDE_FROM_ALL ${header} operators/operator.cc)
+dune_pybindxi_add_module(_operators_matrix_based_factory_1d EXCLUDE_FROM_ALL ${header}
+                         operators/matrix-based_factory_1d.cc)
+dune_pybindxi_add_module(_operators_matrix_based_factory_2d EXCLUDE_FROM_ALL ${header}
+                         operators/matrix-based_factory_2d.cc)
+dune_pybindxi_add_module(_operators_matrix_based_factory_3d EXCLUDE_FROM_ALL ${header}
+                         operators/matrix-based_factory_3d.cc)
+dune_pybindxi_add_module(_operators_operator_1d EXCLUDE_FROM_ALL ${header} operators/operator_1d.cc)
+dune_pybindxi_add_module(_operators_operator_2d EXCLUDE_FROM_ALL ${header} operators/operator_2d.cc)
+dune_pybindxi_add_module(_operators_operator_3d EXCLUDE_FROM_ALL ${header} operators/operator_3d.cc)
 dune_pybindxi_add_module(_prolongations EXCLUDE_FROM_ALL ${header} prolongations.cc)
 dune_pybindxi_add_module(_spaces_bochner EXCLUDE_FROM_ALL ${header} spaces/bochner.cc)
-dune_pybindxi_add_module(_spaces_h1_continuous_lagrange EXCLUDE_FROM_ALL ${header} spaces/h1/continuous-lagrange.cc)
+dune_pybindxi_add_module(_spaces_h1_continuous_lagrange_1d EXCLUDE_FROM_ALL ${header}
+                         spaces/h1/continuous-lagrange_1d.cc)
+dune_pybindxi_add_module(_spaces_h1_continuous_lagrange_2d EXCLUDE_FROM_ALL ${header}
+                         spaces/h1/continuous-lagrange_2d.cc)
+dune_pybindxi_add_module(_spaces_h1_continuous_lagrange_3d EXCLUDE_FROM_ALL ${header}
+                         spaces/h1/continuous-lagrange_3d.cc)
 dune_pybindxi_add_module(_spaces_hdiv_raviart_thomas EXCLUDE_FROM_ALL ${header} spaces/hdiv/raviart-thomas.cc)
 dune_pybindxi_add_module(_spaces_interface EXCLUDE_FROM_ALL ${header} spaces/interface.cc)
-dune_pybindxi_add_module(_spaces_l2_discontinuous_lagrange EXCLUDE_FROM_ALL ${header}
-                         spaces/l2/discontinuous-lagrange.cc)
+dune_pybindxi_add_module(_spaces_l2_discontinuous_lagrange_1d EXCLUDE_FROM_ALL ${header}
+                         spaces/l2/discontinuous-lagrange_1d.cc)
+dune_pybindxi_add_module(_spaces_l2_discontinuous_lagrange_2d EXCLUDE_FROM_ALL ${header}
+                         spaces/l2/discontinuous-lagrange_2d.cc)
+dune_pybindxi_add_module(_spaces_l2_discontinuous_lagrange_3d EXCLUDE_FROM_ALL ${header}
+                         spaces/l2/discontinuous-lagrange_3d.cc)
 dune_pybindxi_add_module(_spaces_l2_finite_volume EXCLUDE_FROM_ALL ${header} spaces/l2/finite-volume.cc)
 dune_pybindxi_add_module(_spaces_skeleton_finite_volume EXCLUDE_FROM_ALL ${header} spaces/skeleton/finite-volume.cc)
 dune_pybindxi_add_module(_tools_adaptation_helper EXCLUDE_FROM_ALL ${header} tools/adaptation-helper.cc)

--- a/python/gdt/dune/gdt/CMakeLists.txt
+++ b/python/gdt/dune/gdt/CMakeLists.txt
@@ -23,12 +23,9 @@ dune_pybindxi_add_module(_discretefunction_discretefunction_3d EXCLUDE_FROM_ALL 
 dune_pybindxi_add_module(_discretefunction_dof_vector EXCLUDE_FROM_ALL ${header} discretefunction/dof-vector.cc)
 dune_pybindxi_add_module(_functionals_interfaces_common EXCLUDE_FROM_ALL ${header} functionals/interfaces_common.cc)
 dune_pybindxi_add_module(_functionals_interfaces_eigen EXCLUDE_FROM_ALL ${header} functionals/interfaces_eigen.cc)
-dune_pybindxi_add_module(_functionals_interfaces_istl_1d EXCLUDE_FROM_ALL ${header}
-                         functionals/interfaces_istl_1d.cc)
-dune_pybindxi_add_module(_functionals_interfaces_istl_2d EXCLUDE_FROM_ALL ${header}
-                         functionals/interfaces_istl_2d.cc)
-dune_pybindxi_add_module(_functionals_interfaces_istl_3d EXCLUDE_FROM_ALL ${header}
-                         functionals/interfaces_istl_3d.cc)
+dune_pybindxi_add_module(_functionals_interfaces_istl_1d EXCLUDE_FROM_ALL ${header} functionals/interfaces_istl_1d.cc)
+dune_pybindxi_add_module(_functionals_interfaces_istl_2d EXCLUDE_FROM_ALL ${header} functionals/interfaces_istl_2d.cc)
+dune_pybindxi_add_module(_functionals_interfaces_istl_3d EXCLUDE_FROM_ALL ${header} functionals/interfaces_istl_3d.cc)
 dune_pybindxi_add_module(_functionals_vector_based_1d EXCLUDE_FROM_ALL ${header} functionals/vector-based_1d.cc)
 dune_pybindxi_add_module(_functionals_vector_based_2d EXCLUDE_FROM_ALL ${header} functionals/vector-based_2d.cc)
 dune_pybindxi_add_module(_functionals_vector_based_3d EXCLUDE_FROM_ALL ${header} functionals/vector-based_3d.cc)

--- a/python/gdt/dune/gdt/__init__.py
+++ b/python/gdt/dune/gdt/__init__.py
@@ -168,23 +168,30 @@ def _make_dispatch(module_base, factory_name, dim_arg=0, dim_kwarg=None):
     return _factory
 
 
-# Canonical factory names restored from their per-dimension submodules (all dispatch on the first
-# argument except DirichletConstraints, whose first argument is a BoundaryInfo).
-Operator = _make_dispatch("_operators_operator", "Operator")
-MatrixOperator = _make_dispatch("_operators_matrix_based_factory", "MatrixOperator")
-BilinearForm = _make_dispatch("_operators_bilinear_form", "BilinearForm")
+# Canonical factory names restored from their per-dimension submodules. All dispatch on the first
+# (positional or keyword) argument, which is a grid provider (.dimension) for every factory below
+# except DiscreteFunction, whose first argument is a space (.dimDomain).
+Operator = _make_dispatch("_operators_operator", "Operator", dim_kwarg="grid")
+MatrixOperator = _make_dispatch(
+    "_operators_matrix_based_factory", "MatrixOperator", dim_kwarg="grid"
+)
+BilinearForm = _make_dispatch(
+    "_operators_bilinear_form", "BilinearForm", dim_kwarg="grid"
+)
 ContinuousLagrangeSpace = _make_dispatch(
-    "_spaces_h1_continuous_lagrange", "ContinuousLagrangeSpace"
+    "_spaces_h1_continuous_lagrange", "ContinuousLagrangeSpace", dim_kwarg="grid"
 )
 DiscontinuousLagrangeSpace = _make_dispatch(
-    "_spaces_l2_discontinuous_lagrange", "DiscontinuousLagrangeSpace"
+    "_spaces_l2_discontinuous_lagrange", "DiscontinuousLagrangeSpace", dim_kwarg="grid"
 )
 DiscreteFunction = _make_dispatch(
-    "_discretefunction_discretefunction", "DiscreteFunction"
-)  # arg0 is a space -> .dimDomain
-VectorFunctional = _make_dispatch("_functionals_vector_based", "VectorFunctional")
+    "_discretefunction_discretefunction", "DiscreteFunction", dim_kwarg="space"
+)
+VectorFunctional = _make_dispatch(
+    "_functionals_vector_based", "VectorFunctional", dim_kwarg="grid"
+)
 IstlVectorFunctional = _make_dispatch(
-    "_functionals_vector_based", "IstlVectorFunctional"
+    "_functionals_vector_based", "IstlVectorFunctional", dim_kwarg="grid"
 )
 
 

--- a/python/gdt/dune/gdt/__init__.py
+++ b/python/gdt/dune/gdt/__init__.py
@@ -10,6 +10,7 @@
 #   René Fritze     (2016, 2018)
 # ~~~
 
+from importlib import import_module
 from tempfile import NamedTemporaryFile
 
 from dune.xt import guarded_import
@@ -21,12 +22,18 @@ __version__ = _version.__version__
 
 for mod_name in (  # order should not matter!
     "_discretefunction_bochner",
-    "_discretefunction_discretefunction",
+    "_discretefunction_discretefunction_1d",
+    "_discretefunction_discretefunction_2d",
+    "_discretefunction_discretefunction_3d",
     "_discretefunction_dof_vector",
     "_functionals_interfaces_common",
     "_functionals_interfaces_eigen",
-    "_functionals_interfaces_istl",
-    "_functionals_vector_based",
+    "_functionals_interfaces_istl_1d",
+    "_functionals_interfaces_istl_2d",
+    "_functionals_interfaces_istl_3d",
+    "_functionals_vector_based_1d",
+    "_functionals_vector_based_2d",
+    "_functionals_vector_based_3d",
     "_interpolations_boundary",
     "_interpolations_default",
     "_interpolations_oswald",
@@ -67,21 +74,31 @@ for mod_name in (  # order should not matter!
     "_local_operators_element_interface",
     "_local_operators_intersection_indicator",
     "_local_operators_intersection_interface",
-    "_operators_bilinear_form",
+    "_operators_bilinear_form_1d",
+    "_operators_bilinear_form_2d",
+    "_operators_bilinear_form_3d",
     "_operators_interfaces_common",
     "_operators_interfaces_eigen",
     "_operators_interfaces_istl_1d",
     "_operators_interfaces_istl_2d",
     "_operators_interfaces_istl_3d",
     "_operators_laplace_ipdg_flux_reconstruction",
-    "_operators_matrix_based_factory",
-    "_operators_operator",
+    "_operators_matrix_based_factory_1d",
+    "_operators_matrix_based_factory_2d",
+    "_operators_matrix_based_factory_3d",
+    "_operators_operator_1d",
+    "_operators_operator_2d",
+    "_operators_operator_3d",
     "_prolongations",
     "_spaces_bochner",
-    "_spaces_h1_continuous_lagrange",
+    "_spaces_h1_continuous_lagrange_1d",
+    "_spaces_h1_continuous_lagrange_2d",
+    "_spaces_h1_continuous_lagrange_3d",
     "_spaces_hdiv_raviart_thomas",
     "_spaces_interface",
-    "_spaces_l2_discontinuous_lagrange",
+    "_spaces_l2_discontinuous_lagrange_1d",
+    "_spaces_l2_discontinuous_lagrange_2d",
+    "_spaces_l2_discontinuous_lagrange_3d",
     "_spaces_l2_finite_volume",
     "_spaces_skeleton_finite_volume",
     "_tools_adaptation_helper",
@@ -90,6 +107,86 @@ for mod_name in (  # order should not matter!
     "_tools_sparsity_pattern",
 ):
     guarded_import(globals(), "dune.gdt", mod_name)
+
+
+# --- dimension-split binding trampolines --------------------------------------------------
+#
+# Several heavy binding TUs are split into per-dimension submodules (_foo_1d/_2d/_3d) to keep each
+# translation unit's compile-time memory bounded (adding UGGrid pushed the monolithic TUs past the
+# 16 GB CI runner). Each split submodule sets `__all__ = ()`, so guarded_import injects nothing into
+# this namespace -- in particular the shared, grid-independent factory function it registers would
+# otherwise collide across the three modules in guarded_import's duplicate-name check. The canonical
+# factory names are restored here by thin Python trampolines that dispatch on the grid dimension of
+# one argument (grid providers expose `.dimension`, spaces `.dimDomain`, (grid) functions
+# `.dim_domain`). This keeps the public API byte-for-byte identical.
+
+
+def _dim_of(obj):
+    for attr in ("dimension", "dimDomain", "dim_domain"):
+        value = getattr(obj, attr, None)
+        if value is not None:
+            return int(value)
+    raise TypeError(
+        f"cannot determine the grid dimension from an argument of type "
+        f"'{type(obj).__name__}'"
+    )
+
+
+_split_submodule_cache = {}
+
+
+def _split_submodule(module_base, dim):
+    key = (module_base, dim)
+    mod = _split_submodule_cache.get(key)
+    if mod is None:
+        try:
+            mod = import_module(f"dune.gdt.{module_base}_{dim}d")
+        except ImportError as e:
+            raise ImportError(
+                f"cannot dispatch to dune.gdt.{module_base}_{dim}d "
+                f"(is the {dim}d grid enabled in this build?)"
+            ) from e
+        _split_submodule_cache[key] = mod
+    return mod
+
+
+def _make_dispatch(module_base, factory_name, dim_arg=0, dim_kwarg=None):
+    def _factory(*args, **kwargs):
+        if dim_arg < len(args):
+            probe = args[dim_arg]
+        elif dim_kwarg is not None and dim_kwarg in kwargs:
+            probe = kwargs[dim_kwarg]
+        else:
+            raise TypeError(
+                f"{factory_name}(): missing the dimension-carrying argument "
+                f"(expected at position {dim_arg})"
+            )
+        submodule = _split_submodule(module_base, _dim_of(probe))
+        return getattr(submodule, factory_name)(*args, **kwargs)
+
+    _factory.__name__ = _factory.__qualname__ = factory_name
+    return _factory
+
+
+# Canonical factory names restored from their per-dimension submodules (all dispatch on the first
+# argument except DirichletConstraints, whose first argument is a BoundaryInfo).
+Operator = _make_dispatch("_operators_operator", "Operator")
+MatrixOperator = _make_dispatch("_operators_matrix_based_factory", "MatrixOperator")
+BilinearForm = _make_dispatch("_operators_bilinear_form", "BilinearForm")
+ContinuousLagrangeSpace = _make_dispatch(
+    "_spaces_h1_continuous_lagrange", "ContinuousLagrangeSpace"
+)
+DiscontinuousLagrangeSpace = _make_dispatch(
+    "_spaces_l2_discontinuous_lagrange", "DiscontinuousLagrangeSpace"
+)
+DiscreteFunction = _make_dispatch(
+    "_discretefunction_discretefunction", "DiscreteFunction"
+)  # arg0 is a space -> .dimDomain
+VectorFunctional = _make_dispatch("_functionals_vector_based", "VectorFunctional")
+IstlVectorFunctional = _make_dispatch(
+    "_functionals_vector_based", "IstlVectorFunctional"
+)
+
 
 if config.HAVE_K3D:
     from dune.xt.common.vtk.plot import plot

--- a/python/gdt/dune/gdt/discretefunction/bochner.cc
+++ b/python/gdt/dune/gdt/discretefunction/bochner.cc
@@ -221,7 +221,9 @@ PYBIND11_MODULE(_discretefunction_bochner, m)
   py::module::import("dune.xt.grid");
   py::module::import("dune.xt.functions");
 
-  py::module::import("dune.gdt._discretefunction_discretefunction");
+  py::module::import("dune.gdt._discretefunction_discretefunction_1d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_2d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_3d");
   py::module::import("dune.gdt._spaces_bochner");
 
   DiscreteBochnerFunction_for_all_grids<LA::CommonDenseVector<double>,

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_1d.cc
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_1d.cc
@@ -13,29 +13,5 @@
 
 PYBIND11_MODULE(_discretefunction_discretefunction_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-  py::module::import("dune.gdt._discretefunction_dof_vector");
-
-  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,
-                                 LA::bindings::Common,
-                                 XT::Grid::bindings::Available1dGridTypes>::bind(m);
-#if HAVE_EIGEN
-  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,
-                                 LA::bindings::Eigen,
-                                 XT::Grid::bindings::Available1dGridTypes>::bind(m);
-#endif
-  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,
-                                 LA::bindings::Istl,
-                                 XT::Grid::bindings::Available1dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_DISCRETEFUNCTION_MODULE(1);
 }

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_1d.cc
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_1d.cc
@@ -1,0 +1,41 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2019)
+
+#include "config.h"
+
+#include "discretefunction_for_all_grids.hh"
+
+PYBIND11_MODULE(_discretefunction_discretefunction_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+  py::module::import("dune.gdt._discretefunction_dof_vector");
+
+  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,
+                                 LA::bindings::Common,
+                                 XT::Grid::bindings::Available1dGridTypes>::bind(m);
+#if HAVE_EIGEN
+  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,
+                                 LA::bindings::Eigen,
+                                 XT::Grid::bindings::Available1dGridTypes>::bind(m);
+#endif
+  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,
+                                 LA::bindings::Istl,
+                                 XT::Grid::bindings::Available1dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_2d.cc
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_2d.cc
@@ -1,0 +1,41 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2019)
+
+#include "config.h"
+
+#include "discretefunction_for_all_grids.hh"
+
+PYBIND11_MODULE(_discretefunction_discretefunction_2d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+  py::module::import("dune.gdt._discretefunction_dof_vector");
+
+  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,
+                                 LA::bindings::Common,
+                                 XT::Grid::bindings::Available2dGridTypes>::bind(m);
+#if HAVE_EIGEN
+  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,
+                                 LA::bindings::Eigen,
+                                 XT::Grid::bindings::Available2dGridTypes>::bind(m);
+#endif
+  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,
+                                 LA::bindings::Istl,
+                                 XT::Grid::bindings::Available2dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_2d.cc
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_2d.cc
@@ -13,29 +13,5 @@
 
 PYBIND11_MODULE(_discretefunction_discretefunction_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-  py::module::import("dune.gdt._discretefunction_dof_vector");
-
-  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,
-                                 LA::bindings::Common,
-                                 XT::Grid::bindings::Available2dGridTypes>::bind(m);
-#if HAVE_EIGEN
-  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,
-                                 LA::bindings::Eigen,
-                                 XT::Grid::bindings::Available2dGridTypes>::bind(m);
-#endif
-  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,
-                                 LA::bindings::Istl,
-                                 XT::Grid::bindings::Available2dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_DISCRETEFUNCTION_MODULE(2);
 }

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_3d.cc
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_3d.cc
@@ -13,29 +13,5 @@
 
 PYBIND11_MODULE(_discretefunction_discretefunction_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-  py::module::import("dune.gdt._discretefunction_dof_vector");
-
-  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,
-                                 LA::bindings::Common,
-                                 XT::Grid::bindings::Available3dGridTypes>::bind(m);
-#if HAVE_EIGEN
-  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,
-                                 LA::bindings::Eigen,
-                                 XT::Grid::bindings::Available3dGridTypes>::bind(m);
-#endif
-  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,
-                                 LA::bindings::Istl,
-                                 XT::Grid::bindings::Available3dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_DISCRETEFUNCTION_MODULE(3);
 }

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_3d.cc
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_3d.cc
@@ -1,0 +1,41 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2019)
+
+#include "config.h"
+
+#include "discretefunction_for_all_grids.hh"
+
+PYBIND11_MODULE(_discretefunction_discretefunction_3d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+  py::module::import("dune.gdt._discretefunction_dof_vector");
+
+  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,
+                                 LA::bindings::Common,
+                                 XT::Grid::bindings::Available3dGridTypes>::bind(m);
+#if HAVE_EIGEN
+  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,
+                                 LA::bindings::Eigen,
+                                 XT::Grid::bindings::Available3dGridTypes>::bind(m);
+#endif
+  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,
+                                 LA::bindings::Istl,
+                                 XT::Grid::bindings::Available3dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_for_all_grids.hh
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_for_all_grids.hh
@@ -45,4 +45,38 @@ struct DiscreteFunction_for_all_grids<V, VT, Dune::XT::Common::tuple_null_type>
 };
 
 
+// Shared by discretefunction_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+#define DUNE_GDT_BIND_DISCRETEFUNCTION_MODULE(dim)                                                                     \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._spaces_interface");                                                                    \
+  py::module::import("dune.gdt._discretefunction_dof_vector");                                                         \
+                                                                                                                       \
+  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,                                                        \
+                                 LA::bindings::Common,                                                                 \
+                                 XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);                             \
+  DUNE_GDT_BIND_DISCRETEFUNCTION_EIGEN(dim)                                                                            \
+  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,                                                          \
+                                 LA::bindings::Istl,                                                                   \
+                                 XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);                             \
+  m.attr("__all__") = py::make_tuple()
+
+#if HAVE_EIGEN
+#  define DUNE_GDT_BIND_DISCRETEFUNCTION_EIGEN(dim)                                                                    \
+    DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,                                                       \
+                                   LA::bindings::Eigen,                                                                \
+                                   XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);
+#else
+#  define DUNE_GDT_BIND_DISCRETEFUNCTION_EIGEN(dim)
+#endif
+
+
 #endif // PYTHON_DUNE_GDT_DISCRETEFUNCTION_DISCRETEFUNCTION_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_for_all_grids.hh
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_for_all_grids.hh
@@ -7,7 +7,9 @@
 // Authors:
 //   Felix Schindler (2019)
 
-#include "config.h"
+#ifndef PYTHON_DUNE_GDT_DISCRETEFUNCTION_DISCRETEFUNCTION_FOR_ALL_GRIDS_HH
+#define PYTHON_DUNE_GDT_DISCRETEFUNCTION_DISCRETEFUNCTION_FOR_ALL_GRIDS_HH
+
 
 #include <dune/xt/grid/grids.hh>
 #include <python/xt/dune/xt/la/traits.hh>
@@ -43,30 +45,4 @@ struct DiscreteFunction_for_all_grids<V, VT, Dune::XT::Common::tuple_null_type>
 };
 
 
-PYBIND11_MODULE(_discretefunction_discretefunction, m)
-{
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-  py::module::import("dune.gdt._discretefunction_dof_vector");
-
-  DiscreteFunction_for_all_grids<LA::CommonDenseVector<double>,
-                                 LA::bindings::Common,
-                                 XT::Grid::bindings::AvailableGridTypes>::bind(m);
-#if HAVE_EIGEN
-  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,
-                                 LA::bindings::Eigen,
-                                 XT::Grid::bindings::AvailableGridTypes>::bind(m);
-#endif
-  DiscreteFunction_for_all_grids<LA::IstlDenseVector<double>,
-                                 LA::bindings::Istl,
-                                 XT::Grid::bindings::AvailableGridTypes>::bind(m);
-}
+#endif // PYTHON_DUNE_GDT_DISCRETEFUNCTION_DISCRETEFUNCTION_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/functionals/interfaces.hh
+++ b/python/gdt/dune/gdt/functionals/interfaces.hh
@@ -113,4 +113,23 @@ struct FunctionalInterface_for_all_grids<V, Dune::XT::Common::tuple_null_type>
 };
 
 
+// Shared by interfaces_istl_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+// Type-only (grid-named classes are unique across modules), so no __all__ / trampoline needed.
+#define DUNE_GDT_BIND_FUNCTIONAL_INTERFACES_ISTL_MODULE(dim)                                                           \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._spaces_interface");                                                                    \
+                                                                                                                       \
+  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>,                                                       \
+                                    XT::Grid::bindings::Available##dim##dGridTypes>::bind(m)
+
+
 #endif // PYTHON_DUNE_GDT_FUNCTIONALS_INTERFACES_HH

--- a/python/gdt/dune/gdt/functionals/interfaces_istl_1d.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_istl_1d.cc
@@ -1,0 +1,32 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include <dune/xt/grid/grids.hh>
+#include <python/xt/dune/xt/grid/grids.bindings.hh>
+
+#include "interfaces.hh"
+
+PYBIND11_MODULE(_functionals_interfaces_istl_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>, XT::Grid::bindings::Available1dGridTypes>::bind(m);
+}

--- a/python/gdt/dune/gdt/functionals/interfaces_istl_1d.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_istl_1d.cc
@@ -16,17 +16,5 @@
 
 PYBIND11_MODULE(_functionals_interfaces_istl_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>, XT::Grid::bindings::Available1dGridTypes>::bind(m);
+  DUNE_GDT_BIND_FUNCTIONAL_INTERFACES_ISTL_MODULE(1);
 }

--- a/python/gdt/dune/gdt/functionals/interfaces_istl_2d.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_istl_2d.cc
@@ -1,0 +1,32 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include <dune/xt/grid/grids.hh>
+#include <python/xt/dune/xt/grid/grids.bindings.hh>
+
+#include "interfaces.hh"
+
+PYBIND11_MODULE(_functionals_interfaces_istl_2d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>, XT::Grid::bindings::Available2dGridTypes>::bind(m);
+}

--- a/python/gdt/dune/gdt/functionals/interfaces_istl_2d.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_istl_2d.cc
@@ -16,17 +16,5 @@
 
 PYBIND11_MODULE(_functionals_interfaces_istl_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>, XT::Grid::bindings::Available2dGridTypes>::bind(m);
+  DUNE_GDT_BIND_FUNCTIONAL_INTERFACES_ISTL_MODULE(2);
 }

--- a/python/gdt/dune/gdt/functionals/interfaces_istl_3d.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_istl_3d.cc
@@ -1,0 +1,32 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include <dune/xt/grid/grids.hh>
+#include <python/xt/dune/xt/grid/grids.bindings.hh>
+
+#include "interfaces.hh"
+
+PYBIND11_MODULE(_functionals_interfaces_istl_3d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>, XT::Grid::bindings::Available3dGridTypes>::bind(m);
+}

--- a/python/gdt/dune/gdt/functionals/interfaces_istl_3d.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_istl_3d.cc
@@ -16,17 +16,5 @@
 
 PYBIND11_MODULE(_functionals_interfaces_istl_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>, XT::Grid::bindings::Available3dGridTypes>::bind(m);
+  DUNE_GDT_BIND_FUNCTIONAL_INTERFACES_ISTL_MODULE(3);
 }

--- a/python/gdt/dune/gdt/functionals/vector-based_1d.cc
+++ b/python/gdt/dune/gdt/functionals/vector-based_1d.cc
@@ -13,34 +13,5 @@
 
 PYBIND11_MODULE(_functionals_vector_based_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  //  py::module::import("dune.gdt._local_functionals_element_interface");
-  py::module::import("dune.gdt._functionals_interfaces_common");
-  py::module::import("dune.gdt._functionals_interfaces_eigen");
-  py::module::import("dune.gdt._functionals_interfaces_istl_1d");
-  py::module::import("dune.gdt._functionals_interfaces_istl_2d");
-  py::module::import("dune.gdt._functionals_interfaces_istl_3d");
-  py::module::import("dune.gdt._spaces_interface");
-
-  //  VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>,
-  //                               LA::bindings::Common,
-  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "common_dense");
-  // #if HAVE_EIGEN
-  //  VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>,
-  //                               LA::bindings::Eigen,
-  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "eigen_dense");
-  // #endif
-  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,
-                                      LA::bindings::Istl,
-                                      XT::Grid::bindings::Available1dGridTypes>::bind(m, "istl");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_VECTOR_BASED_FUNCTIONAL_MODULE(1);
 }

--- a/python/gdt/dune/gdt/functionals/vector-based_1d.cc
+++ b/python/gdt/dune/gdt/functionals/vector-based_1d.cc
@@ -1,0 +1,46 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "vector_based_for_all_grids.hh"
+
+PYBIND11_MODULE(_functionals_vector_based_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  //  py::module::import("dune.gdt._local_functionals_element_interface");
+  py::module::import("dune.gdt._functionals_interfaces_common");
+  py::module::import("dune.gdt._functionals_interfaces_eigen");
+  py::module::import("dune.gdt._functionals_interfaces_istl_1d");
+  py::module::import("dune.gdt._functionals_interfaces_istl_2d");
+  py::module::import("dune.gdt._functionals_interfaces_istl_3d");
+  py::module::import("dune.gdt._spaces_interface");
+
+  //  VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>,
+  //                               LA::bindings::Common,
+  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "common_dense");
+  // #if HAVE_EIGEN
+  //  VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>,
+  //                               LA::bindings::Eigen,
+  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "eigen_dense");
+  // #endif
+  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,
+                                      LA::bindings::Istl,
+                                      XT::Grid::bindings::Available1dGridTypes>::bind(m, "istl");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/functionals/vector-based_2d.cc
+++ b/python/gdt/dune/gdt/functionals/vector-based_2d.cc
@@ -1,0 +1,46 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "vector_based_for_all_grids.hh"
+
+PYBIND11_MODULE(_functionals_vector_based_2d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  //  py::module::import("dune.gdt._local_functionals_element_interface");
+  py::module::import("dune.gdt._functionals_interfaces_common");
+  py::module::import("dune.gdt._functionals_interfaces_eigen");
+  py::module::import("dune.gdt._functionals_interfaces_istl_1d");
+  py::module::import("dune.gdt._functionals_interfaces_istl_2d");
+  py::module::import("dune.gdt._functionals_interfaces_istl_3d");
+  py::module::import("dune.gdt._spaces_interface");
+
+  //  VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>,
+  //                               LA::bindings::Common,
+  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "common_dense");
+  // #if HAVE_EIGEN
+  //  VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>,
+  //                               LA::bindings::Eigen,
+  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "eigen_dense");
+  // #endif
+  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,
+                                      LA::bindings::Istl,
+                                      XT::Grid::bindings::Available2dGridTypes>::bind(m, "istl");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/functionals/vector-based_2d.cc
+++ b/python/gdt/dune/gdt/functionals/vector-based_2d.cc
@@ -13,34 +13,5 @@
 
 PYBIND11_MODULE(_functionals_vector_based_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  //  py::module::import("dune.gdt._local_functionals_element_interface");
-  py::module::import("dune.gdt._functionals_interfaces_common");
-  py::module::import("dune.gdt._functionals_interfaces_eigen");
-  py::module::import("dune.gdt._functionals_interfaces_istl_1d");
-  py::module::import("dune.gdt._functionals_interfaces_istl_2d");
-  py::module::import("dune.gdt._functionals_interfaces_istl_3d");
-  py::module::import("dune.gdt._spaces_interface");
-
-  //  VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>,
-  //                               LA::bindings::Common,
-  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "common_dense");
-  // #if HAVE_EIGEN
-  //  VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>,
-  //                               LA::bindings::Eigen,
-  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "eigen_dense");
-  // #endif
-  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,
-                                      LA::bindings::Istl,
-                                      XT::Grid::bindings::Available2dGridTypes>::bind(m, "istl");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_VECTOR_BASED_FUNCTIONAL_MODULE(2);
 }

--- a/python/gdt/dune/gdt/functionals/vector-based_3d.cc
+++ b/python/gdt/dune/gdt/functionals/vector-based_3d.cc
@@ -1,0 +1,46 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "vector_based_for_all_grids.hh"
+
+PYBIND11_MODULE(_functionals_vector_based_3d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  //  py::module::import("dune.gdt._local_functionals_element_interface");
+  py::module::import("dune.gdt._functionals_interfaces_common");
+  py::module::import("dune.gdt._functionals_interfaces_eigen");
+  py::module::import("dune.gdt._functionals_interfaces_istl_1d");
+  py::module::import("dune.gdt._functionals_interfaces_istl_2d");
+  py::module::import("dune.gdt._functionals_interfaces_istl_3d");
+  py::module::import("dune.gdt._spaces_interface");
+
+  //  VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>,
+  //                               LA::bindings::Common,
+  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "common_dense");
+  // #if HAVE_EIGEN
+  //  VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>,
+  //                               LA::bindings::Eigen,
+  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "eigen_dense");
+  // #endif
+  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,
+                                      LA::bindings::Istl,
+                                      XT::Grid::bindings::Available3dGridTypes>::bind(m, "istl");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/functionals/vector-based_3d.cc
+++ b/python/gdt/dune/gdt/functionals/vector-based_3d.cc
@@ -13,34 +13,5 @@
 
 PYBIND11_MODULE(_functionals_vector_based_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  //  py::module::import("dune.gdt._local_functionals_element_interface");
-  py::module::import("dune.gdt._functionals_interfaces_common");
-  py::module::import("dune.gdt._functionals_interfaces_eigen");
-  py::module::import("dune.gdt._functionals_interfaces_istl_1d");
-  py::module::import("dune.gdt._functionals_interfaces_istl_2d");
-  py::module::import("dune.gdt._functionals_interfaces_istl_3d");
-  py::module::import("dune.gdt._spaces_interface");
-
-  //  VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>,
-  //                               LA::bindings::Common,
-  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "common_dense");
-  // #if HAVE_EIGEN
-  //  VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>,
-  //                               LA::bindings::Eigen,
-  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "eigen_dense");
-  // #endif
-  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,
-                                      LA::bindings::Istl,
-                                      XT::Grid::bindings::Available3dGridTypes>::bind(m, "istl");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_VECTOR_BASED_FUNCTIONAL_MODULE(3);
 }

--- a/python/gdt/dune/gdt/functionals/vector_based_for_all_grids.hh
+++ b/python/gdt/dune/gdt/functionals/vector_based_for_all_grids.hh
@@ -244,4 +244,37 @@ struct VectorBasedFunctional_for_all_grids<V, VT, Dune::XT::Common::tuple_null_t
 };
 
 
+// Shared by vector-based_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+// The commented-out non-istl backends are left generic (dimension is only ever spelled out
+// once, here) rather than duplicated per dimension.
+#define DUNE_GDT_BIND_VECTOR_BASED_FUNCTIONAL_MODULE(dim)                                                              \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._functionals_interfaces_common");                                                       \
+  py::module::import("dune.gdt._functionals_interfaces_eigen");                                                        \
+  py::module::import("dune.gdt._functionals_interfaces_istl_1d");                                                      \
+  py::module::import("dune.gdt._functionals_interfaces_istl_2d");                                                      \
+  py::module::import("dune.gdt._functionals_interfaces_istl_3d");                                                      \
+  py::module::import("dune.gdt._spaces_interface");                                                                    \
+                                                                                                                       \
+  /* VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>, LA::bindings::Common, */                       \
+  /* XT::Grid::bindings::AvailableNdGridTypes>::bind(m, "common_dense"); */                                            \
+  /* #if HAVE_EIGEN */                                                                                                 \
+  /* VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>, LA::bindings::Eigen, */                         \
+  /* XT::Grid::bindings::AvailableNdGridTypes>::bind(m, "eigen_dense"); */                                             \
+  /* #endif */                                                                                                         \
+  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,                                                     \
+                                      LA::bindings::Istl,                                                              \
+                                      XT::Grid::bindings::Available##dim##dGridTypes>::bind(m, "istl");                \
+  m.attr("__all__") = py::make_tuple()
+
+
 #endif // PYTHON_DUNE_GDT_FUNCTIONALS_VECTOR_BASED_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/functionals/vector_based_for_all_grids.hh
+++ b/python/gdt/dune/gdt/functionals/vector_based_for_all_grids.hh
@@ -7,7 +7,9 @@
 // Authors:
 //   Felix Schindler (2020)
 
-#include "config.h"
+#ifndef PYTHON_DUNE_GDT_FUNCTIONALS_VECTOR_BASED_FOR_ALL_GRIDS_HH
+#define PYTHON_DUNE_GDT_FUNCTIONALS_VECTOR_BASED_FOR_ALL_GRIDS_HH
+
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -242,33 +244,4 @@ struct VectorBasedFunctional_for_all_grids<V, VT, Dune::XT::Common::tuple_null_t
 };
 
 
-PYBIND11_MODULE(_functionals_vector_based, m)
-{
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  //  py::module::import("dune.gdt._local_functionals_element_interface");
-  py::module::import("dune.gdt._functionals_interfaces_common");
-  py::module::import("dune.gdt._functionals_interfaces_eigen");
-  py::module::import("dune.gdt._functionals_interfaces_istl");
-  py::module::import("dune.gdt._spaces_interface");
-
-  //  VectorBasedFunctional_for_all_grids<LA::CommonDenseVector<double>,
-  //                               LA::bindings::Common,
-  //                               XT::Grid::bindings::AvailableGridTypes>::bind(m, "common_dense");
-  // #if HAVE_EIGEN
-  //  VectorBasedFunctional_for_all_grids<LA::EigenDenseVector<double>,
-  //                               LA::bindings::Eigen,
-  //                               XT::Grid::bindings::AvailableGridTypes>::bind(m, "eigen_dense");
-  // #endif
-  VectorBasedFunctional_for_all_grids<LA::IstlDenseVector<double>,
-                                      LA::bindings::Istl,
-                                      XT::Grid::bindings::AvailableGridTypes>::bind(m, "istl");
-}
+#endif // PYTHON_DUNE_GDT_FUNCTIONALS_VECTOR_BASED_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/interpolations/boundary.cc
+++ b/python/gdt/dune/gdt/interpolations/boundary.cc
@@ -142,7 +142,9 @@ PYBIND11_MODULE(_interpolations_boundary, m)
   py::module::import("dune.xt.grid");
   py::module::import("dune.xt.functions");
 
-  py::module::import("dune.gdt._discretefunction_discretefunction");
+  py::module::import("dune.gdt._discretefunction_discretefunction_1d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_2d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_3d");
   py::module::import("dune.gdt._spaces_interface");
 
 #if 0

--- a/python/gdt/dune/gdt/interpolations/default.cc
+++ b/python/gdt/dune/gdt/interpolations/default.cc
@@ -124,7 +124,9 @@ PYBIND11_MODULE(_interpolations_default, m)
   py::module::import("dune.xt.grid");
   py::module::import("dune.xt.functions");
 
-  py::module::import("dune.gdt._discretefunction_discretefunction");
+  py::module::import("dune.gdt._discretefunction_discretefunction_1d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_2d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_3d");
   py::module::import("dune.gdt._spaces_interface");
 
 #if 0

--- a/python/gdt/dune/gdt/interpolations/oswald.cc
+++ b/python/gdt/dune/gdt/interpolations/oswald.cc
@@ -135,7 +135,9 @@ PYBIND11_MODULE(_interpolations_oswald, m)
   py::module::import("dune.xt.grid");
   py::module::import("dune.xt.functions");
 
-  py::module::import("dune.gdt._discretefunction_discretefunction");
+  py::module::import("dune.gdt._discretefunction_discretefunction_1d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_2d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_3d");
   py::module::import("dune.gdt._spaces_interface");
 
   // Only the dune-istl backend is bound, consistent with the other GDT operator/interpolation

--- a/python/gdt/dune/gdt/operators/bilinear-form_1d.cc
+++ b/python/gdt/dune/gdt/operators/bilinear-form_1d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "bilinear_form_for_all_grids.hh"
+
+PYBIND11_MODULE(_operators_bilinear_form_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
+
+  BilinearForm_for_all_grids<XT::Grid::bindings::Available1dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/bilinear-form_1d.cc
+++ b/python/gdt/dune/gdt/operators/bilinear-form_1d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_operators_bilinear_form_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
-
-  BilinearForm_for_all_grids<XT::Grid::bindings::Available1dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_BILINEAR_FORM_MODULE(1);
 }

--- a/python/gdt/dune/gdt/operators/bilinear-form_2d.cc
+++ b/python/gdt/dune/gdt/operators/bilinear-form_2d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_operators_bilinear_form_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
-
-  BilinearForm_for_all_grids<XT::Grid::bindings::Available2dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_BILINEAR_FORM_MODULE(2);
 }

--- a/python/gdt/dune/gdt/operators/bilinear-form_2d.cc
+++ b/python/gdt/dune/gdt/operators/bilinear-form_2d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "bilinear_form_for_all_grids.hh"
+
+PYBIND11_MODULE(_operators_bilinear_form_2d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
+
+  BilinearForm_for_all_grids<XT::Grid::bindings::Available2dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/bilinear-form_3d.cc
+++ b/python/gdt/dune/gdt/operators/bilinear-form_3d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_operators_bilinear_form_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
-
-  BilinearForm_for_all_grids<XT::Grid::bindings::Available3dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_BILINEAR_FORM_MODULE(3);
 }

--- a/python/gdt/dune/gdt/operators/bilinear-form_3d.cc
+++ b/python/gdt/dune/gdt/operators/bilinear-form_3d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "bilinear_form_for_all_grids.hh"
+
+PYBIND11_MODULE(_operators_bilinear_form_3d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
+
+  BilinearForm_for_all_grids<XT::Grid::bindings::Available3dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
@@ -258,4 +258,22 @@ struct BilinearForm_for_all_grids<Dune::XT::Common::tuple_null_type>
 };
 
 
+// Shared by bilinear-form_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+#define DUNE_GDT_BIND_BILINEAR_FORM_MODULE(dim)                                                                        \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._local_bilinear_forms_element_interface");                                              \
+                                                                                                                       \
+  BilinearForm_for_all_grids<XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);                                 \
+  m.attr("__all__") = py::make_tuple()
+
+
 #endif // PYTHON_DUNE_GDT_OPERATORS_BILINEAR_FORM_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
@@ -7,7 +7,9 @@
 // Authors:
 //   Felix Schindler (2020)
 
-#include "config.h"
+#ifndef PYTHON_DUNE_GDT_OPERATORS_BILINEAR_FORM_FOR_ALL_GRIDS_HH
+#define PYTHON_DUNE_GDT_OPERATORS_BILINEAR_FORM_FOR_ALL_GRIDS_HH
+
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -256,19 +258,4 @@ struct BilinearForm_for_all_grids<Dune::XT::Common::tuple_null_type>
 };
 
 
-PYBIND11_MODULE(_operators_bilinear_form, m)
-{
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
-
-  BilinearForm_for_all_grids<XT::Grid::bindings::AvailableGridTypes>::bind(m);
-}
+#endif // PYTHON_DUNE_GDT_OPERATORS_BILINEAR_FORM_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/operators/interfaces_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/interfaces_all_grids.hh
@@ -132,4 +132,25 @@ struct OperatorInterface_for_all_grids<M, MT, ST, Dune::XT::Common::tuple_null_t
 };
 
 
+// Shared by interfaces_istl_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+// Type-only (grid-named classes are unique across modules), so no __all__ / trampoline needed.
+#define DUNE_GDT_BIND_OPERATOR_INTERFACES_ISTL_MODULE(dim)                                                             \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._spaces_interface");                                                                    \
+                                                                                                                       \
+  OperatorInterface_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,                                                \
+                                  LA::bindings::Istl,                                                                  \
+                                  void,                                                                                \
+                                  XT::Grid::bindings::Available##dim##dGridTypes>::bind(m, "istl_sparse")
+
+
 #endif // PYTHON_DUNE_GDT_OPERATORS_INTERFACES_BINDINGS_HH

--- a/python/gdt/dune/gdt/operators/interfaces_istl_1d.cc
+++ b/python/gdt/dune/gdt/operators/interfaces_istl_1d.cc
@@ -15,23 +15,7 @@
 
 #include "interfaces_all_grids.hh"
 
-
 PYBIND11_MODULE(_operators_interfaces_istl_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  OperatorInterface_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                                  LA::bindings::Istl,
-                                  void,
-                                  XT::Grid::bindings::Available1dGridTypes>::bind(m, "istl_sparse");
+  DUNE_GDT_BIND_OPERATOR_INTERFACES_ISTL_MODULE(1);
 }

--- a/python/gdt/dune/gdt/operators/interfaces_istl_2d.cc
+++ b/python/gdt/dune/gdt/operators/interfaces_istl_2d.cc
@@ -10,27 +10,12 @@
 #include "config.h"
 
 #include <dune/xt/grid/grids.hh>
+#include <python/xt/dune/xt/grid/grids.bindings.hh>
 #include <python/xt/dune/xt/la/traits.hh>
 
 #include "interfaces_all_grids.hh"
 
-
 PYBIND11_MODULE(_operators_interfaces_istl_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  OperatorInterface_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                                  LA::bindings::Istl,
-                                  void,
-                                  XT::Grid::bindings::Available2dGridTypes>::bind(m, "istl_sparse");
+  DUNE_GDT_BIND_OPERATOR_INTERFACES_ISTL_MODULE(2);
 }

--- a/python/gdt/dune/gdt/operators/interfaces_istl_3d.cc
+++ b/python/gdt/dune/gdt/operators/interfaces_istl_3d.cc
@@ -10,27 +10,12 @@
 #include "config.h"
 
 #include <dune/xt/grid/grids.hh>
+#include <python/xt/dune/xt/grid/grids.bindings.hh>
 #include <python/xt/dune/xt/la/traits.hh>
 
 #include "interfaces_all_grids.hh"
 
-
 PYBIND11_MODULE(_operators_interfaces_istl_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  OperatorInterface_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                                  LA::bindings::Istl,
-                                  void,
-                                  XT::Grid::bindings::Available3dGridTypes>::bind(m, "istl_sparse");
+  DUNE_GDT_BIND_OPERATOR_INTERFACES_ISTL_MODULE(3);
 }

--- a/python/gdt/dune/gdt/operators/matrix-based_factory.hh
+++ b/python/gdt/dune/gdt/operators/matrix-based_factory.hh
@@ -61,4 +61,44 @@ struct MatrixOperatorFactory_for_all_grids<M, MT, ST, Dune::XT::Common::tuple_nu
   static void bind(pybind11::module& /*m*/, const std::string& /*matrix_id*/) {}
 };
 
+
+// Shared by matrix-based_factory_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+// The commented-out non-istl backends are left generic (dimension is only ever spelled out
+// once, here) rather than duplicated per dimension.
+#define DUNE_GDT_BIND_MATRIX_BASED_FACTORY_MODULE(dim)                                                                 \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._local_bilinear_forms_element_interface");                                              \
+  py::module::import("dune.gdt._operators_interfaces_common");                                                         \
+  py::module::import("dune.gdt._operators_interfaces_eigen");                                                          \
+  py::module::import("dune.gdt._operators_interfaces_istl_1d");                                                        \
+  py::module::import("dune.gdt._operators_interfaces_istl_2d");                                                        \
+  py::module::import("dune.gdt._operators_interfaces_istl_3d");                                                        \
+  py::module::import("dune.gdt._spaces_interface");                                                                    \
+                                                                                                                       \
+  /* MatrixOperatorFactory_for_all_grids<LA::CommonDenseMatrix<double>, LA::bindings::Common, */                       \
+  /* LA::bindings::Dense, XT::Grid::bindings::AvailableNdGridTypes>::bind(m, "common_dense"); */                       \
+  /* Generic linear solver missing for CommonSparseMatrix! */                                                          \
+  /* MatrixOperatorFactory_for_all_grids<LA::CommonSparseMatrix<double>, LA::bindings::Common, */                      \
+  /* LA::bindings::Sparse, XT::Grid::bindings::AvailableNdGridTypes>::bind(m, "common_sparse"); */                     \
+  /* #if HAVE_EIGEN */                                                                                                 \
+  /* MatrixOperatorFactory_for_all_grids<LA::EigenDenseMatrix<double>, LA::bindings::Eigen, */                         \
+  /* LA::bindings::Dense, XT::Grid::bindings::AvailableNdGridTypes>::bind(m, "eigen_dense"); */                        \
+  /* MatrixOperatorFactory_for_all_grids<LA::EigenRowMajorSparseMatrix<double>, LA::bindings::Eigen, */                \
+  /* LA::bindings::Sparse, XT::Grid::bindings::AvailableNdGridTypes>::bind(m, "eigen_sparse"); */                      \
+  /* #endif */                                                                                                         \
+  MatrixOperatorFactory_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,                                            \
+                                      LA::bindings::Istl,                                                              \
+                                      void,                                                                            \
+                                      XT::Grid::bindings::Available##dim##dGridTypes>::bind(m, "istl_sparse");         \
+  m.attr("__all__") = py::make_tuple()
+
 #endif // DUNE_GDT_PYTHON_OPERATORS_MATRIX_BASED_FACTORY_HH

--- a/python/gdt/dune/gdt/operators/matrix-based_factory_1d.cc
+++ b/python/gdt/dune/gdt/operators/matrix-based_factory_1d.cc
@@ -13,46 +13,5 @@
 
 PYBIND11_MODULE(_operators_matrix_based_factory_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
-  py::module::import("dune.gdt._operators_interfaces_common");
-  py::module::import("dune.gdt._operators_interfaces_eigen");
-  py::module::import("dune.gdt._operators_interfaces_istl_1d");
-  py::module::import("dune.gdt._operators_interfaces_istl_2d");
-  py::module::import("dune.gdt._operators_interfaces_istl_3d");
-  py::module::import("dune.gdt._spaces_interface");
-
-  //  MatrixOperatorFactory_for_all_grids<LA::CommonDenseMatrix<double>,
-  //                               LA::bindings::Common,
-  //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "common_dense");
-  //  // Generic linear solver missing for CommonSparseMatrix!
-  //  MatrixOperatorFactory_for_all_grids<LA::CommonSparseMatrix<double>,
-  //                               LA::bindings::Common,
-  //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "common_sparse");
-  // #if HAVE_EIGEN
-  //  MatrixOperatorFactory_for_all_grids<LA::EigenDenseMatrix<double>,
-  //                               LA::bindings::Eigen,
-  //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "eigen_dense");
-  //  MatrixOperatorFactory_for_all_grids<LA::EigenRowMajorSparseMatrix<double>,
-  //                               LA::bindings::Eigen,
-  //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "eigen_sparse");
-  // #endif
-  MatrixOperatorFactory_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                                      LA::bindings::Istl,
-                                      void,
-                                      XT::Grid::bindings::Available1dGridTypes>::bind(m, "istl_sparse");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_MATRIX_BASED_FACTORY_MODULE(1);
 }

--- a/python/gdt/dune/gdt/operators/matrix-based_factory_1d.cc
+++ b/python/gdt/dune/gdt/operators/matrix-based_factory_1d.cc
@@ -1,0 +1,58 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "matrix-based_factory.hh"
+
+PYBIND11_MODULE(_operators_matrix_based_factory_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
+  py::module::import("dune.gdt._operators_interfaces_common");
+  py::module::import("dune.gdt._operators_interfaces_eigen");
+  py::module::import("dune.gdt._operators_interfaces_istl_1d");
+  py::module::import("dune.gdt._operators_interfaces_istl_2d");
+  py::module::import("dune.gdt._operators_interfaces_istl_3d");
+  py::module::import("dune.gdt._spaces_interface");
+
+  //  MatrixOperatorFactory_for_all_grids<LA::CommonDenseMatrix<double>,
+  //                               LA::bindings::Common,
+  //                               LA::bindings::Dense,
+  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "common_dense");
+  //  // Generic linear solver missing for CommonSparseMatrix!
+  //  MatrixOperatorFactory_for_all_grids<LA::CommonSparseMatrix<double>,
+  //                               LA::bindings::Common,
+  //                               LA::bindings::Sparse,
+  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "common_sparse");
+  // #if HAVE_EIGEN
+  //  MatrixOperatorFactory_for_all_grids<LA::EigenDenseMatrix<double>,
+  //                               LA::bindings::Eigen,
+  //                               LA::bindings::Dense,
+  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "eigen_dense");
+  //  MatrixOperatorFactory_for_all_grids<LA::EigenRowMajorSparseMatrix<double>,
+  //                               LA::bindings::Eigen,
+  //                               LA::bindings::Sparse,
+  //                               XT::Grid::bindings::Available1dGridTypes>::bind(m, "eigen_sparse");
+  // #endif
+  MatrixOperatorFactory_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
+                                      LA::bindings::Istl,
+                                      void,
+                                      XT::Grid::bindings::Available1dGridTypes>::bind(m, "istl_sparse");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/matrix-based_factory_2d.cc
+++ b/python/gdt/dune/gdt/operators/matrix-based_factory_2d.cc
@@ -13,46 +13,5 @@
 
 PYBIND11_MODULE(_operators_matrix_based_factory_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
-  py::module::import("dune.gdt._operators_interfaces_common");
-  py::module::import("dune.gdt._operators_interfaces_eigen");
-  py::module::import("dune.gdt._operators_interfaces_istl_1d");
-  py::module::import("dune.gdt._operators_interfaces_istl_2d");
-  py::module::import("dune.gdt._operators_interfaces_istl_3d");
-  py::module::import("dune.gdt._spaces_interface");
-
-  //  MatrixOperatorFactory_for_all_grids<LA::CommonDenseMatrix<double>,
-  //                               LA::bindings::Common,
-  //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "common_dense");
-  //  // Generic linear solver missing for CommonSparseMatrix!
-  //  MatrixOperatorFactory_for_all_grids<LA::CommonSparseMatrix<double>,
-  //                               LA::bindings::Common,
-  //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "common_sparse");
-  // #if HAVE_EIGEN
-  //  MatrixOperatorFactory_for_all_grids<LA::EigenDenseMatrix<double>,
-  //                               LA::bindings::Eigen,
-  //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "eigen_dense");
-  //  MatrixOperatorFactory_for_all_grids<LA::EigenRowMajorSparseMatrix<double>,
-  //                               LA::bindings::Eigen,
-  //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "eigen_sparse");
-  // #endif
-  MatrixOperatorFactory_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                                      LA::bindings::Istl,
-                                      void,
-                                      XT::Grid::bindings::Available2dGridTypes>::bind(m, "istl_sparse");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_MATRIX_BASED_FACTORY_MODULE(2);
 }

--- a/python/gdt/dune/gdt/operators/matrix-based_factory_2d.cc
+++ b/python/gdt/dune/gdt/operators/matrix-based_factory_2d.cc
@@ -9,12 +9,9 @@
 
 #include "config.h"
 
-#include <python/xt/dune/xt/grid/grids.bindings.hh>
-
 #include "matrix-based_factory.hh"
 
-
-PYBIND11_MODULE(_operators_matrix_based_factory, m)
+PYBIND11_MODULE(_operators_matrix_based_factory_2d, m)
 {
   namespace py = pybind11;
   using namespace Dune;
@@ -37,24 +34,25 @@ PYBIND11_MODULE(_operators_matrix_based_factory, m)
   //  MatrixOperatorFactory_for_all_grids<LA::CommonDenseMatrix<double>,
   //                               LA::bindings::Common,
   //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::AvailableGridTypes>::bind(m, "common_dense");
+  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "common_dense");
   //  // Generic linear solver missing for CommonSparseMatrix!
   //  MatrixOperatorFactory_for_all_grids<LA::CommonSparseMatrix<double>,
   //                               LA::bindings::Common,
   //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::AvailableGridTypes>::bind(m, "common_sparse");
+  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "common_sparse");
   // #if HAVE_EIGEN
   //  MatrixOperatorFactory_for_all_grids<LA::EigenDenseMatrix<double>,
   //                               LA::bindings::Eigen,
   //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::AvailableGridTypes>::bind(m, "eigen_dense");
+  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "eigen_dense");
   //  MatrixOperatorFactory_for_all_grids<LA::EigenRowMajorSparseMatrix<double>,
   //                               LA::bindings::Eigen,
   //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::AvailableGridTypes>::bind(m, "eigen_sparse");
+  //                               XT::Grid::bindings::Available2dGridTypes>::bind(m, "eigen_sparse");
   // #endif
   MatrixOperatorFactory_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
                                       LA::bindings::Istl,
                                       void,
-                                      XT::Grid::bindings::AvailableGridTypes>::bind(m, "istl_sparse");
+                                      XT::Grid::bindings::Available2dGridTypes>::bind(m, "istl_sparse");
+  m.attr("__all__") = py::make_tuple();
 }

--- a/python/gdt/dune/gdt/operators/matrix-based_factory_3d.cc
+++ b/python/gdt/dune/gdt/operators/matrix-based_factory_3d.cc
@@ -1,0 +1,58 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "matrix-based_factory.hh"
+
+PYBIND11_MODULE(_operators_matrix_based_factory_3d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
+  py::module::import("dune.gdt._operators_interfaces_common");
+  py::module::import("dune.gdt._operators_interfaces_eigen");
+  py::module::import("dune.gdt._operators_interfaces_istl_1d");
+  py::module::import("dune.gdt._operators_interfaces_istl_2d");
+  py::module::import("dune.gdt._operators_interfaces_istl_3d");
+  py::module::import("dune.gdt._spaces_interface");
+
+  //  MatrixOperatorFactory_for_all_grids<LA::CommonDenseMatrix<double>,
+  //                               LA::bindings::Common,
+  //                               LA::bindings::Dense,
+  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "common_dense");
+  //  // Generic linear solver missing for CommonSparseMatrix!
+  //  MatrixOperatorFactory_for_all_grids<LA::CommonSparseMatrix<double>,
+  //                               LA::bindings::Common,
+  //                               LA::bindings::Sparse,
+  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "common_sparse");
+  // #if HAVE_EIGEN
+  //  MatrixOperatorFactory_for_all_grids<LA::EigenDenseMatrix<double>,
+  //                               LA::bindings::Eigen,
+  //                               LA::bindings::Dense,
+  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "eigen_dense");
+  //  MatrixOperatorFactory_for_all_grids<LA::EigenRowMajorSparseMatrix<double>,
+  //                               LA::bindings::Eigen,
+  //                               LA::bindings::Sparse,
+  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "eigen_sparse");
+  // #endif
+  MatrixOperatorFactory_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
+                                      LA::bindings::Istl,
+                                      void,
+                                      XT::Grid::bindings::Available3dGridTypes>::bind(m, "istl_sparse");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/matrix-based_factory_3d.cc
+++ b/python/gdt/dune/gdt/operators/matrix-based_factory_3d.cc
@@ -13,46 +13,5 @@
 
 PYBIND11_MODULE(_operators_matrix_based_factory_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_bilinear_forms_element_interface");
-  py::module::import("dune.gdt._operators_interfaces_common");
-  py::module::import("dune.gdt._operators_interfaces_eigen");
-  py::module::import("dune.gdt._operators_interfaces_istl_1d");
-  py::module::import("dune.gdt._operators_interfaces_istl_2d");
-  py::module::import("dune.gdt._operators_interfaces_istl_3d");
-  py::module::import("dune.gdt._spaces_interface");
-
-  //  MatrixOperatorFactory_for_all_grids<LA::CommonDenseMatrix<double>,
-  //                               LA::bindings::Common,
-  //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "common_dense");
-  //  // Generic linear solver missing for CommonSparseMatrix!
-  //  MatrixOperatorFactory_for_all_grids<LA::CommonSparseMatrix<double>,
-  //                               LA::bindings::Common,
-  //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "common_sparse");
-  // #if HAVE_EIGEN
-  //  MatrixOperatorFactory_for_all_grids<LA::EigenDenseMatrix<double>,
-  //                               LA::bindings::Eigen,
-  //                               LA::bindings::Dense,
-  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "eigen_dense");
-  //  MatrixOperatorFactory_for_all_grids<LA::EigenRowMajorSparseMatrix<double>,
-  //                               LA::bindings::Eigen,
-  //                               LA::bindings::Sparse,
-  //                               XT::Grid::bindings::Available3dGridTypes>::bind(m, "eigen_sparse");
-  // #endif
-  MatrixOperatorFactory_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                                      LA::bindings::Istl,
-                                      void,
-                                      XT::Grid::bindings::Available3dGridTypes>::bind(m, "istl_sparse");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_MATRIX_BASED_FACTORY_MODULE(3);
 }

--- a/python/gdt/dune/gdt/operators/operator_1d.cc
+++ b/python/gdt/dune/gdt/operators/operator_1d.cc
@@ -13,27 +13,5 @@
 
 PYBIND11_MODULE(_operators_operator_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_operators_element_interface");
-  py::module::import("dune.gdt._local_operators_intersection_interface");
-  py::module::import("dune.gdt._operators_interfaces_common");
-  py::module::import("dune.gdt._operators_interfaces_eigen");
-  py::module::import("dune.gdt._operators_interfaces_istl_1d");
-  py::module::import("dune.gdt._operators_interfaces_istl_2d");
-  py::module::import("dune.gdt._operators_interfaces_istl_3d");
-
-  /// \todo Add other la backends if required
-  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                         LA::bindings::Istl,
-                         XT::Grid::bindings::Available1dGridTypes>::bind(m, "istl_sparse");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_OPERATOR_MODULE(1);
 }

--- a/python/gdt/dune/gdt/operators/operator_1d.cc
+++ b/python/gdt/dune/gdt/operators/operator_1d.cc
@@ -1,0 +1,39 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "operator_for_all_grids.hh"
+
+PYBIND11_MODULE(_operators_operator_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_operators_element_interface");
+  py::module::import("dune.gdt._local_operators_intersection_interface");
+  py::module::import("dune.gdt._operators_interfaces_common");
+  py::module::import("dune.gdt._operators_interfaces_eigen");
+  py::module::import("dune.gdt._operators_interfaces_istl_1d");
+  py::module::import("dune.gdt._operators_interfaces_istl_2d");
+  py::module::import("dune.gdt._operators_interfaces_istl_3d");
+
+  /// \todo Add other la backends if required
+  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
+                         LA::bindings::Istl,
+                         XT::Grid::bindings::Available1dGridTypes>::bind(m, "istl_sparse");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/operator_2d.cc
+++ b/python/gdt/dune/gdt/operators/operator_2d.cc
@@ -1,0 +1,39 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "operator_for_all_grids.hh"
+
+PYBIND11_MODULE(_operators_operator_2d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_operators_element_interface");
+  py::module::import("dune.gdt._local_operators_intersection_interface");
+  py::module::import("dune.gdt._operators_interfaces_common");
+  py::module::import("dune.gdt._operators_interfaces_eigen");
+  py::module::import("dune.gdt._operators_interfaces_istl_1d");
+  py::module::import("dune.gdt._operators_interfaces_istl_2d");
+  py::module::import("dune.gdt._operators_interfaces_istl_3d");
+
+  /// \todo Add other la backends if required
+  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
+                         LA::bindings::Istl,
+                         XT::Grid::bindings::Available2dGridTypes>::bind(m, "istl_sparse");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/operator_2d.cc
+++ b/python/gdt/dune/gdt/operators/operator_2d.cc
@@ -13,27 +13,5 @@
 
 PYBIND11_MODULE(_operators_operator_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_operators_element_interface");
-  py::module::import("dune.gdt._local_operators_intersection_interface");
-  py::module::import("dune.gdt._operators_interfaces_common");
-  py::module::import("dune.gdt._operators_interfaces_eigen");
-  py::module::import("dune.gdt._operators_interfaces_istl_1d");
-  py::module::import("dune.gdt._operators_interfaces_istl_2d");
-  py::module::import("dune.gdt._operators_interfaces_istl_3d");
-
-  /// \todo Add other la backends if required
-  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                         LA::bindings::Istl,
-                         XT::Grid::bindings::Available2dGridTypes>::bind(m, "istl_sparse");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_OPERATOR_MODULE(2);
 }

--- a/python/gdt/dune/gdt/operators/operator_3d.cc
+++ b/python/gdt/dune/gdt/operators/operator_3d.cc
@@ -1,0 +1,39 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "operator_for_all_grids.hh"
+
+PYBIND11_MODULE(_operators_operator_3d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_operators_element_interface");
+  py::module::import("dune.gdt._local_operators_intersection_interface");
+  py::module::import("dune.gdt._operators_interfaces_common");
+  py::module::import("dune.gdt._operators_interfaces_eigen");
+  py::module::import("dune.gdt._operators_interfaces_istl_1d");
+  py::module::import("dune.gdt._operators_interfaces_istl_2d");
+  py::module::import("dune.gdt._operators_interfaces_istl_3d");
+
+  /// \todo Add other la backends if required
+  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
+                         LA::bindings::Istl,
+                         XT::Grid::bindings::Available3dGridTypes>::bind(m, "istl_sparse");
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/operators/operator_3d.cc
+++ b/python/gdt/dune/gdt/operators/operator_3d.cc
@@ -13,27 +13,5 @@
 
 PYBIND11_MODULE(_operators_operator_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_operators_element_interface");
-  py::module::import("dune.gdt._local_operators_intersection_interface");
-  py::module::import("dune.gdt._operators_interfaces_common");
-  py::module::import("dune.gdt._operators_interfaces_eigen");
-  py::module::import("dune.gdt._operators_interfaces_istl_1d");
-  py::module::import("dune.gdt._operators_interfaces_istl_2d");
-  py::module::import("dune.gdt._operators_interfaces_istl_3d");
-
-  /// \todo Add other la backends if required
-  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                         LA::bindings::Istl,
-                         XT::Grid::bindings::Available3dGridTypes>::bind(m, "istl_sparse");
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_OPERATOR_MODULE(3);
 }

--- a/python/gdt/dune/gdt/operators/operator_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/operator_for_all_grids.hh
@@ -7,7 +7,9 @@
 // Authors:
 //   Felix Schindler (2020)
 
-#include "config.h"
+#ifndef PYTHON_DUNE_GDT_OPERATORS_OPERATOR_FOR_ALL_GRIDS_HH
+#define PYTHON_DUNE_GDT_OPERATORS_OPERATOR_FOR_ALL_GRIDS_HH
+
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -201,28 +203,4 @@ struct Operator_for_all_grids<M, MT, Dune::XT::Common::tuple_null_type>
 };
 
 
-PYBIND11_MODULE(_operators_operator, m)
-{
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._local_operators_element_interface");
-  py::module::import("dune.gdt._local_operators_intersection_interface");
-  py::module::import("dune.gdt._operators_interfaces_common");
-  py::module::import("dune.gdt._operators_interfaces_eigen");
-  py::module::import("dune.gdt._operators_interfaces_istl_1d");
-  py::module::import("dune.gdt._operators_interfaces_istl_2d");
-  py::module::import("dune.gdt._operators_interfaces_istl_3d");
-
-  /// \todo Add other la backends if required
-  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,
-                         LA::bindings::Istl,
-                         XT::Grid::bindings::AvailableGridTypes>::bind(m, "istl_sparse");
-}
+#endif // PYTHON_DUNE_GDT_OPERATORS_OPERATOR_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/operators/operator_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/operator_for_all_grids.hh
@@ -203,4 +203,33 @@ struct Operator_for_all_grids<M, MT, Dune::XT::Common::tuple_null_type>
 };
 
 
+// Shared by operator_1d.cc/_2d.cc/_3d.cc: the only per-dimension difference is which
+// Available<dim>dGridTypes tuple gets instantiated, so the whole PYBIND11_MODULE body lives
+// here once (rather than 3x, which trips SonarCloud's copy-paste detector).
+#define DUNE_GDT_BIND_OPERATOR_MODULE(dim)                                                                             \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._local_operators_element_interface");                                                   \
+  py::module::import("dune.gdt._local_operators_intersection_interface");                                              \
+  py::module::import("dune.gdt._operators_interfaces_common");                                                         \
+  py::module::import("dune.gdt._operators_interfaces_eigen");                                                          \
+  py::module::import("dune.gdt._operators_interfaces_istl_1d");                                                        \
+  py::module::import("dune.gdt._operators_interfaces_istl_2d");                                                        \
+  py::module::import("dune.gdt._operators_interfaces_istl_3d");                                                        \
+                                                                                                                       \
+  /* \todo Add other la backends if required */                                                                        \
+  Operator_for_all_grids<LA::IstlRowMajorSparseMatrix<double>,                                                         \
+                         LA::bindings::Istl,                                                                           \
+                         XT::Grid::bindings::Available##dim##dGridTypes>::bind(m, "istl_sparse");                      \
+  m.attr("__all__") = py::make_tuple()
+
+
 #endif // PYTHON_DUNE_GDT_OPERATORS_OPERATOR_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/prolongations.cc
+++ b/python/gdt/dune/gdt/prolongations.cc
@@ -160,7 +160,9 @@ PYBIND11_MODULE(_prolongations, m)
   py::module::import("dune.xt.grid");
   py::module::import("dune.xt.functions");
 
-  py::module::import("dune.gdt._discretefunction_discretefunction");
+  py::module::import("dune.gdt._discretefunction_discretefunction_1d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_2d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_3d");
   py::module::import("dune.gdt._spaces_interface");
 
 #if 0

--- a/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_1d.cc
+++ b/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_1d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_spaces_h1_continuous_lagrange_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available1dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_CONTINUOUS_LAGRANGE_MODULE(1);
 }

--- a/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_1d.cc
+++ b/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_1d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "continuous_lagrange_for_all_grids.hh"
+
+PYBIND11_MODULE(_spaces_h1_continuous_lagrange_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available1dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_2d.cc
+++ b/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_2d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "continuous_lagrange_for_all_grids.hh"
+
+PYBIND11_MODULE(_spaces_h1_continuous_lagrange_2d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available2dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_2d.cc
+++ b/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_2d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_spaces_h1_continuous_lagrange_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available2dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_CONTINUOUS_LAGRANGE_MODULE(2);
 }

--- a/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_3d.cc
+++ b/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_3d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_spaces_h1_continuous_lagrange_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available3dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_CONTINUOUS_LAGRANGE_MODULE(3);
 }

--- a/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_3d.cc
+++ b/python/gdt/dune/gdt/spaces/h1/continuous-lagrange_3d.cc
@@ -9,13 +9,9 @@
 
 #include "config.h"
 
-#include <dune/xt/grid/grids.hh>
-#include <python/xt/dune/xt/grid/grids.bindings.hh>
+#include "continuous_lagrange_for_all_grids.hh"
 
-#include "interfaces.hh"
-
-
-PYBIND11_MODULE(_functionals_interfaces_istl, m)
+PYBIND11_MODULE(_spaces_h1_continuous_lagrange_3d, m)
 {
   namespace py = pybind11;
   using namespace Dune;
@@ -29,5 +25,6 @@ PYBIND11_MODULE(_functionals_interfaces_istl, m)
 
   py::module::import("dune.gdt._spaces_interface");
 
-  FunctionalInterface_for_all_grids<LA::IstlDenseVector<double>, XT::Grid::bindings::AvailableGridTypes>::bind(m);
+  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available3dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
 }

--- a/python/gdt/dune/gdt/spaces/h1/continuous_lagrange_for_all_grids.hh
+++ b/python/gdt/dune/gdt/spaces/h1/continuous_lagrange_for_all_grids.hh
@@ -7,7 +7,9 @@
 // Authors:
 //   Felix Schindler (2020)
 
-#include "config.h"
+#ifndef PYTHON_DUNE_GDT_SPACES_H1_CONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH
+#define PYTHON_DUNE_GDT_SPACES_H1_CONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH
+
 
 #include <python/xt/dune/xt/grid/grids.bindings.hh>
 
@@ -39,19 +41,4 @@ struct ContinuousLagrangeSpace_for_all_grids<Dune::XT::Common::tuple_null_type>
 };
 
 
-PYBIND11_MODULE(_spaces_h1_continuous_lagrange, m)
-{
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::AvailableGridTypes>::bind(m);
-}
+#endif // PYTHON_DUNE_GDT_SPACES_H1_CONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/spaces/h1/continuous_lagrange_for_all_grids.hh
+++ b/python/gdt/dune/gdt/spaces/h1/continuous_lagrange_for_all_grids.hh
@@ -41,4 +41,22 @@ struct ContinuousLagrangeSpace_for_all_grids<Dune::XT::Common::tuple_null_type>
 };
 
 
+// Shared by continuous-lagrange_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+#define DUNE_GDT_BIND_CONTINUOUS_LAGRANGE_MODULE(dim)                                                                  \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._spaces_interface");                                                                    \
+                                                                                                                       \
+  ContinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);                      \
+  m.attr("__all__") = py::make_tuple()
+
+
 #endif // PYTHON_DUNE_GDT_SPACES_H1_CONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_1d.cc
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_1d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "discontinuous_lagrange_for_all_grids.hh"
+
+PYBIND11_MODULE(_spaces_l2_discontinuous_lagrange_1d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available1dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_1d.cc
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_1d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_spaces_l2_discontinuous_lagrange_1d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available1dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_DISCONTINUOUS_LAGRANGE_MODULE(1);
 }

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_2d.cc
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_2d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_spaces_l2_discontinuous_lagrange_2d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available2dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_DISCONTINUOUS_LAGRANGE_MODULE(2);
 }

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_2d.cc
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_2d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "discontinuous_lagrange_for_all_grids.hh"
+
+PYBIND11_MODULE(_spaces_l2_discontinuous_lagrange_2d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available2dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_3d.cc
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_3d.cc
@@ -1,0 +1,30 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#include "config.h"
+
+#include "discontinuous_lagrange_for_all_grids.hh"
+
+PYBIND11_MODULE(_spaces_l2_discontinuous_lagrange_3d, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._spaces_interface");
+
+  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available3dGridTypes>::bind(m);
+  m.attr("__all__") = py::make_tuple();
+}

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_3d.cc
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange_3d.cc
@@ -13,18 +13,5 @@
 
 PYBIND11_MODULE(_spaces_l2_discontinuous_lagrange_3d, m)
 {
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available3dGridTypes>::bind(m);
-  m.attr("__all__") = py::make_tuple();
+  DUNE_GDT_BIND_DISCONTINUOUS_LAGRANGE_MODULE(3);
 }

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous_lagrange_for_all_grids.hh
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous_lagrange_for_all_grids.hh
@@ -44,4 +44,22 @@ struct DiscontinuousLagrangeSpace_for_all_grids<Dune::XT::Common::tuple_null_typ
 };
 
 
+// Shared by discontinuous-lagrange_1d.cc/_2d.cc/_3d.cc: see DUNE_GDT_BIND_OPERATOR_MODULE for rationale.
+#define DUNE_GDT_BIND_DISCONTINUOUS_LAGRANGE_MODULE(dim)                                                               \
+  namespace py = pybind11;                                                                                             \
+  using namespace Dune;                                                                                                \
+  using namespace Dune::XT;                                                                                            \
+  using namespace Dune::GDT;                                                                                           \
+                                                                                                                       \
+  py::module::import("dune.xt.common");                                                                                \
+  py::module::import("dune.xt.la");                                                                                    \
+  py::module::import("dune.xt.grid");                                                                                  \
+  py::module::import("dune.xt.functions");                                                                             \
+                                                                                                                       \
+  py::module::import("dune.gdt._spaces_interface");                                                                    \
+                                                                                                                       \
+  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);                   \
+  m.attr("__all__") = py::make_tuple()
+
+
 #endif // PYTHON_DUNE_GDT_SPACES_L2_DISCONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous_lagrange_for_all_grids.hh
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous_lagrange_for_all_grids.hh
@@ -7,7 +7,9 @@
 // Authors:
 //   Felix Schindler (2020)
 
-#include "config.h"
+#ifndef PYTHON_DUNE_GDT_SPACES_L2_DISCONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH
+#define PYTHON_DUNE_GDT_SPACES_L2_DISCONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH
+
 
 #include <python/xt/dune/xt/grid/grids.bindings.hh>
 
@@ -42,19 +44,4 @@ struct DiscontinuousLagrangeSpace_for_all_grids<Dune::XT::Common::tuple_null_typ
 };
 
 
-PYBIND11_MODULE(_spaces_l2_discontinuous_lagrange, m)
-{
-  namespace py = pybind11;
-  using namespace Dune;
-  using namespace Dune::XT;
-  using namespace Dune::GDT;
-
-  py::module::import("dune.xt.common");
-  py::module::import("dune.xt.la");
-  py::module::import("dune.xt.grid");
-  py::module::import("dune.xt.functions");
-
-  py::module::import("dune.gdt._spaces_interface");
-
-  DiscontinuousLagrangeSpace_for_all_grids<XT::Grid::bindings::AvailableGridTypes>::bind(m);
-}
+#endif // PYTHON_DUNE_GDT_SPACES_L2_DISCONTINUOUS_LAGRANGE_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/tools/adaptation-helper.cc
+++ b/python/gdt/dune/gdt/tools/adaptation-helper.cc
@@ -244,7 +244,9 @@ PYBIND11_MODULE(_tools_adaptation_helper, m)
   py::module::import("dune.xt.functions");
 
   py::module::import("dune.gdt._spaces_interface");
-  py::module::import("dune.gdt._discretefunction_discretefunction");
+  py::module::import("dune.gdt._discretefunction_discretefunction_1d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_2d");
+  py::module::import("dune.gdt._discretefunction_discretefunction_3d");
 
   //  AdaptationHelper_for_all_grids<LA::CommonDenseVector<double>, LA::bindings::Common>::bind(m);
   // #if HAVE_EIGEN

--- a/python/gdt/test/test_hypothesis_mixed_grids.py
+++ b/python/gdt/test/test_hypothesis_mixed_grids.py
@@ -1,0 +1,85 @@
+# ~~~
+# This file is part of the dune-gdt project:
+#   https://github.com/dune-gdt/dune-gdt
+# Copyright 2010-2026 dune-gdt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""WP3 (#320): mixed-element and prism grids via UGGrid.
+
+The structured grid_specs used by the other hypothesis suites always carry a single geometry type
+per grid, so the per-geometry-type DoF bookkeeping of the DG mapper is never exercised on a mesh
+that mixes cubes and simplices. UGGrid can, and make_mixed_grid / make_prism_grid (mirroring the
+C++ fixtures in dune/gdt/test/spaces/base.hh) build exactly such meshes. This module pins
+
+  * the per-geometry-type element counts (the fixtures have a fixed topology), and
+  * the DG DoF-count property generalized to mixed grids: the global DoF count is the sum over
+    elements of the local (per-geometry) Lagrange DoF count, at any refinement level.
+"""
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    MIXED_GRID_ELEMENTS,
+    PRISM_GRID_ELEMENTS,
+    dg_dof_count_on_mixed_grid,
+    element_geometry_counts,
+    has_uggrid,
+    make_mixed_grid_provider,
+    make_prism_grid_provider,
+)
+
+# UGGrid is an optional dependency; without it there are no mixed/prism factories to test.
+pytestmark = pytest.mark.skipif(
+    not has_uggrid(), reason="no UGGrid bindings available in this build"
+)
+
+
+@pytest.mark.parametrize("dim", [2, 3])
+def test_mixed_grid_has_the_expected_geometry_types(dim):
+    grid = make_mixed_grid_provider(dim)
+    counts = element_geometry_counts(grid)
+    assert counts == MIXED_GRID_ELEMENTS[dim]
+    assert sum(counts.values()) == grid.size(0)
+    # a genuinely mixed mesh: more than one geometry type is present
+    assert len([c for c in counts.values() if c]) > 1
+
+
+def test_prism_grid_is_a_single_prism():
+    grid = make_prism_grid_provider()
+    counts = element_geometry_counts(grid)
+    assert counts == PRISM_GRID_ELEMENTS[3]
+    assert sum(counts.values()) == grid.size(0)
+
+
+@given(
+    dim=st.sampled_from([2, 3]), order=st.integers(0, 2), refinements=st.integers(0, 1)
+)
+def test_dg_dof_count_generalizes_to_mixed_grids(dim, order, refinements):
+    from dune.gdt import DiscontinuousLagrangeSpace
+
+    grid = make_mixed_grid_provider(dim, num_refinements=refinements)
+    space = DiscontinuousLagrangeSpace(grid, order=order)
+    # the DG DoF count is per element and per geometry type: cubes contribute Q_k, simplices P_k;
+    # summing over the actually present elements must reproduce the mapper's global count exactly
+    assert space.num_DoFs == dg_dof_count_on_mixed_grid(grid, order)
+
+
+@given(refinements=st.integers(0, 1))
+def test_refinement_preserves_the_mixed_geometry_types(refinements):
+    grid = make_mixed_grid_provider(2, num_refinements=refinements)
+    counts = element_geometry_counts(grid)
+    # refinement multiplies the element counts but never introduces an unclassifiable geometry
+    assert "unknown" not in counts
+    assert set(counts) == set(MIXED_GRID_ELEMENTS[2])
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)

--- a/python/xt/dune/xt/grid/CMakeLists.txt
+++ b/python/xt/dune/xt/grid/CMakeLists.txt
@@ -28,6 +28,7 @@ dune_pybindxi_add_module(_grid_functors_interfaces EXCLUDE_FROM_ALL functors/int
 # dune_pybindxi_add_module(_grid_functors_refinement EXCLUDE_FROM_ALL functors/refinement.cc)
 dune_pybindxi_add_module(_grid_gridprovider_cube EXCLUDE_FROM_ALL gridprovider/cube.cc)
 dune_pybindxi_add_module(_grid_gridprovider_gmsh EXCLUDE_FROM_ALL gridprovider/gmsh.cc)
+dune_pybindxi_add_module(_grid_gridprovider_unstructured EXCLUDE_FROM_ALL gridprovider/unstructured.cc)
 dune_pybindxi_add_module(_grid_intersection EXCLUDE_FROM_ALL intersection.cc)
 dune_pybindxi_add_module(_grid_gridprovider_provider EXCLUDE_FROM_ALL gridprovider/provider.cc)
 dune_pybindxi_add_module(_grid_traits EXCLUDE_FROM_ALL traits.cc)

--- a/python/xt/dune/xt/grid/__init__.py
+++ b/python/xt/dune/xt/grid/__init__.py
@@ -33,6 +33,7 @@ for mod_name in (
     # '_grid_functors_refinement',
     "_grid_gridprovider_cube",
     "_grid_gridprovider_gmsh",
+    "_grid_gridprovider_unstructured",
     "_grid_gridprovider_provider",
     "_grid_dd_glued_gridprovider_cube",
     "_grid_dd_glued_gridprovider_provider",

--- a/python/xt/dune/xt/grid/gridprovider/unstructured.cc
+++ b/python/xt/dune/xt/grid/gridprovider/unstructured.cc
@@ -1,0 +1,147 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include "config.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <dune/geometry/type.hh>
+#include <dune/grid/common/gridfactory.hh>
+
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/grid/gridprovider/provider.hh>
+#include <dune/xt/grid/grids.hh>
+
+#include <python/xt/dune/xt/common/bindings.hh>
+#include <python/xt/dune/xt/common/fvector.hh>
+#include <python/xt/dune/xt/grid/traits.hh>
+
+using namespace Dune;
+using namespace Dune::XT::Grid::bindings;
+
+
+// The mixed-element and prism factories below mirror the C++ test fixtures make_mixed_grid /
+// make_prism_grid (dune/gdt/test/spaces/base.hh), which are currently the only place those element
+// types are exercised anywhere. Only UGGrid can hold a mesh with more than one geometry type (or a
+// prism), so these factories are instantiated for UG grids exclusively.
+#if HAVE_DUNE_UGGRID || HAVE_UG
+
+
+template <class G>
+struct make_prism_grid
+{
+  static constexpr size_t d = G::dimension;
+  static_assert(d == 3, "prism grids are only meaningful in 3d");
+
+  static void bind(pybind11::module& m)
+  {
+    using namespace pybind11::literals;
+    using D = typename G::ctype;
+
+    m.def(
+        "make_prism_grid",
+        [](const Dimension<d>&, const unsigned int num_refinements) {
+          GridFactory<G> factory;
+          for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
+                                XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
+                                XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
+                                XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
+                                XT::Common::FieldVector<D, d>({-1., -1., -1.}),
+                                XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.})}) {
+            factory.insertVertex(vertex);
+          }
+          factory.insertElement(GeometryTypes::prism, {0, 1, 2, 3, 4, 5});
+          XT::Grid::GridProvider<G> grid(factory.createGrid());
+          grid.global_refine(num_refinements);
+          return grid;
+        },
+        "dimension"_a,
+        "num_refinements"_a = 0);
+  } // ... bind(...)
+}; // struct make_prism_grid
+
+
+template <class G>
+struct make_mixed_grid
+{
+  static constexpr size_t d = G::dimension;
+  static_assert(d == 2 || d == 3, "mixed-element grids are only implemented in 2d and 3d");
+
+  static void bind(pybind11::module& m)
+  {
+    using namespace pybind11::literals;
+    using D = typename G::ctype;
+
+    m.def(
+        "make_mixed_grid",
+        [](const Dimension<d>&, const unsigned int num_refinements) {
+          GridFactory<G> factory;
+          if constexpr (d == 2) {
+            for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1., -1.25}),
+                                  XT::Common::FieldVector<D, d>({-1., -1.}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1.25}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1.}),
+                                  XT::Common::FieldVector<D, d>({-1.75, -1.25})}) {
+              factory.insertVertex(vertex);
+            }
+            factory.insertElement(GeometryTypes::cube(2), {3, 0, 4, 1});
+            factory.insertElement(GeometryTypes::cube(2), {4, 1, 5, 2});
+            factory.insertElement(GeometryTypes::simplex(2), {4, 6, 3});
+            factory.insertElement(GeometryTypes::simplex(2), {4, 5, 6});
+          } else {
+            for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
+                                  XT::Common::FieldVector<D, d>({-1., -1.25, -1.}),
+                                  XT::Common::FieldVector<D, d>({-1., -1., -1.}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1., -1.}),
+                                  XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1., -1.25, -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1.5, -1., -1.5}),
+                                  XT::Common::FieldVector<D, d>({-1.75, -1.25, -1.})}) {
+              factory.insertVertex(vertex);
+            }
+            factory.insertElement(GeometryTypes::cube(3), {3, 0, 4, 1, 9, 6, 10, 7});
+            factory.insertElement(GeometryTypes::cube(3), {4, 1, 5, 2, 10, 7, 11, 8});
+            factory.insertElement(GeometryTypes::simplex(3), {4, 12, 3, 10});
+            factory.insertElement(GeometryTypes::simplex(3), {4, 5, 12, 10});
+          }
+          XT::Grid::GridProvider<G> grid(factory.createGrid());
+          grid.global_refine(num_refinements);
+          return grid;
+        },
+        "dimension"_a,
+        "num_refinements"_a = 0);
+  } // ... bind(...)
+}; // struct make_mixed_grid
+
+
+#endif // HAVE_DUNE_UGGRID || HAVE_UG
+
+
+PYBIND11_MODULE(_grid_gridprovider_unstructured, m)
+{
+  namespace py = pybind11;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.grid._grid_gridprovider_provider");
+  py::module::import("dune.xt.grid._grid_traits");
+
+#if HAVE_DUNE_UGGRID || HAVE_UG
+  make_mixed_grid<UG_2D>::bind(m);
+  make_mixed_grid<UG_3D>::bind(m);
+  make_prism_grid<UG_3D>::bind(m);
+#endif
+}

--- a/python/xt/dune/xt/grid/gridprovider/unstructured.cc
+++ b/python/xt/dune/xt/grid/gridprovider/unstructured.cc
@@ -12,103 +12,21 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <dune/geometry/type.hh>
-#include <dune/grid/common/gridfactory.hh>
-
-#include <dune/xt/common/fvector.hh>
-#include <dune/xt/grid/gridprovider/provider.hh>
+#include <dune/xt/grid/gridprovider/unstructured.hh>
 #include <dune/xt/grid/grids.hh>
 
 #include <python/xt/dune/xt/common/bindings.hh>
-#include <python/xt/dune/xt/common/fvector.hh>
 #include <python/xt/dune/xt/grid/traits.hh>
 
 using namespace Dune;
 using namespace Dune::XT::Grid::bindings;
 
 
-// The mixed-element and prism factories below mirror the C++ test fixtures make_mixed_grid /
-// make_prism_grid (dune/gdt/test/spaces/base.hh), which are currently the only place those element
-// types are exercised anywhere. Only UGGrid can hold a mesh with more than one geometry type (or a
-// prism), so these factories are instantiated for UG grids exclusively.
+// make_mixed_grid / make_prism_grid (dune/xt/grid/gridprovider/unstructured.hh) build meshes with
+// more than one geometry type (or a prism), which only UGGrid can hold -- so they are bound for UG
+// grids exclusively. The very same factories build the meshes used by the C++ space tests
+// (dune/gdt/test/spaces/base.hh), so the bindings exercise identical meshes.
 #if HAVE_DUNE_UGGRID || HAVE_UG
-
-
-// Shared tail: create the grid from a filled factory and refine it. Keeping it in one place (rather
-// than repeating it in every builder) is both less code and less duplication for the analysers.
-template <class G>
-XT::Grid::GridProvider<G> build_and_refine(GridFactory<G>& factory, const unsigned int num_refinements)
-{
-  XT::Grid::GridProvider<G> grid(factory.createGrid());
-  grid.global_refine(num_refinements);
-  return grid;
-}
-
-
-template <class G>
-XT::Grid::GridProvider<G> make_prism_grid(const unsigned int num_refinements)
-{
-  using D = typename G::ctype;
-  static constexpr size_t d = G::dimension;
-  static_assert(d == 3, "prism grids are only meaningful in 3d");
-  GridFactory<G> factory;
-  for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
-                        XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
-                        XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
-                        XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
-                        XT::Common::FieldVector<D, d>({-1., -1., -1.}),
-                        XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.})}) {
-    factory.insertVertex(vertex);
-  }
-  factory.insertElement(GeometryTypes::prism, {0, 1, 2, 3, 4, 5});
-  return build_and_refine(factory, num_refinements);
-}
-
-
-template <class G>
-XT::Grid::GridProvider<G> make_mixed_grid(const unsigned int num_refinements)
-{
-  using D = typename G::ctype;
-  static constexpr size_t d = G::dimension;
-  static_assert(d == 2 || d == 3, "mixed-element grids are only implemented in 2d and 3d");
-  GridFactory<G> factory;
-  if constexpr (d == 2) {
-    for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5}),
-                          XT::Common::FieldVector<D, d>({-1., -1.25}),
-                          XT::Common::FieldVector<D, d>({-1., -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.25}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.}),
-                          XT::Common::FieldVector<D, d>({-1.75, -1.25})}) {
-      factory.insertVertex(vertex);
-    }
-    factory.insertElement(GeometryTypes::cube(2), {3, 0, 4, 1});
-    factory.insertElement(GeometryTypes::cube(2), {4, 1, 5, 2});
-    factory.insertElement(GeometryTypes::simplex(2), {4, 6, 3});
-    factory.insertElement(GeometryTypes::simplex(2), {4, 5, 6});
-  } else {
-    for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
-                          XT::Common::FieldVector<D, d>({-1., -1.25, -1.}),
-                          XT::Common::FieldVector<D, d>({-1., -1., -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1., -1.}),
-                          XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1., -1.25, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.5, -1., -1.5}),
-                          XT::Common::FieldVector<D, d>({-1.75, -1.25, -1.})}) {
-      factory.insertVertex(vertex);
-    }
-    factory.insertElement(GeometryTypes::cube(3), {3, 0, 4, 1, 9, 6, 10, 7});
-    factory.insertElement(GeometryTypes::cube(3), {4, 1, 5, 2, 10, 7, 11, 8});
-    factory.insertElement(GeometryTypes::simplex(3), {4, 12, 3, 10});
-    factory.insertElement(GeometryTypes::simplex(3), {4, 5, 12, 10});
-  }
-  return build_and_refine(factory, num_refinements);
-}
 
 
 // Both factories share the same python signature -- (Dim, num_refinements) -> GridProvider -- so a
@@ -139,8 +57,8 @@ PYBIND11_MODULE(_grid_gridprovider_unstructured, m)
   py::module::import("dune.xt.grid._grid_traits");
 
 #if HAVE_DUNE_UGGRID || HAVE_UG
-  bind_unstructured_factory<UG_2D, &make_mixed_grid<UG_2D>>(m, "make_mixed_grid");
-  bind_unstructured_factory<UG_3D, &make_mixed_grid<UG_3D>>(m, "make_mixed_grid");
-  bind_unstructured_factory<UG_3D, &make_prism_grid<UG_3D>>(m, "make_prism_grid");
+  bind_unstructured_factory<UG_2D, &XT::Grid::make_mixed_grid<UG_2D>>(m, "make_mixed_grid");
+  bind_unstructured_factory<UG_3D, &XT::Grid::make_mixed_grid<UG_3D>>(m, "make_mixed_grid");
+  bind_unstructured_factory<UG_3D, &XT::Grid::make_prism_grid<UG_3D>>(m, "make_prism_grid");
 #endif
 }

--- a/python/xt/dune/xt/grid/gridprovider/unstructured.cc
+++ b/python/xt/dune/xt/grid/gridprovider/unstructured.cc
@@ -34,98 +34,97 @@ using namespace Dune::XT::Grid::bindings;
 #if HAVE_DUNE_UGGRID || HAVE_UG
 
 
+// Shared tail: create the grid from a filled factory and refine it. Keeping it in one place (rather
+// than repeating it in every builder) is both less code and less duplication for the analysers.
 template <class G>
-struct make_prism_grid
+XT::Grid::GridProvider<G> build_and_refine(GridFactory<G>& factory, const unsigned int num_refinements)
 {
+  XT::Grid::GridProvider<G> grid(factory.createGrid());
+  grid.global_refine(num_refinements);
+  return grid;
+}
+
+
+template <class G>
+XT::Grid::GridProvider<G> make_prism_grid(const unsigned int num_refinements)
+{
+  using D = typename G::ctype;
   static constexpr size_t d = G::dimension;
   static_assert(d == 3, "prism grids are only meaningful in 3d");
-
-  static void bind(pybind11::module& m)
-  {
-    using namespace pybind11::literals;
-    using D = typename G::ctype;
-
-    m.def(
-        "make_prism_grid",
-        [](const Dimension<d>&, const unsigned int num_refinements) {
-          GridFactory<G> factory;
-          for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
-                                XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
-                                XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
-                                XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
-                                XT::Common::FieldVector<D, d>({-1., -1., -1.}),
-                                XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.})}) {
-            factory.insertVertex(vertex);
-          }
-          factory.insertElement(GeometryTypes::prism, {0, 1, 2, 3, 4, 5});
-          XT::Grid::GridProvider<G> grid(factory.createGrid());
-          grid.global_refine(num_refinements);
-          return grid;
-        },
-        "dimension"_a,
-        "num_refinements"_a = 0);
-  } // ... bind(...)
-}; // struct make_prism_grid
+  GridFactory<G> factory;
+  for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
+                        XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
+                        XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
+                        XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
+                        XT::Common::FieldVector<D, d>({-1., -1., -1.}),
+                        XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.})}) {
+    factory.insertVertex(vertex);
+  }
+  factory.insertElement(GeometryTypes::prism, {0, 1, 2, 3, 4, 5});
+  return build_and_refine(factory, num_refinements);
+}
 
 
 template <class G>
-struct make_mixed_grid
+XT::Grid::GridProvider<G> make_mixed_grid(const unsigned int num_refinements)
 {
+  using D = typename G::ctype;
   static constexpr size_t d = G::dimension;
   static_assert(d == 2 || d == 3, "mixed-element grids are only implemented in 2d and 3d");
+  GridFactory<G> factory;
+  if constexpr (d == 2) {
+    for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5}),
+                          XT::Common::FieldVector<D, d>({-1., -1.25}),
+                          XT::Common::FieldVector<D, d>({-1., -1.}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1.5}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1.25}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1.}),
+                          XT::Common::FieldVector<D, d>({-1.75, -1.25})}) {
+      factory.insertVertex(vertex);
+    }
+    factory.insertElement(GeometryTypes::cube(2), {3, 0, 4, 1});
+    factory.insertElement(GeometryTypes::cube(2), {4, 1, 5, 2});
+    factory.insertElement(GeometryTypes::simplex(2), {4, 6, 3});
+    factory.insertElement(GeometryTypes::simplex(2), {4, 5, 6});
+  } else {
+    for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
+                          XT::Common::FieldVector<D, d>({-1., -1.25, -1.}),
+                          XT::Common::FieldVector<D, d>({-1., -1., -1.}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1., -1.}),
+                          XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
+                          XT::Common::FieldVector<D, d>({-1., -1.25, -1.5}),
+                          XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.5}),
+                          XT::Common::FieldVector<D, d>({-1.5, -1., -1.5}),
+                          XT::Common::FieldVector<D, d>({-1.75, -1.25, -1.})}) {
+      factory.insertVertex(vertex);
+    }
+    factory.insertElement(GeometryTypes::cube(3), {3, 0, 4, 1, 9, 6, 10, 7});
+    factory.insertElement(GeometryTypes::cube(3), {4, 1, 5, 2, 10, 7, 11, 8});
+    factory.insertElement(GeometryTypes::simplex(3), {4, 12, 3, 10});
+    factory.insertElement(GeometryTypes::simplex(3), {4, 5, 12, 10});
+  }
+  return build_and_refine(factory, num_refinements);
+}
 
-  static void bind(pybind11::module& m)
-  {
-    using namespace pybind11::literals;
-    using D = typename G::ctype;
 
-    m.def(
-        "make_mixed_grid",
-        [](const Dimension<d>&, const unsigned int num_refinements) {
-          GridFactory<G> factory;
-          if constexpr (d == 2) {
-            for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1., -1.25}),
-                                  XT::Common::FieldVector<D, d>({-1., -1.}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1.25}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1.}),
-                                  XT::Common::FieldVector<D, d>({-1.75, -1.25})}) {
-              factory.insertVertex(vertex);
-            }
-            factory.insertElement(GeometryTypes::cube(2), {3, 0, 4, 1});
-            factory.insertElement(GeometryTypes::cube(2), {4, 1, 5, 2});
-            factory.insertElement(GeometryTypes::simplex(2), {4, 6, 3});
-            factory.insertElement(GeometryTypes::simplex(2), {4, 5, 6});
-          } else {
-            for (auto&& vertex : {XT::Common::FieldVector<D, d>({-1., -1.5, -1.}),
-                                  XT::Common::FieldVector<D, d>({-1., -1.25, -1.}),
-                                  XT::Common::FieldVector<D, d>({-1., -1., -1.}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1., -1.}),
-                                  XT::Common::FieldVector<D, d>({-1., -1.5, -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1., -1.25, -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1., -1., -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1.5, -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1.25, -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1.5, -1., -1.5}),
-                                  XT::Common::FieldVector<D, d>({-1.75, -1.25, -1.})}) {
-              factory.insertVertex(vertex);
-            }
-            factory.insertElement(GeometryTypes::cube(3), {3, 0, 4, 1, 9, 6, 10, 7});
-            factory.insertElement(GeometryTypes::cube(3), {4, 1, 5, 2, 10, 7, 11, 8});
-            factory.insertElement(GeometryTypes::simplex(3), {4, 12, 3, 10});
-            factory.insertElement(GeometryTypes::simplex(3), {4, 5, 12, 10});
-          }
-          XT::Grid::GridProvider<G> grid(factory.createGrid());
-          grid.global_refine(num_refinements);
-          return grid;
-        },
-        "dimension"_a,
-        "num_refinements"_a = 0);
-  } // ... bind(...)
-}; // struct make_mixed_grid
+// Both factories share the same python signature -- (Dim, num_refinements) -> GridProvider -- so a
+// single generic binder expresses it once; the concrete builder is passed as a function pointer.
+template <class G, XT::Grid::GridProvider<G> (*factory_function)(unsigned int)>
+void bind_unstructured_factory(pybind11::module& m, const std::string& name)
+{
+  using namespace pybind11::literals;
+  m.def(
+      name.c_str(),
+      [](const Dimension<G::dimension>&, const unsigned int num_refinements) {
+        return factory_function(num_refinements);
+      },
+      "dimension"_a,
+      "num_refinements"_a = 0);
+}
 
 
 #endif // HAVE_DUNE_UGGRID || HAVE_UG
@@ -140,8 +139,8 @@ PYBIND11_MODULE(_grid_gridprovider_unstructured, m)
   py::module::import("dune.xt.grid._grid_traits");
 
 #if HAVE_DUNE_UGGRID || HAVE_UG
-  make_mixed_grid<UG_2D>::bind(m);
-  make_mixed_grid<UG_3D>::bind(m);
-  make_prism_grid<UG_3D>::bind(m);
+  bind_unstructured_factory<UG_2D, &make_mixed_grid<UG_2D>>(m, "make_mixed_grid");
+  bind_unstructured_factory<UG_3D, &make_mixed_grid<UG_3D>>(m, "make_mixed_grid");
+  bind_unstructured_factory<UG_3D, &make_prism_grid<UG_3D>>(m, "make_prism_grid");
 #endif
 }

--- a/python/xt/dune/xt/grid/grids.bindings.hh
+++ b/python/xt/dune/xt/grid/grids.bindings.hh
@@ -214,6 +214,10 @@ struct grid_name<UGGrid<dim>>
 /// 2d cube ALUGrid at all. Only the 3d hexahedral cube grid has a leaf view (ALU3dGrid<hexa>)
 /// distinct from the tetrahedral simplex and structured YASP views, so only it is added here.
 /// unique_grid_tuple_t guards the grid tuples against any exact-type aliasing on top.
+///
+/// WP3 (#320) adds UGGrid, the only bound grid manager that supports mixed-element and prism meshes,
+/// as the backend for make_mixed_grid / make_prism_grid (see gridprovider/unstructured.cc); it is
+/// added below so that GridProvider, spaces and operators are instantiated for it across the binding TUs.
 
 using Available1dGridTypes = std::tuple<ONED_1D, YASP_1D_EQUIDISTANT_OFFSET>;
 
@@ -222,6 +226,10 @@ using Available2dGridTypes = unique_grid_tuple_t<std::tuple<YASP_2D_EQUIDISTANT_
                                                             ,
                                                             ALU_2D_SIMPLEX_CONFORMING
 #endif
+#if HAVE_DUNE_UGGRID || HAVE_UG
+                                                            ,
+                                                            UG_2D
+#endif
                                                             >>;
 
 using Available3dGridTypes = unique_grid_tuple_t<std::tuple<YASP_3D_EQUIDISTANT_OFFSET
@@ -229,6 +237,10 @@ using Available3dGridTypes = unique_grid_tuple_t<std::tuple<YASP_3D_EQUIDISTANT_
                                                             ,
                                                             ALU_3D_SIMPLEX_CONFORMING,
                                                             ALU_3D_CUBE
+#endif
+#if HAVE_DUNE_UGGRID || HAVE_UG
+                                                            ,
+                                                            UG_3D
 #endif
                                                             >>;
 

--- a/python/xt/dune/xt/test/hypothesis_strategies.py
+++ b/python/xt/dune/xt/test/hypothesis_strategies.py
@@ -22,6 +22,7 @@ the dune-gdt pytest suites can import the same strategies.
 """
 
 import importlib
+import math
 import re
 from dataclasses import dataclass, field
 from itertools import product as _cartesian
@@ -421,3 +422,102 @@ def polynomials(draw, dim, max_order=3, coefficient_bound=100.0, min_order=0):
         for alpha in multi_indices
     }
     return Polynomial(dim=dim, coefficients=coefficients)
+
+
+# --- unstructured (UG) grids: mixed-element and prism meshes --------------------------------
+#
+# UGGrid is the only bound grid manager that can hold a mesh with more than one geometry type (or
+# a prism); make_mixed_grid / make_prism_grid (python/xt/dune/xt/grid/gridprovider/unstructured.cc)
+# mirror the C++ fixtures in dune/gdt/test/spaces/base.hh. Their topology is fixed, so the per
+# geometry-type element counts are exact and pin the DG mapper on mixed grids -- something the
+# structured (single geometry type) grid_specs above cannot reach (WP3 of #320).
+
+
+def has_uggrid(module=None):
+    """Whether the build binds UGGrid, i.e. make_mixed_grid / make_prism_grid are available.
+
+    Pass an explicit module (e.g. a stub) to test the detection without the compiled wheel.
+    """
+    return any(b.impl == "uggrid" for b in discover_grid_bindings(module))
+
+
+# (dim, number of corners) -> geometry type, covering every element the bound grids can carry. A
+# 1d element is both a simplex and a cube; it is reported as "cube" (Q_k == P_k in 1d anyway).
+_GEOMETRY_BY_CORNERS = {
+    (1, 2): "cube",
+    (2, 3): "simplex",
+    (2, 4): "cube",
+    (3, 4): "simplex",
+    (3, 5): "pyramid",
+    (3, 6): "prism",
+    (3, 8): "cube",
+}
+
+
+def classify_element(dim, num_corners):
+    """Name the geometry type of an element from its dimension and corner count."""
+    return _GEOMETRY_BY_CORNERS.get((dim, num_corners), "unknown")
+
+
+def element_geometry_counts(grid):
+    """Count leaf elements per geometry type by walking the grid (exact on mixed grids)."""
+    dim = grid.dimension
+    counts = {}
+
+    def visit(element):
+        geometry_type = classify_element(dim, element.corners.shape[0])
+        counts[geometry_type] = counts.get(geometry_type, 0) + 1
+
+    grid.apply_on_each_element(visit)
+    return counts
+
+
+def dg_dofs_per_element(geometry_type, order, dim):
+    """Local (discontinuous) Lagrange DoF count for a single element of the given geometry.
+
+    These are the per-geometry blocks that a DG space assembles element by element, so on a mixed
+    grid the global DoF count is the sum over elements of this quantity (see
+    dg_dof_count_on_mixed_grid).
+    """
+    if geometry_type == "cube":
+        return (order + 1) ** dim  # Q_k, tensor-product Lagrange
+    if geometry_type == "simplex":
+        return math.comb(order + dim, dim)  # P_k on a d-simplex
+    if geometry_type == "prism":
+        # a prism is (2-simplex) x line, so its Lagrange space is P_k(triangle) (x) P_k(line)
+        return math.comb(order + 2, 2) * (order + 1)
+    raise NotImplementedError(
+        f"DG DoF count for geometry type {geometry_type!r} is not encoded"
+    )
+
+
+def dg_dof_count_on_mixed_grid(grid, order):
+    """Expected number of DoFs of a DiscontinuousLagrangeSpace(grid, order) on any (mixed) grid."""
+    dim = grid.dimension
+    return sum(
+        count * dg_dofs_per_element(geometry_type, order, dim)
+        for geometry_type, count in element_geometry_counts(grid).items()
+    )
+
+
+# Topology of the unstructured fixtures before any refinement, as dim -> {geometry type: count};
+# mirrors the element insertions in make_mixed_grid / make_prism_grid.
+MIXED_GRID_ELEMENTS = {
+    2: {"cube": 2, "simplex": 2},
+    3: {"cube": 2, "simplex": 2},
+}
+PRISM_GRID_ELEMENTS = {3: {"prism": 1}}
+
+
+def make_mixed_grid_provider(dim, num_refinements=0):
+    """A UG grid with mixed cube/simplex elements (2d or 3d), as a GridProvider."""
+    from dune.xt.grid import Dim, make_mixed_grid
+
+    return make_mixed_grid(Dim(dim), num_refinements=num_refinements)
+
+
+def make_prism_grid_provider(num_refinements=0):
+    """A 3d UG grid consisting of prism elements, as a GridProvider."""
+    from dune.xt.grid import Dim, make_prism_grid
+
+    return make_prism_grid(Dim(3), num_refinements=num_refinements)

--- a/python/xt/test/test_hypothesis_strategies.py
+++ b/python/xt/test/test_hypothesis_strategies.py
@@ -258,9 +258,7 @@ def test_sampled_grid_bindings_filters_dims_elements_and_conformity(monkeypatch)
 
 
 def test_has_uggrid_detects_the_ug_provider():
-    with_ug = _stub_module(
-        list(_FULL_BUILD_GRID_CLASSES) + ["GridProvider2dSimplexUggrid"]
-    )
+    with_ug = _stub_module([*_FULL_BUILD_GRID_CLASSES, "GridProvider2dSimplexUggrid"])
     without_ug = _stub_module(_FULL_BUILD_GRID_CLASSES)
     assert hs.has_uggrid(with_ug) is True
     assert hs.has_uggrid(without_ug) is False
@@ -307,7 +305,7 @@ class _FakeMixedGrid:
     """A stand-in GridProvider: two quads and two triangles in 2d, walked corner-count first."""
 
     dimension = 2
-    _corner_counts = [4, 4, 3, 3]
+    _corner_counts = (4, 4, 3, 3)
 
     def apply_on_each_element(self, visitor):
         for corners in self._corner_counts:

--- a/python/xt/test/test_hypothesis_strategies.py
+++ b/python/xt/test/test_hypothesis_strategies.py
@@ -254,6 +254,82 @@ def test_sampled_grid_bindings_filters_dims_elements_and_conformity(monkeypatch)
     assert set(only_cube_3d) == {(3, "cube", "yaspgrid")}
 
 
+# --- WP3 (#320): unstructured (UG) mixed-element and prism grid helpers --------------------
+
+
+def test_has_uggrid_detects_the_ug_provider():
+    with_ug = _stub_module(
+        list(_FULL_BUILD_GRID_CLASSES) + ["GridProvider2dSimplexUggrid"]
+    )
+    without_ug = _stub_module(_FULL_BUILD_GRID_CLASSES)
+    assert hs.has_uggrid(with_ug) is True
+    assert hs.has_uggrid(without_ug) is False
+
+
+@pytest.mark.parametrize(
+    ("dim", "num_corners", "expected"),
+    [
+        (1, 2, "cube"),
+        (2, 3, "simplex"),
+        (2, 4, "cube"),
+        (3, 4, "simplex"),
+        (3, 5, "pyramid"),
+        (3, 6, "prism"),
+        (3, 8, "cube"),
+        (3, 7, "unknown"),  # no element type has seven corners
+    ],
+)
+def test_classify_element(dim, num_corners, expected):
+    assert hs.classify_element(dim, num_corners) == expected
+
+
+@pytest.mark.parametrize(
+    ("geometry_type", "order", "dim", "expected"),
+    [
+        ("cube", 0, 2, 1),
+        ("cube", 1, 2, 4),  # Q_1 on a quad
+        ("cube", 2, 3, 27),  # Q_2 on a hex
+        ("simplex", 1, 2, 3),  # P_1 on a triangle
+        ("simplex", 2, 3, 10),  # P_2 on a tet
+        ("prism", 1, 3, 6),  # the six vertices of a prism
+    ],
+)
+def test_dg_dofs_per_element(geometry_type, order, dim, expected):
+    assert hs.dg_dofs_per_element(geometry_type, order, dim) == expected
+
+
+def test_dg_dofs_per_element_rejects_unknown_geometry():
+    with pytest.raises(NotImplementedError):
+        hs.dg_dofs_per_element("unknown", 1, 2)
+
+
+class _FakeMixedGrid:
+    """A stand-in GridProvider: two quads and two triangles in 2d, walked corner-count first."""
+
+    dimension = 2
+    _corner_counts = [4, 4, 3, 3]
+
+    def apply_on_each_element(self, visitor):
+        for corners in self._corner_counts:
+            visitor(types.SimpleNamespace(corners=_Shape((corners, 2))))
+
+
+class _Shape:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+def test_element_geometry_counts_on_a_mixed_grid():
+    assert hs.element_geometry_counts(_FakeMixedGrid()) == {"cube": 2, "simplex": 2}
+
+
+def test_dg_dof_count_on_mixed_grid_sums_per_geometry():
+    # order 1: two quads (Q_1: 4 DoFs) + two triangles (P_1: 3 DoFs) = 2*4 + 2*3 = 14
+    assert hs.dg_dof_count_on_mixed_grid(_FakeMixedGrid(), order=1) == 14
+    # order 0: one DoF per element regardless of geometry -> 4
+    assert hs.dg_dof_count_on_mixed_grid(_FakeMixedGrid(), order=0) == 4
+
+
 # --- against the real bindings, when this build actually provides them --------------------
 
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,4 +21,10 @@ sonar.tests=dune/gdt/test,dune/xt/test,python/gdt/test,python/xt/test
 
 # Test files are intentionally repetitive (multiple similar test methods are expected).
 # Exclude them from copy-paste detection so structural test patterns don't trip the gate.
-sonar.cpd.exclusions=dune/gdt/test/**,dune/xt/test/**
+#
+# gridprovider/unstructured.cc is a deliberate, exact mirror of the make_mixed_grid /
+# make_prism_grid fixtures in dune/gdt/test/spaces/base.hh (already cpd-excluded above): the
+# python factories must reproduce the very same vertex coordinates and element topology so that
+# the bindings exercise the identical meshes. It cannot share code with that test header across
+# the dune-xt / dune-gdt boundary, so the geometry is duplicated on purpose and excluded here too.
+sonar.cpd.exclusions=dune/gdt/test/**,dune/xt/test/**,python/xt/dune/xt/grid/gridprovider/unstructured.cc

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,10 +21,4 @@ sonar.tests=dune/gdt/test,dune/xt/test,python/gdt/test,python/xt/test
 
 # Test files are intentionally repetitive (multiple similar test methods are expected).
 # Exclude them from copy-paste detection so structural test patterns don't trip the gate.
-#
-# gridprovider/unstructured.cc is a deliberate, exact mirror of the make_mixed_grid /
-# make_prism_grid fixtures in dune/gdt/test/spaces/base.hh (already cpd-excluded above): the
-# python factories must reproduce the very same vertex coordinates and element topology so that
-# the bindings exercise the identical meshes. It cannot share code with that test header across
-# the dune-xt / dune-gdt boundary, so the geometry is duplicated on purpose and excluded here too.
-sonar.cpd.exclusions=dune/gdt/test/**,dune/xt/test/**,python/xt/dune/xt/grid/gridprovider/unstructured.cc
+sonar.cpd.exclusions=dune/gdt/test/**,dune/xt/test/**


### PR DESCRIPTION
## WP3 — UG grids incl. prism and mixed-element factories (#320)

Binds `UGGrid` and adds Python factories mirroring the C++ test fixtures `make_prism_grid` / `make_mixed_grid` (`dune/gdt/test/spaces/base.hh`), which are currently the only way mixed-element and prism meshes are exercised anywhere. `UGGrid` is the only bound grid manager that can hold a mesh mixing cubes and simplices (or, in 3d, prisms), so this makes those geometry types reachable — and property-tested — from Python.

> **Stacked on #323 (WP0).** This PR's base is WP0's branch (`claude/wp0-issue-320-dosfsk`), which introduces the binding-discovery plumbing in `dune.xt.test.hypothesis_strategies`. It should be merged after #323 (retarget to `main` once #323 lands). #323 in turn stacks on #319.

### What changed

**Bindings (dune-xt)**
- `UG_2D`/`UG_3D` added to `bindings::AvailableGridTypes` (guarded by `HAVE_DUNE_UGGRID || HAVE_UG`), so `GridProvider`, the element wrapper, spaces and operators are instantiated for UG across the binding TUs.
- New `python/xt/dune/xt/grid/gridprovider/unstructured.cc` exposing `make_mixed_grid(Dim(2|3), num_refinements=0)` and `make_prism_grid(Dim(3), num_refinements=0)`, mirroring the vertex/element insertions of the C++ fixtures exactly. Registered in the grid `__init__.py` and `CMakeLists.txt`.

**Strategies (`dune.xt.test.hypothesis_strategies`)**
- `has_uggrid` discovery; `classify_element` (by corner count) and `element_geometry_counts` (walks a grid, counts elements per geometry type — exact on mixed grids).
- `dg_dofs_per_element` / `dg_dof_count_on_mixed_grid`: the per-element DG Lagrange DoF count (`Q_k` on cubes, `P_k` on simplices, tensor `P_k` on prisms) summed over the elements actually present — the mixed-grid generalization of the per-element DG DoF-count property.
- `make_mixed_grid_provider` / `make_prism_grid_provider` helpers and the fixed fixture topologies (`MIXED_GRID_ELEMENTS` / `PRISM_GRID_ELEMENTS`).

**Docs**
- `example__mixed_and_prism_grids.md`: builds a mixed 2d grid, shows per-geometry-type element counts, assembles + solves with IPDG (DG is the natural fit for mixed meshes), and inspects a 3d prism grid. Linked from `examples.md`, so the docs CI job executes it as a bindings smoke test.

### Acceptance (per #320 WP3)

- ✅ Bindings + `make_prism_grid` / `make_mixed_grid` in `dune.xt.grid`.
- ✅ Strategies with per-element-type DoF-count expectations for mixed grids.
- ✅ Notebook `example__mixed_and_prism_grids.md` linked from `examples.md`.
- ✅ **DG DoF-count property generalized to mixed grids** — `dg_dof_count_on_mixed_grid` sums the per-geometry local counts; `test_dg_dof_count_generalizes_to_mixed_grids` asserts it equals the mapper's global count at several refinement levels.

### Tests

- `python/gdt/test/test_hypothesis_mixed_grids.py`: per-geometry element counts (2d/3d mixed, 3d prism) and the generalized DG DoF-count property; the module `skipif`s cleanly on builds without UGGrid.
- `python/xt/test/test_hypothesis_strategies.py`: stub-based unit tests for the new pure-Python helpers, so they run without the compiled bindings. `ruff` / `ruff-format` clean; the new `.cc` is `clang-format` clean.

### Build-cost guardrail — needs CI measurement

Per #320's cost guardrail, adding a grid type multiplies instantiations across the ~40 binding TUs that template over `bindings::AvailableGridTypes`, and this is the CI memory driver. I could not measure the bindings build-time / peak-RAM delta in this environment (no DUNE/vcpkg toolchain), so **the delta must be read off CI**; if any binding TU crosses the ~4 GB budget it should be split further (as already done for `operators/interfaces_istl_{1d,2d,3d}.cc`, which already absorb the new UG_2D/UG_3D instantiations per dimension). Watch point for the first CI build: the `HAVE_DUNE_GRID_GLUE` blocks in `gridprovider/provider.cc` / `traits.cc` now also instantiate `DD::Glued<UG_2D, UG_2D>` for the 2d UG grid (the mechanism is grid-agnostic, but this is its first UG use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKisgXrmWpN99sphukLVmm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating UGGrid mixed-element (2D/3D) meshes and 3D prism meshes, including refinement.
  * Exposed Python factories to build these meshes and support geometry-type counting used in validation.

* **Documentation**
  * Added a new mixed/prism grid example page with refinement, visualization, DG setup, and downloadable notebook resources.

* **Tests**
  * Added Hypothesis coverage for mixed/prism behavior, refinement stability, and DG DoF expectations (automatically skipped when UGGrid bindings aren’t available).

* **Refactor**
  * Updated Python bindings to be dimension-aware (1D/2D/3D) while keeping the same high-level public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->