### PR TITLE
feat(python): bind the ALU cube grid (3d hexahedra) (WP1, #320)

### DIFF
--- a/docs/source/example__alugrid_variants.md
+++ b/docs/source/example__alugrid_variants.md
@@ -1,0 +1,127 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: the ALU cube grid (3d hexahedra)
+
+Historically the Python bindings instantiated exactly *one cube and one simplex grid per
+dimension* -- the structured `YaspGrid` for cubes and the conforming `ALUGrid` for simplices.
+As part of [#320](https://github.com/dune-gdt/dune-gdt/issues/320) the bindings add the
+**unstructured, nonconforming ALU cube grid in 3d** (hexahedra), reached through a
+`Nonconforming()` selector:
+
+```python
+make_cube_grid(Dim(3), Cube())                   # structured YaspGrid (default)
+make_cube_grid(Dim(3), Cube(), Nonconforming())  # unstructured ALU hexahedral grid
+```
+
+Existing `make_cube_grid` calls are unchanged; `pybind11` dispatches on the extra tag.
+
+```{admonition} Why only the 3d cube?
+:class: note
+
+The bindings register spaces, operators and boundary infos keyed on the grid's *leaf view*
+type, and dune-alugrid expresses that view through the legacy `ALU3dGrid<tetra|hexa>` /
+`ALU2dGrid` -- the conforming/nonconforming refinement policy is **not part of the view type**.
+So the conforming and nonconforming ALU *simplex* grids share one leaf-view type and cannot both
+be registered, and there is no distinct 2d cube ALUGrid at all. Only the 3d hexahedral grid has a
+leaf view (`ALU3dGrid<hexa>`) distinct from the tetrahedral simplex and structured YASP views, so
+it is the one new grid this work package can expose. Closing the nonconforming-*simplex* gap needs
+a binding-layer change (keying on the grid rather than the view) and is tracked in #320.
+```
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+from dune.xt.grid import Dim, Cube, Nonconforming, make_cube_grid, visualize_grid
+```
+
+## Structured YASP vs. unstructured ALU cube
+
+Both grids start from the same structured `2 x 2 x 2` box, so the macro grids agree on element and
+vertex counts:
+
+```{code-cell}
+domain = dict(lower_left=[0, 0, 0], upper_right=[1, 1, 1], num_elements=[2, 2, 2])
+
+yasp = make_cube_grid(Dim(3), Cube(), **domain)
+alu = make_cube_grid(Dim(3), Cube(), Nonconforming(), **domain)
+
+for name, grid in (("YASP (structured)", yasp), ("ALU (unstructured)", alu)):
+    print(f"{name:20s}: {grid.size(0)} elements, {grid.size(3)} vertices")
+```
+
+One global refinement splits every hexahedron into `2^d = 8` children, for both implementations:
+
+```{code-cell}
+for name, grid in (("YASP (structured)", yasp), ("ALU (unstructured)", alu)):
+    before = grid.size(0)
+    grid.global_refine(1)
+    print(f"{name:20s}: {before} -> {grid.size(0)} elements  (x{grid.size(0) // before})")
+```
+
+## A finite-element space on the ALU cube grid
+
+The FEM stack works on the new grid like on any other: we can build a `ContinuousLagrangeSpace`,
+a `DiscreteFunction`, and visualise the hexahedral grid.
+
+```{code-cell}
+from dune.gdt import ContinuousLagrangeSpace, DiscreteFunction
+
+grid = make_cube_grid(Dim(3), Cube(), Nonconforming(),
+                      lower_left=[0, 0, 0], upper_right=[1, 1, 1], num_elements=[4, 4, 4])
+V_h = ContinuousLagrangeSpace(grid, order=1)
+u_h = DiscreteFunction(V_h, name="u_h")
+
+print(f"ALU cube grid: {grid.size(0)} elements, {V_h.num_DoFs} DoFs (Q1)")
+_ = visualize_grid(grid)
+```
+
+```{admonition} Local adaptation is simplex-only for now
+:class: note
+
+The ALU cube grid *supports* local, nonconforming refinement in principle, but `AdaptationHelper`
+(and the marking/adapt machinery) is currently bound only for the simplex grids -- see the
+{doc}`grid adaptation example <example__simple_grid_adaptation>`, which marks and adapts a 2d
+simplex grid. Extending the adaptation bindings to cube grids is a separate binding gap, tracked
+in [#320](https://github.com/dune-gdt/dune-gdt/issues/320).
+```
+
+## How this reaches the property-test suite
+
+The `GridProvider*` classes that `dune.xt.grid` exposes encode every bound grid combination as
+`GridProvider<dim>d<Element><Impl>`. The shared `dune.xt.test.hypothesis_strategies` module
+*discovers* the bound grids by parsing exactly these names (see
+[#320](https://github.com/dune-gdt/dune-gdt/issues/320) WP0), so the new `GridProvider3dCubeAlunonconformgrid`
+is drawn by the property tests automatically -- no strategy edit was needed to start exercising it:
+
+```{code-cell}
+import dune.xt.grid as xtgrid
+
+for name in sorted(n for n in dir(xtgrid) if n.startswith("GridProvider")):
+    print(name)
+```

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -6,6 +6,7 @@ The examples each highlight a specific aspect, possibly without much explanation
 example__prolongations_products_and_norms
 example__simple_grid_adaptation
 example__structured_1d_grids
+example__alugrid_variants
 example__ESV2007_estimates
 example__gmsh_grid
 example__MNS2002_estimates

--- a/python/xt/dune/xt/grid/gridprovider/cube.cc
+++ b/python/xt/dune/xt/grid/gridprovider/cube.cc
@@ -54,6 +54,45 @@ struct make_cube_grid
   } // ... bind(...)
 }; // struct make_cube_grid<...>
 
+// Same factory as make_cube_grid<G, element_type>, but with an additional leading selector tag
+// (e.g. Nonconforming) so that a second grid implementation sharing the (dimension, element_type)
+// signature -- the unstructured ALU cube/simplex grids added in #320 WP1 -- can be reached without
+// colliding with the structured/conforming default overload. pybind11 dispatches on the extra
+// argument, so `make_cube_grid(Dim(2), Cube())` still yields YASP while
+// `make_cube_grid(Dim(2), Cube(), Nonconforming())` yields the ALU cube grid.
+template <class G, class element_type, class backend_type>
+struct make_cube_grid_backend
+{
+  static void bind(pybind11::module& m)
+  {
+    using namespace pybind11::literals;
+    using D = typename G::ctype;
+    static constexpr size_t d = G::dimension;
+
+    m.def(
+        "make_cube_grid",
+        [](const Dimension<d>&,
+           const element_type&,
+           const backend_type&,
+           const FieldVector<D, d>& lower_left,
+           const FieldVector<D, d>& upper_right,
+           const std::array<unsigned int, d>& num_elements,
+           const unsigned int num_refinements,
+           const std::array<unsigned int, d>& overlap_size) {
+          return XT::Grid::make_cube_grid<G>(lower_left, upper_right, num_elements, num_refinements, overlap_size);
+        },
+        "dimension"_a,
+        "element_type"_a,
+        "backend"_a,
+        "lower_left"_a,
+        "upper_right"_a,
+        "num_elements"_a,
+        "num_refinements"_a = 0,
+        "overlap_size"_a =
+            XT::Grid::cube_gridprovider_default_config().get<std::array<unsigned int, d>>("overlap_size"));
+  } // ... bind(...)
+}; // struct make_cube_grid_backend<...>
+
 template <class G>
 struct make_cube_grid<G, void>
 {
@@ -99,9 +138,13 @@ PYBIND11_MODULE(_grid_gridprovider_cube, m)
   make_cube_grid<YASP_2D_EQUIDISTANT_OFFSET, Cube>::bind(m);
   make_cube_grid<YASP_3D_EQUIDISTANT_OFFSET, Cube>::bind(m);
 #if HAVE_DUNE_ALUGRID
+  // default (structured cube / conforming simplex) overloads
   make_cube_grid<ALU_2D_SIMPLEX_CONFORMING, Simplex>::bind(m);
-  make_cube_grid<ALU_2D_CUBE, Cube>::bind(m);
   make_cube_grid<ALU_3D_SIMPLEX_CONFORMING, Simplex>::bind(m);
-  make_cube_grid<ALU_3D_CUBE, Cube>::bind(m);
+  // Nonconforming() selects the unstructured, nonconforming ALU cube (hexahedral) grid, which shares
+  // the (Dim(3), Cube) signature with the structured YASP cube. It is the only ALU variant beyond the
+  // historical set that is separately bindable: the nonconforming ALU *simplex* grids share their
+  // leaf-view type with the conforming ones (see grids.bindings.hh), and 2d has no cube ALUGrid.
+  make_cube_grid_backend<ALU_3D_CUBE, Cube, Nonconforming>::bind(m);
 #endif
 }

--- a/python/xt/dune/xt/grid/grids.bindings.hh
+++ b/python/xt/dune/xt/grid/grids.bindings.hh
@@ -12,12 +12,58 @@
 #ifndef DUNE_XT_GRID_GRIDS_BINDINGS_HH
 #define DUNE_XT_GRID_GRIDS_BINDINGS_HH
 
+#include <tuple>
+#include <type_traits>
+
 #include <dune/xt/common/string.hh>
 #include <dune/xt/common/tuple.hh>
 #include <dune/xt/grid/grids.hh>
 
 
 namespace Dune::XT::Grid::bindings {
+
+
+namespace internal {
+
+
+// Whether Tuple already contains the exact type T.
+template <class T, class Tuple>
+struct tuple_contains : std::false_type
+{};
+
+template <class T, class Head, class... Tail>
+struct tuple_contains<T, std::tuple<Head, Tail...>>
+  : std::conditional_t<std::is_same<T, Head>::value, std::true_type, tuple_contains<T, std::tuple<Tail...>>>
+{};
+
+// Accumulate the first occurrence of every type, dropping later duplicates.
+template <class Acc, class Tuple>
+struct unique_tuple_helper
+{
+  using type = Acc;
+};
+
+template <class... Accs, class Head, class... Tail>
+struct unique_tuple_helper<std::tuple<Accs...>, std::tuple<Head, Tail...>>
+{
+  using next = std::
+      conditional_t<tuple_contains<Head, std::tuple<Accs...>>::value, std::tuple<Accs...>, std::tuple<Accs..., Head>>;
+  using type = typename unique_tuple_helper<next, std::tuple<Tail...>>::type;
+};
+
+
+} // namespace internal
+
+
+/// \brief Drop duplicate types from a grid-type tuple.
+///
+/// pybind11 registers each C++ type exactly once per interpreter, so a grid tuple that lists two
+/// aliases resolving to the *same* type (e.g. dune-alugrid maps ALUGrid<2,2,cube,nonconforming>
+/// onto the 2d simplex grid -- there is no distinct 2d cube ALUGrid) would double-register its
+/// GridProvider/BoundaryInfo classes and abort module import. Deduplicating here keeps the binding
+/// grid lists robust against such aliasing regardless of the dune-alugrid configuration.
+template <class Tuple>
+using unique_grid_tuple_t = typename internal::unique_tuple_helper<std::tuple<>, Tuple>::type;
 
 
 template <class G>
@@ -149,33 +195,45 @@ struct grid_name<UGGrid<dim>>
 #endif // HAVE_DUNE_UGGRID || HAVE_UG
 
 
-/// \attention The following choices are on purpose: only two variants per dim, one cube one simplex.
-///            In particular the grid_name<G>::value needs to be unique for all alugrid variants and the
-///            make_...grid methods need to be more general if we extend the choice of grids here!
+/// \attention grid_name<G>::value must be unique for all grid variants below, and every make_...grid
+///            factory that a bound grid needs (see gridprovider/cube.cc) has to be able to construct it.
 ///
 /// WP2 (#320) adds YASP_1D_EQUIDISTANT_OFFSET next to ONED_1D: a structured 1d grid with the same
 /// equidistant-offset coordinates as the 2d/3d YaspGrids (periodic/overlap features, and the C++
 /// SimplicialGrids list tests it). The two 1d grids are disambiguated in the make_cube_grid factory
 /// by their element-type tag -- ONED_1D keeps the dimension-only overload, YASP_1D binds the
 /// (Dimension, Cube) overload (see python/xt/dune/xt/grid/gridprovider/cube.cc).
+///
+/// #320 WP1 adds the ALU cube (hexahedral) grid in 3d -- the only ALU variant beyond the historical
+/// "one cube, one simplex per dim" set that is actually bindable: the bindings register
+/// spaces/operators/boundaryinfo keyed on the *leaf grid view* type (only named via grid_name<G>),
+/// and dune-alugrid expresses that view through the legacy ALU3dGrid<tetra|hexa> / ALU2dGrid,
+/// dropping the conforming/nonconforming refinement policy from the view type. Hence the conforming
+/// and nonconforming ALU *simplex* grids share one leaf-view type and cannot both be registered (the
+/// second aborts module import with a pybind11 "type already registered"), and there is no distinct
+/// 2d cube ALUGrid at all. Only the 3d hexahedral cube grid has a leaf view (ALU3dGrid<hexa>)
+/// distinct from the tetrahedral simplex and structured YASP views, so only it is added here.
+/// unique_grid_tuple_t guards the grid tuples against any exact-type aliasing on top.
 
 using Available1dGridTypes = std::tuple<ONED_1D, YASP_1D_EQUIDISTANT_OFFSET>;
 
-using Available2dGridTypes = std::tuple<YASP_2D_EQUIDISTANT_OFFSET
+using Available2dGridTypes = unique_grid_tuple_t<std::tuple<YASP_2D_EQUIDISTANT_OFFSET
 #if HAVE_DUNE_ALUGRID
-                                        ,
-                                        ALU_2D_SIMPLEX_CONFORMING
+                                                            ,
+                                                            ALU_2D_SIMPLEX_CONFORMING
 #endif
-                                        >;
+                                                            >>;
 
-using Available3dGridTypes = std::tuple<YASP_3D_EQUIDISTANT_OFFSET
+using Available3dGridTypes = unique_grid_tuple_t<std::tuple<YASP_3D_EQUIDISTANT_OFFSET
 #if HAVE_DUNE_ALUGRID
-                                        ,
-                                        ALU_3D_SIMPLEX_CONFORMING
+                                                            ,
+                                                            ALU_3D_SIMPLEX_CONFORMING,
+                                                            ALU_3D_CUBE
 #endif
-                                        >;
+                                                            >>;
 
-using AvailableGridTypes = Common::tuple_cat_t<Available1dGridTypes, Available2dGridTypes, Available3dGridTypes>;
+using AvailableGridTypes =
+    unique_grid_tuple_t<Common::tuple_cat_t<Available1dGridTypes, Available2dGridTypes, Available3dGridTypes>>;
 
 
 } // namespace Dune::XT::Grid::bindings

--- a/python/xt/dune/xt/grid/traits.cc
+++ b/python/xt/dune/xt/grid/traits.cc
@@ -60,6 +60,9 @@ PYBIND11_MODULE(_grid_traits, m)
   pybind11::class_<Prism>(m, "Prism", "tag: Prism").def(py::init()).def("__repr__", [](const Prism&) {
     return "Prism()";
   });
+  pybind11::class_<Nonconforming>(m, "Nonconforming", "tag: Nonconforming (make_cube_grid backend selector)")
+      .def(py::init())
+      .def("__repr__", [](const Nonconforming&) { return "Nonconforming()"; });
 
   pybind11::class_<Dimension<0>>(m, "Dimension0", "tag: Dimension0")
       .def(py::init())

--- a/python/xt/dune/xt/grid/traits.hh
+++ b/python/xt/dune/xt/grid/traits.hh
@@ -41,6 +41,12 @@ class Prism
 {};
 
 
+/// \brief make_cube_grid selector tag picking the unstructured, nonconforming-refinement grid
+///        implementation (ALUGrid) over the structured/conforming default for a given element type.
+class Nonconforming
+{};
+
+
 template <size_t d>
 class Dimension
 {};

--- a/python/xt/dune/xt/test/hypothesis_strategies.py
+++ b/python/xt/dune/xt/test/hypothesis_strategies.py
@@ -129,9 +129,25 @@ def discover_matrix_types(module=None):
     return _discover_container_types("Matrix", module)
 
 
+# Every GridProvider* the wheel exposes, at the (dim, element, impl) granularity -- so that two
+# implementations sharing a (dim, element) slice (e.g. the structured YASP cube and the
+# unstructured ALU cube added in #320 WP1) are both drawn by the strategies below.
+GRID_BINDINGS = discover_grid_bindings()
+
 # The runtime-reachable slice of the compile-time grid lists used by the C++ typed tests, e.g.
 # on a full build: (1, "simplex") ONEDGRID, (2|3, "cube") YASPGRID, (2|3, "simplex") ALUGRID.
 GRID_COMBINATIONS = discover_grid_combinations()
+
+# ALUGrid implementations whose LeafGridView is non-conforming (both the ALU cube grid and the
+# nonconforming ALU simplex grid parse to this impl -- the element disambiguates them). Several
+# GridProvider methods (size/centers for 0 < codim < dim, the intersection-index helpers) are
+# guarded with requirements_not_met on non-conforming grids, so properties relying on them draw
+# only conforming specs (grid_specs(conforming_only=True)).
+_NONCONFORMING_IMPLS = frozenset({"alunonconformgrid"})
+
+
+def _impl_is_conforming(impl):
+    return impl is None or impl not in _NONCONFORMING_IMPLS
 
 
 def has_grid(dim=None, element=None):
@@ -148,13 +164,26 @@ SIMPLICES_PER_CUBE = {1: 1, 2: 2, 3: 6}
 
 @dataclass(frozen=True)
 class GridSpec:
-    """A runtime description of a make_cube_grid call with known structural expectations."""
+    """A runtime description of a make_cube_grid call with known structural expectations.
+
+    `impl` selects the grid implementation within a (dim, element) slice, matching the impl word
+    of the discovered GridProvider name ("yaspgrid", "onedgrid", "aluconformgrid",
+    "alunonconformgrid"). It defaults to None, i.e. the structured/conforming make_cube_grid default
+    (YASP cube, conforming ALU simplex, ONEDGRID) -- so a GridSpec built without an impl keeps the
+    pre-#320 behaviour. A non-conforming impl is reached via the Nonconforming() factory selector.
+    """
 
     dim: int
     element: str  # "cube" or "simplex"
     lower_left: tuple
     upper_right: tuple
     num_elements: tuple
+    impl: str = None
+
+    @property
+    def conforming(self):
+        """Whether the grid's LeafGridView is conforming (governs which methods are available)."""
+        return _impl_is_conforming(self.impl)
 
     def make_grid(self):
         from dune.xt.grid import Cube, Dim, Simplex, make_cube_grid
@@ -169,8 +198,14 @@ class GridSpec:
             # type); the structured 1d YaspGrid (WP2, #320) instead uses the (Dim, Cube) overload
             # like its 2d/3d siblings, handled by the general branch below.
             return make_cube_grid(Dim(1), **kwargs)
-        elem = {"cube": Cube, "simplex": Simplex}[self.element]
-        return make_cube_grid(Dim(self.dim), elem(), **kwargs)
+        elem = {"cube": Cube, "simplex": Simplex}[self.element]()
+        if not self.conforming:
+            # the unstructured ALU cube/simplex grids share the (dim, element) overload signature
+            # with the structured/conforming defaults; Nonconforming() disambiguates them
+            from dune.xt.grid import Nonconforming
+
+            return make_cube_grid(Dim(self.dim), elem, Nonconforming(), **kwargs)
+        return make_cube_grid(Dim(self.dim), elem, **kwargs)
 
     @property
     def num_cubes(self):
@@ -222,6 +257,22 @@ def bounding_boxes(draw, dim, coordinate_range=100.0, min_extent=0.1, max_extent
     return lower, upper
 
 
+def _sampled_grid_bindings(dims, elements, conforming_only):
+    """The (dim, element, impl) triples to draw from, filtered to the caller's needs.
+
+    Drawn from GRID_BINDINGS (all discovered implementations), so both YASP and ALU cube grids --
+    and both conforming and nonconforming ALU simplex grids -- are exercised, not just one default
+    per (dim, element).
+    """
+    return [
+        (b.dim, b.element, b.impl)
+        for b in GRID_BINDINGS
+        if b.dim in dims
+        and b.element in elements
+        and (not conforming_only or _impl_is_conforming(b.impl))
+    ]
+
+
 @st.composite
 def grid_specs(
     draw,
@@ -229,16 +280,17 @@ def grid_specs(
     elements=("cube", "simplex"),
     max_elements_per_dim=4,
     unit_box=False,
+    conforming_only=False,
 ):
     """Draw a GridSpec for one of the binding-instantiated grid types.
 
     max_elements_per_dim keeps 3d grids small (a 4^3 cube box already yields 384 simplices);
-    hypothesis shrinks towards 1 element per axis.
+    hypothesis shrinks towards 1 element per axis. conforming_only restricts the draw to grids
+    with a conforming LeafGridView, for properties that use methods the bindings do not implement
+    on non-conforming grids (the codim-1 intersection-index helpers).
     """
-    dim, element = draw(
-        st.sampled_from(
-            [(d, e) for (d, e) in GRID_COMBINATIONS if d in dims and e in elements]
-        )
+    dim, element, impl = draw(
+        st.sampled_from(_sampled_grid_bindings(dims, elements, conforming_only))
     )
     if unit_box:
         lower, upper = (0.0,) * dim, (1.0,) * dim
@@ -253,6 +305,7 @@ def grid_specs(
         lower_left=lower,
         upper_right=upper,
         num_elements=num_elements,
+        impl=impl,
     )
 
 

--- a/python/xt/test/test_hypothesis_grid_provider.py
+++ b/python/xt/test/test_hypothesis_grid_provider.py
@@ -56,15 +56,19 @@ def test_global_refine_scales_element_count(spec):
     before = grid.size(0)
     grid.global_refine(1)
     if spec.element == "cube":
-        # structured cube grids refine each cell into 2^d children
+        # every cube grid -- the structured YASP grid and the unstructured, nonconforming ALU
+        # cube grid alike -- refines each cell into 2^d children under one global refinement
         assert grid.size(0) == before * 2**spec.dim
     else:
-        # the conforming ALU simplex grids refine by bisection, so one global refinement
-        # step only guarantees growth; the exact factor is a grid implementation detail
+        # the ALU simplex grids refine by bisection (conforming variant) or regular refinement
+        # (nonconforming variant), so one global refinement step only guarantees growth; the
+        # exact factor is a grid implementation detail
         assert grid.size(0) > before
 
 
-@given(spec=grid_specs(max_elements_per_dim=3))
+# The codim-1 intersection-index helpers are guarded with requirements_not_met on non-conforming
+# grids (see gridprovider.hh), so this partition property is stated only for conforming grids.
+@given(spec=grid_specs(max_elements_per_dim=3, conforming_only=True))
 def test_boundary_and_inner_intersection_indices_partition(spec):
     grid = spec.make_grid()
     boundary = set(grid.boundary_intersection_indices())

--- a/python/xt/test/test_hypothesis_strategies.py
+++ b/python/xt/test/test_hypothesis_strategies.py
@@ -166,6 +166,94 @@ def test_discovery_ignores_non_class_attributes():
     assert [c.__name__ for c in hs.discover_vector_types(module)] == ["CommonVector"]
 
 
+# --- impl-aware GridSpec (WP1): conforming classification is pure Python ------------------
+
+
+@pytest.mark.parametrize(
+    ("impl", "conforming"),
+    [
+        (
+            None,
+            True,
+        ),  # the make_cube_grid default (structured cube / conforming simplex)
+        ("yaspgrid", True),
+        ("onedgrid", True),
+        ("aluconformgrid", True),
+        (
+            "alunonconformgrid",
+            False,
+        ),  # both the ALU cube and the nonconforming ALU simplex grid
+    ],
+)
+def test_grid_spec_conforming_reflects_the_implementation(impl, conforming):
+    spec = hs.GridSpec(
+        dim=2,
+        element="cube",
+        lower_left=(0.0, 0.0),
+        upper_right=(1.0, 1.0),
+        num_elements=(1, 1),
+        impl=impl,
+    )
+    assert spec.conforming is conforming
+    assert hs._impl_is_conforming(impl) is conforming
+
+
+def test_grid_spec_defaults_to_the_conforming_default_implementation():
+    # A GridSpec built without an impl (as the interpolation-points subprocess does) must keep the
+    # pre-#320 behaviour: the structured/conforming make_cube_grid default, hence conforming.
+    spec = hs.GridSpec(
+        dim=1,
+        element="simplex",
+        lower_left=(0.0,),
+        upper_right=(1.0,),
+        num_elements=(2,),
+    )
+    assert spec.impl is None
+    assert spec.conforming is True
+
+
+def test_sampled_grid_bindings_filters_dims_elements_and_conformity(monkeypatch):
+    # A stub mirroring the bindable ALUGrid build (#320 WP1): the 3d cube slice exposes both the
+    # structured YASP grid and the nonconforming ALU hexahedral grid, while every simplex slice has
+    # only the conforming ALU grid (conforming and nonconforming ALU simplex grids share a leaf-view
+    # type and cannot both be bound; there is no 2d cube ALUGrid) -- see grids.bindings.hh.
+    stub = [
+        hs.GridBinding(1, "simplex", "onedgrid", "GridProvider1dSimplexOnedgrid"),
+        hs.GridBinding(2, "cube", "yaspgrid", "GridProvider2dCubeYaspgrid"),
+        hs.GridBinding(
+            2, "simplex", "aluconformgrid", "GridProvider2dSimplexAluconformgrid"
+        ),
+        hs.GridBinding(3, "cube", "yaspgrid", "GridProvider3dCubeYaspgrid"),
+        hs.GridBinding(
+            3, "simplex", "aluconformgrid", "GridProvider3dSimplexAluconformgrid"
+        ),
+        hs.GridBinding(
+            3, "cube", "alunonconformgrid", "GridProvider3dCubeAlunonconformgrid"
+        ),
+    ]
+    monkeypatch.setattr(hs, "GRID_BINDINGS", stub)
+
+    # both cube implementations are offered for (3, "cube")
+    cubes = hs._sampled_grid_bindings(
+        dims=(3,), elements=("cube",), conforming_only=False
+    )
+    assert set(cubes) == {(3, "cube", "yaspgrid"), (3, "cube", "alunonconformgrid")}
+
+    # conforming_only drops the nonconforming ALU cube grid
+    conforming = hs._sampled_grid_bindings(
+        dims=(1, 2, 3), elements=("cube", "simplex"), conforming_only=True
+    )
+    assert all(impl != "alunonconformgrid" for (_, _, impl) in conforming)
+    assert (3, "cube", "yaspgrid") in conforming
+    assert (3, "simplex", "aluconformgrid") in conforming
+
+    # dimension and element filters compose
+    only_cube_3d = hs._sampled_grid_bindings(
+        dims=(3,), elements=("cube",), conforming_only=True
+    )
+    assert set(only_cube_3d) == {(3, "cube", "yaspgrid")}
+
+
 # --- against the real bindings, when this build actually provides them --------------------
 
 


### PR DESCRIPTION
## WP1 — ALU cube grid (3d hexahedra) (#320)

Adds the unstructured, nonconforming **ALU cube grid in 3d** (hexahedra) to the Python bindings — reachable via a `Nonconforming()` selector — and property-tests it through the shared hypothesis strategies.

```python
make_cube_grid(Dim(3), Cube())                   # structured YaspGrid (default, unchanged)
make_cube_grid(Dim(3), Cube(), Nonconforming())  # unstructured ALU hexahedral grid (new)
```

> **Rebased onto `main`.** #319, #323 (WP0), and #324 (WP2) have merged, so this now sits directly on `main` as a single commit (WP2's YASP_1D changes merged in).

### Scope: why only the 3d cube

WP1 originally aimed to also bind the nonconforming ALU *simplex* grids (2d & 3d). While implementing it, CI surfaced a hard binding-layer constraint:

- The bindings register spaces/operators/boundary-infos keyed on the grid's **leaf-view** type (`ContinuousLagrangeSpace<GV>`, `BoundaryInfo<I>`, …) and only *name* them via `grid_name<G>`.
- dune-alugrid expresses that view through the legacy `ALU3dGrid<tetra|hexa>` / `ALU2dGrid`, so the **conforming/nonconforming refinement policy is not part of the view type**.
- Hence the conforming and nonconforming ALU *simplex* grids share one leaf-view type; registering both makes pybind11 register the same C++ type twice under two names and **aborts module import** (`type "BoundaryInfo…Alunonconform…" is already registered`). There is also no distinct 2d cube ALUGrid.

Only the **3d hexahedral** grid has a leaf view (`ALU3dGrid<hexa>`) distinct from the tetrahedral simplex and structured YASP views, so it is the one grid this work package can bind. **Closing the nonconforming-simplex gap needs a binding-layer change (keying on the grid, not the view)** — left as a documented finding for #320.

### What changed

- **`grids.bindings.hh`** — `Available3dGridTypes` adds `ALU_3D_CUBE`; a compile-time `unique_grid_tuple_t` dedups the grid tuples as a defensive net. The leaf-view constraint is documented inline.
- **`traits.{hh,cc}`, `gridprovider/cube.cc`** — a `Nonconforming()` tag selects the ALU cube variant that shares the `(Dim(3), Cube)` `make_cube_grid` signature with YASP. Existing call sites untouched (pybind11 dispatches on the extra tag).
- **Hypothesis strategies** — `GRID_BINDINGS` / `grid_specs` draw at `(dim, element, impl)` granularity so the ALU cube grid is property-tested alongside YASP. `GridSpec` tracks whether the leaf view is conforming and passes `Nonconforming()` when building; `grid_specs(conforming_only=True)` restricts to conforming grids for the codim-1 intersection-index properties the bindings guard with `requirements_not_met` on the (nonconforming) ALU cube grid.
- **Notebook** `docs/source/example__alugrid_variants.md` (linked from `examples.md`) — structured YASP vs. unstructured ALU cube construction, `2^d` uniform refinement, and a finite-element space on the grid.

### Tests

- The existing grid/space/operator/interpolation property suites now cover the ALU cube grid automatically (discovered via WP0's plumbing). Per the issue's direction, no new gtest instantiations are added — the new grid is covered by the Python hypothesis suites.
- New pure-Python unit tests for the conforming classification and the `(dim, element, impl)` / `conforming_only` sampling filter.
- `ruff` / `ruff-format` clean; `clang-format` applied to the C++ additions.

### Build-cost delta (per the #320 cost guardrail)

The bound grid list grows by **one** type (`Available3d` 2 → 3; 1d/2d unchanged), so the dune-gdt binding TUs that iterate `AvailableGridTypes` see a modest instantiation increase concentrated in 3d. The actual peak-RAM / wall-clock delta comes from the non-docker CI build — flagging for reviewers to watch `bindings_jobs` memory, though this scope is much lighter than the original 4-grid plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vL23BwCd5WzWRMafrfWPw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating unstructured, nonconforming 3D ALU cube grids through a new backend selector.
  * Added documentation and a walkthrough demonstrating grid creation, refinement, finite-element spaces, and visualization.
  * Grid-based test generation now discovers and exercises specific available implementations.

* **Bug Fixes**
  * Prevented duplicate grid implementations from being registered.
  * Restricted incompatible intersection checks to conforming grids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->