### PR TITLE
feat(python): vector-valued CG factory overloads + Stokes example (WP4, #320)

### DIFF
--- a/docs/source/example__stokes_taylor_hood.md
+++ b/docs/source/example__stokes_taylor_hood.md
@@ -173,19 +173,30 @@ g_D = np.array(discrete_dirichlet_values.dofs.vector)
 rhs_u = np.zeros(n_u)
 rhs_p = np.zeros(n_p)
 
+# B_upper feeds the velocity equations (row i replaced by the trivial u[i] = g_D[i] at a
+# Dirichlet DoF, so its pressure coupling is dropped there too); B_lower feeds the pressure
+# (divergence) equations and must keep every column's *true* entries -- including at the
+# Dirichlet velocity DoFs -- since u there still enters those equations, just as a value fixed
+# by A_np's unit rows rather than as a free unknown. Reusing one row-zeroed matrix for both
+# blocks would silently drop that div(u)|_{Dirichlet} contribution from the pressure equations.
+B_upper = B_np.copy()
+B_lower = B_np.T.copy()
+
 for dof in dirichlet_constraints.dirichlet_DoFs:
     A_np[dof, :] = 0.0
     A_np[dof, dof] = 1.0
-    B_np[dof, :] = 0.0
+    B_upper[dof, :] = 0.0
     rhs_u[dof] = g_D[dof]
 
-# pin pressure DoF 0 to p = 0, decoupling it from every velocity equation
-B_np[:, 0] = 0.0
+# pin pressure DoF 0 to p = 0: decouple it from every velocity equation (its true contribution
+# is p[0] * B_np[:, 0] = 0 anyway) and make its own row a pure identity, decoupled from velocity
+B_upper[:, 0] = 0.0
+B_lower[0, :] = 0.0
 
 K = np.zeros((n_u + n_p, n_u + n_p))
 K[:n_u, :n_u] = A_np
-K[:n_u, n_u:] = B_np
-K[n_u:, :n_u] = B_np.T
+K[:n_u, n_u:] = B_upper
+K[n_u:, :n_u] = B_lower
 K[n_u, n_u] = 1.0
 
 rhs = np.concatenate([rhs_u, rhs_p])

--- a/docs/source/example__stokes_taylor_hood.md
+++ b/docs/source/example__stokes_taylor_hood.md
@@ -1,0 +1,239 @@
+---
+jupytext:
+  text_representation:
+   format_name: myst
+jupyter:
+  jupytext:
+    cell_metadata_filter: -all
+    formats: ipynb,myst
+    main_language: python
+    text_representation:
+      format_name: myst
+      extension: .md
+      format_version: '1.3'
+      jupytext_version: 1.11.2
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+```{try_on_binder}
+```
+
+```{code-cell}
+:tags: [remove-cell]
+:load: myst_code_init.py
+```
+
+# Example: Taylor-Hood P2/P1 Stokes
+
+The C++ test suite (`dune/gdt/test/stokes/stokes-taylorhood.hh`) solves a stationary Stokes problem with
+a Taylor-Hood discretization: a **vector-valued**, order-2 continuous Lagrange space for the velocity
+paired with a scalar, order-1 continuous Lagrange space for the pressure. Until now this was impossible
+from Python: the bindings only ever instantiated `ContinuousLagrangeSpace` for scalar
+(`dim_range=Dim(1)`) fields, even though `DiscontinuousLagrangeSpace` and `FiniteVolumeSpace` already had
+the `dim_range=Dim(d)` overload (#320, WP4). This example is the first Python reproduction of that
+reference test.
+
+We solve
+$$-\Delta u + \nabla p = f, \qquad \operatorname{div} u = g$$
+on $\Omega = (-1, 1)^2$ with Dirichlet boundary values everywhere, using the manufactured "testcase 1"
+solution from `dune/gdt/data/stokes.hh` ($f = 0$, $g = 0$, and $u$, $p$ given below), so we can compare
+the discrete solution against the exact one.
+
+```{code-cell}
+# wurlitzer: display dune's output in the notebook
+%load_ext wurlitzer
+
+import numpy as np
+```
+
+## grid and spaces
+
+```{code-cell}
+from dune.xt.grid import AllDirichletBoundaryInfo, Dim, Simplex, Walker, make_cube_grid
+
+d = 2
+grid = make_cube_grid(Dim(d), Simplex(), [-1, -1], [1, 1], [6, 6])
+boundary_info = AllDirichletBoundaryInfo(grid)
+
+print(f'grid has {grid.size(0)} elements, {grid.size(d)} vertices')
+```
+
+```{code-cell}
+from dune.gdt import ContinuousLagrangeSpace
+
+# the vector-valued factory overload added for WP4: dim_range=Dim(d) selects the r=d instantiation,
+# exactly the way DiscontinuousLagrangeSpace/FiniteVolumeSpace already worked
+velocity_space = ContinuousLagrangeSpace(grid, order=2, dim_range=Dim(d))
+pressure_space = ContinuousLagrangeSpace(grid, order=1)
+
+print(f'velocity_space: {velocity_space.num_DoFs} DoFs (order 2, {d}-valued)')
+print(f'pressure_space: {pressure_space.num_DoFs} DoFs (order 1, scalar)')
+```
+
+Two related contract limits of `ContinuousLagrangeSpace` are documented (not lifted) as part of WP4:
+order $> 2$ on non-cube grids is a hard mapper limitation (`dune/gdt/spaces/mapper/continuous.hh`), and
+`RaviartThomasSpace` only supports order $0$ (`dune/gdt/spaces/hdiv/raviart-thomas.hh`) -- neither is hit
+here, since Taylor-Hood only ever needs order $\le 2$ CG spaces.
+
+## the exact solution
+
+```{code-cell}
+from dune.xt.functions import ExpressionFunction, GridFunction as GF
+
+u_exact_expr = ExpressionFunction(
+    dim_domain=Dim(d),
+    variable='x',
+    expressions=[
+        '-1*exp(x[0])*(x[1]*cos(x[1])+sin(x[1]))',
+        'exp(x[0])*x[1]*sin(x[1])',
+    ],
+    order=5,
+    name='u_exact',
+)
+p_exact_expr = ExpressionFunction(
+    dim_domain=Dim(d),
+    variable='x',
+    expression='2*exp(x[0])*sin(x[1])',
+    order=5,
+    name='p_exact',
+)
+```
+
+## assembling $A$ (velocity Laplacian) and $B$ (pressure/velocity divergence coupling)
+
+The saddle-point system is
+$$\begin{pmatrix} A & B \\ B^T & 0 \end{pmatrix} \begin{pmatrix} u \\ p \end{pmatrix}
+  = \begin{pmatrix} f \\ g \end{pmatrix}, \qquad
+  A_{ij} = \int_\Omega \nabla v_i : \nabla v_j, \qquad
+  B_{ij} = -\int_\Omega p_j \operatorname{div}(v_i).$$
+
+$B$ pairs a *vector* test basis (velocity, rank $d$) with a *scalar* ansatz basis (pressure, rank $1$):
+this rectangular combination needed two more WP4 fixes to reach from Python -- a new
+`LocalElementAnsatzValueTestDivProductIntegrand` binding (the C++ class existed, just unbound), and a
+`BilinearForm(grid, ansatz_range=..., test_range=...)` disambiguation, since the previously grid-only
+factory could not otherwise tell its four rank instantiations apart.
+
+```{code-cell}
+from dune.gdt import (
+    BilinearForm,
+    LocalElementAnsatzValueTestDivProductIntegrand,
+    LocalElementIntegralBilinearForm,
+    LocalLaplaceIntegrand,
+    MatrixOperator,
+)
+
+diffusion = GF(grid, 1.0, dim_range=(Dim(d), Dim(d)), name='diffusion')
+
+a_form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
+a_form += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+A = MatrixOperator(grid, source_space=velocity_space, range_space=velocity_space)
+A.append(a_form)
+
+b_form = BilinearForm(grid, ansatz_range=Dim(1), test_range=Dim(d))
+b_form += LocalElementIntegralBilinearForm(LocalElementAnsatzValueTestDivProductIntegrand(GF(grid, -1.0)))
+B = MatrixOperator(grid, source_space=pressure_space, range_space=velocity_space)
+B.append(b_form)
+```
+
+```{code-cell}
+from dune.gdt import DirichletConstraints, boundary_interpolation
+from dune.xt.grid import DirichletBoundary
+
+dirichlet_constraints = DirichletConstraints(boundary_info, velocity_space)
+
+walker = Walker(grid)
+walker.append(A)
+walker.append(B)
+walker.append(dirichlet_constraints)
+walker.walk()
+
+discrete_dirichlet_values = boundary_interpolation(
+    GF(grid, u_exact_expr), velocity_space, boundary_info, DirichletBoundary()
+)
+```
+
+## solving the saddle-point system
+
+`dune.xt.la` does not (yet) expose a saddle-point solver to Python, so we assemble the small dense
+system directly with `get_entry`/numpy: eliminate the Dirichlet velocity DoFs by row replacement, and
+pin one pressure DoF to remove the constant pressure null space (the same two steps
+`stokes-taylorhood.hh` performs on the C++ containers before calling `XT::LA::SaddlePointSolver`).
+
+```{code-cell}
+n_u = velocity_space.num_DoFs
+n_p = pressure_space.num_DoFs
+
+A_np = np.array([[A.matrix.get_entry(i, j) for j in range(n_u)] for i in range(n_u)])
+B_np = np.array([[B.matrix.get_entry(i, j) for j in range(n_p)] for i in range(n_u)])
+
+g_D = np.array(discrete_dirichlet_values.dofs.vector)
+
+rhs_u = np.zeros(n_u)
+rhs_p = np.zeros(n_p)
+
+for dof in dirichlet_constraints.dirichlet_DoFs:
+    A_np[dof, :] = 0.0
+    A_np[dof, dof] = 1.0
+    B_np[dof, :] = 0.0
+    rhs_u[dof] = g_D[dof]
+
+# pin pressure DoF 0 to p = 0, decoupling it from every velocity equation
+B_np[:, 0] = 0.0
+
+K = np.zeros((n_u + n_p, n_u + n_p))
+K[:n_u, :n_u] = A_np
+K[:n_u, n_u:] = B_np
+K[n_u:, :n_u] = B_np.T
+K[n_u, n_u] = 1.0
+
+rhs = np.concatenate([rhs_u, rhs_p])
+solution = np.linalg.solve(K, rhs)
+u_dofs, p_dofs = solution[:n_u], solution[n_u:]
+```
+
+```{code-cell}
+from dune.gdt import DiscreteFunction
+
+u_h = DiscreteFunction(velocity_space, name='u_h')
+for ii in range(n_u):
+    u_h.dofs.vector[ii] = u_dofs[ii]
+
+p_h = DiscreteFunction(pressure_space, name='p_h')
+for ii in range(n_p):
+    p_h.dofs.vector[ii] = p_dofs[ii]
+```
+
+```{code-cell}
+u_h.visualize('example__stokes_taylor_hood_velocity')
+p_h.visualize('example__stokes_taylor_hood_pressure')
+```
+
+Start `paraview` in a terminal to visualize `u_h`/`p_h`.
+
+## comparing against the exact solution
+
+Interpolating the exact solution into the same spaces gives a cheap, DoF-wise sanity check (a proper
+$L^2$ error would need `dune.gdt.l2_norm`, which is not bound to Python):
+
+```{code-cell}
+from dune.gdt import default_interpolation
+
+u_exact_h = default_interpolation(GF(grid, u_exact_expr), velocity_space)
+p_exact_h = default_interpolation(GF(grid, p_exact_expr), pressure_space)
+
+u_error = np.max(np.abs(np.array(u_h.dofs.vector) - np.array(u_exact_h.dofs.vector)))
+
+# p_h was pinned to p_h[0] = 0, which the exact solution does not satisfy; shift p_exact by its
+# value at that same DoF before comparing, since Stokes pressure is only unique up to a constant
+p_exact_dofs = np.array(p_exact_h.dofs.vector)
+p_error = np.max(np.abs(np.array(p_h.dofs.vector) - (p_exact_dofs - p_exact_dofs[0])))
+
+print(f'max |u_h - u_exact| at the DoFs: {u_error:.3e}')
+print(f'max |p_h - p_exact| at the DoFs (up to the additive constant pinned by DoF 0): {p_error:.3e}')
+```
+
+Download the code:
+{download}`example__stokes_taylor_hood.md`
+{nb-download}`example__stokes_taylor_hood.ipynb`

--- a/docs/source/example__stokes_taylor_hood.md
+++ b/docs/source/example__stokes_taylor_hood.md
@@ -127,7 +127,11 @@ from dune.gdt import (
 diffusion = GF(grid, 1.0, dim_range=(Dim(d), Dim(d)), name='diffusion')
 
 a_form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
-a_form += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+# dim_range_bases=Dim(d) selects the vector-valued LocalLaplaceIntegrand overload (pre-existing,
+# same dim_range_bases idiom as BilinearForm's ansatz_range/test_range above); the diffusion tensor
+# itself is always (d, d)-shaped regardless of the test/ansatz basis rank, so it alone can't
+# disambiguate the two overloads and dim_range_bases has to be passed explicitly.
+a_form += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion, dim_range_bases=Dim(d)))
 A = MatrixOperator(grid, source_space=velocity_space, range_space=velocity_space)
 A.append(a_form)
 

--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -10,6 +10,7 @@ example__alugrid_variants
 example__ESV2007_estimates
 example__gmsh_grid
 example__mixed_and_prism_grids
+example__stokes_taylor_hood
 example__MNS2002_estimates
 example__ipdg_stationary_heat_equation
 example__ipdg_heat_equation

--- a/dune/gdt/spaces/h1/continuous-lagrange.hh
+++ b/dune/gdt/spaces/h1/continuous-lagrange.hh
@@ -48,7 +48,21 @@ namespace GDT {
  * - 3d: pyramids (jacobians seem to be incorrect)
  * - 3d: mixed simplices and cubes (intersections are non-conforming)
  *
+ * \note Order > 2 on non-cube grids (in d >= 2) is a *hard*, currently unresolved contract limit, not
+ *       a missing overload: ContinuousMapper::global_index() throws Dune::NotImplemented in that case
+ *       (see the comment there). The root cause is that order >= 3 Lagrange elements place more than
+ *       one DoF on a shared sub-entity (e.g. two DoFs on one edge), and the mapper has no canonical,
+ *       grid-independent way of telling whether the local numbering of those DoFs agrees between the
+ *       two elements sharing the sub-entity; on cube grids (YaspGrid, cube-ALUGrid, UGGrid) the local
+ *       numbering happens to always agree, but not on simplicial grids in general. Fixing this needs a
+ *       consistent sub-entity orientation scheme threaded through the local finite element's DoF
+ *       numbering, which is a mapper-level feature, not something `ContinuousLagrangeSpace` itself can
+ *       route around. This boundary (order <= 2 on simplices vs. order <= 3 on cubes) is encoded as a
+ *       tested contract in `python/gdt/test/test_hypothesis_spaces.py` (`_cg_orders`), so that a future
+ *       fix in the mapper is picked up by the property tests without any test needing to change.
+ *
  * \sa make_local_lagrange_finite_element
+ * \sa ContinuousMapper
  */
 template <class GV, size_t r = 1, class R = double>
 class ContinuousLagrangeSpace : public SpaceInterface<GV, r, 1, R>

--- a/dune/gdt/spaces/hdiv/raviart-thomas.hh
+++ b/dune/gdt/spaces/hdiv/raviart-thomas.hh
@@ -50,6 +50,12 @@ namespace GDT {
  * The following dimensions/orders/elements are tested to fail:
  *
  * - 3d: mixed simplices and cubes (the mapper cannot handle non-conforming intersections/the switches are not corect)
+ *
+ * \note Order > 0 is a *hard* contract limit, unconditionally rejected by the constructor
+ *       (`DUNE_THROW_IF(order_ != 0, ...)` below): unlike the ContinuousLagrangeSpace order limit, this
+ *       is not a subtle mapper edge case but a simple "not implemented yet" -- the higher-order local
+ *       Raviart-Thomas finite elements and the matching basis/mapper plumbing do not exist in this
+ *       codebase at all. Lifting it means adding that machinery, not fixing an existing bug.
  */
 template <class GV, class R = double>
 class RaviartThomasSpace : public SpaceInterface<GV, GV::dimension, 1, R>

--- a/python/gdt/dune/gdt/CMakeLists.txt
+++ b/python/gdt/dune/gdt/CMakeLists.txt
@@ -66,8 +66,7 @@ dune_pybindxi_add_module(_local_integrands_binary_element_interface EXCLUDE_FROM
                          local/integrands/binary_element_interface.cc)
 dune_pybindxi_add_module(_local_integrands_binary_intersection_interface EXCLUDE_FROM_ALL ${header}
                          local/integrands/binary_intersection_interface.cc)
-dune_pybindxi_add_module(_local_integrands_element_div EXCLUDE_FROM_ALL ${header}
-                         local/integrands/element_div.cc)
+dune_pybindxi_add_module(_local_integrands_element_div EXCLUDE_FROM_ALL ${header} local/integrands/element_div.cc)
 dune_pybindxi_add_module(_local_integrands_element_product EXCLUDE_FROM_ALL ${header}
                          local/integrands/element_product.cc)
 dune_pybindxi_add_module(_local_integrands_intersection_product EXCLUDE_FROM_ALL ${header}

--- a/python/gdt/dune/gdt/CMakeLists.txt
+++ b/python/gdt/dune/gdt/CMakeLists.txt
@@ -66,6 +66,8 @@ dune_pybindxi_add_module(_local_integrands_binary_element_interface EXCLUDE_FROM
                          local/integrands/binary_element_interface.cc)
 dune_pybindxi_add_module(_local_integrands_binary_intersection_interface EXCLUDE_FROM_ALL ${header}
                          local/integrands/binary_intersection_interface.cc)
+dune_pybindxi_add_module(_local_integrands_element_div EXCLUDE_FROM_ALL ${header}
+                         local/integrands/element_div.cc)
 dune_pybindxi_add_module(_local_integrands_element_product EXCLUDE_FROM_ALL ${header}
                          local/integrands/element_product.cc)
 dune_pybindxi_add_module(_local_integrands_intersection_product EXCLUDE_FROM_ALL ${header}

--- a/python/gdt/dune/gdt/__init__.py
+++ b/python/gdt/dune/gdt/__init__.py
@@ -54,6 +54,7 @@ for mod_name in (  # order should not matter!
     "_local_functionals_vectorized_element_integrals",
     "_local_integrands_binary_element_interface",
     "_local_integrands_binary_intersection_interface",
+    "_local_integrands_element_div",
     "_local_integrands_element_product",
     "_local_integrands_intersection_product",
     "_local_integrands_ipdg_boundary_penalty",

--- a/python/gdt/dune/gdt/local/integrands/element_div.cc
+++ b/python/gdt/dune/gdt/local/integrands/element_div.cc
@@ -63,20 +63,17 @@ public:
       class_name += "_" + XT::Common::Typename<F>::value(/*fail_wo_typeid=*/true);
     const auto ClassName = XT::Common::to_camel_case(class_name);
     bound_type c(m, ClassName.c_str(), ClassName.c_str());
-    c.def(py::init([](const XT::Functions::GridFunctionInterface<E, 1, 1, F>& weight,
-                      const std::string logging_prefix) { return new type(weight, logging_prefix); }),
-          "weight"_a,
-          "logging_prefix"_a = "");
+    // NOTE: unlike LocalElementProductIntegrand, this class has no logging_prefix constructor
+    // argument (see div.hh), so none is exposed here.
+    c.def(py::init([](const XT::Functions::GridFunctionInterface<E, 1, 1, F>& weight) { return new type(weight); }),
+          "weight"_a);
 
     // factory
     const auto FactoryName = XT::Common::to_camel_case(class_id);
     m.def(
         FactoryName.c_str(),
-        [](const XT::Functions::GridFunctionInterface<E, 1, 1, F>& weight, const std::string& logging_prefix) {
-          return new type(weight, logging_prefix);
-        },
-        "weight"_a,
-        "logging_prefix"_a = "");
+        [](const XT::Functions::GridFunctionInterface<E, 1, 1, F>& weight) { return new type(weight); },
+        "weight"_a);
 
     return c;
   } // ... bind(...)

--- a/python/gdt/dune/gdt/local/integrands/element_div.cc
+++ b/python/gdt/dune/gdt/local/integrands/element_div.cc
@@ -47,11 +47,10 @@ public:
   using bound_type = pybind11::class_<type, base_type>;
 
 public:
-  static bound_type
-  bind(pybind11::module& m,
-       const std::string& layer_id = "",
-       const std::string& grid_id = XT::Grid::bindings::grid_name<G>::value(),
-       const std::string& class_id = "local_element_ansatz_value_test_div_product_integrand")
+  static bound_type bind(pybind11::module& m,
+                         const std::string& layer_id = "",
+                         const std::string& grid_id = XT::Grid::bindings::grid_name<G>::value(),
+                         const std::string& class_id = "local_element_ansatz_value_test_div_product_integrand")
   {
     namespace py = pybind11;
     using namespace pybind11::literals;

--- a/python/gdt/dune/gdt/local/integrands/element_div.cc
+++ b/python/gdt/dune/gdt/local/integrands/element_div.cc
@@ -46,7 +46,6 @@ public:
   using base_type = GDT::LocalBinaryElementIntegrandInterface<E, d, 1, F, F, 1, 1, F>;
   using bound_type = pybind11::class_<type, base_type>;
 
-public:
   static bound_type bind(pybind11::module& m,
                          const std::string& layer_id = "",
                          const std::string& grid_id = XT::Grid::bindings::grid_name<G>::value(),
@@ -55,10 +54,7 @@ public:
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    std::string class_name = class_id;
-    class_name += "_" + grid_id;
-    if (!layer_id.empty())
-      class_name += "_" + layer_id;
+    std::string class_name = class_id + "_" + grid_id + (layer_id.empty() ? "" : "_" + layer_id);
     if (!std::is_same<F, double>::value)
       class_name += "_" + XT::Common::Typename<F>::value(/*fail_wo_typeid=*/true);
     const auto ClassName = XT::Common::to_camel_case(class_name);

--- a/python/gdt/dune/gdt/local/integrands/element_div.cc
+++ b/python/gdt/dune/gdt/local/integrands/element_div.cc
@@ -1,0 +1,136 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+#include "config.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/provider.hh>
+
+#include <dune/gdt/local/integrands/div.hh>
+
+#include <python/xt/dune/xt/common/configuration.hh>
+#include <python/xt/dune/xt/common/fvector.hh>
+#include <python/xt/dune/xt/grid/grids.bindings.hh>
+
+
+namespace Dune {
+namespace GDT {
+namespace bindings {
+
+
+/**
+ * \sa GDT::LocalElementAnsatzValueTestDivProductIntegrand
+ *
+ * Pairs a d-valued test basis (its divergence) with a scalar ansatz basis, e.g. the velocity/pressure
+ * coupling term of a mixed (Taylor-Hood-type) Stokes discretization. Unlike LocalElementProductIntegrand,
+ * test and ansatz ranks are not equal, so there is a single instantiation per grid (test rank is always
+ * the grid's dimension), not one per rank.
+ */
+template <class G, class E, class F = double>
+class LocalElementAnsatzValueTestDivProductIntegrand
+{
+  static const constexpr size_t d = E::dimension;
+
+public:
+  using type = GDT::LocalElementAnsatzValueTestDivProductIntegrand<E, F, F, F>;
+  using base_type = GDT::LocalBinaryElementIntegrandInterface<E, d, 1, F, F, 1, 1, F>;
+  using bound_type = pybind11::class_<type, base_type>;
+
+public:
+  static bound_type
+  bind(pybind11::module& m,
+       const std::string& layer_id = "",
+       const std::string& grid_id = XT::Grid::bindings::grid_name<G>::value(),
+       const std::string& class_id = "local_element_ansatz_value_test_div_product_integrand")
+  {
+    namespace py = pybind11;
+    using namespace pybind11::literals;
+
+    std::string class_name = class_id;
+    class_name += "_" + grid_id;
+    if (!layer_id.empty())
+      class_name += "_" + layer_id;
+    if (!std::is_same<F, double>::value)
+      class_name += "_" + XT::Common::Typename<F>::value(/*fail_wo_typeid=*/true);
+    const auto ClassName = XT::Common::to_camel_case(class_name);
+    bound_type c(m, ClassName.c_str(), ClassName.c_str());
+    c.def(py::init([](const XT::Functions::GridFunctionInterface<E, 1, 1, F>& weight,
+                      const std::string logging_prefix) { return new type(weight, logging_prefix); }),
+          "weight"_a,
+          "logging_prefix"_a = "");
+
+    // factory
+    const auto FactoryName = XT::Common::to_camel_case(class_id);
+    m.def(
+        FactoryName.c_str(),
+        [](const XT::Functions::GridFunctionInterface<E, 1, 1, F>& weight, const std::string& logging_prefix) {
+          return new type(weight, logging_prefix);
+        },
+        "weight"_a,
+        "logging_prefix"_a = "");
+
+    return c;
+  } // ... bind(...)
+}; // class LocalElementAnsatzValueTestDivProductIntegrand
+
+
+} // namespace bindings
+} // namespace GDT
+} // namespace Dune
+
+
+template <class GridTypes = Dune::XT::Grid::bindings::AvailableGridTypes>
+struct LocalElementAnsatzValueTestDivProductIntegrand_for_all_grids
+{
+  using G = Dune::XT::Common::tuple_head_t<GridTypes>;
+  using GV = typename G::LeafGridView;
+  using E = Dune::XT::Grid::extract_entity_t<GV>;
+  static const constexpr size_t d = G::dimension;
+
+  static void bind(pybind11::module& m)
+  {
+    using Dune::GDT::bindings::LocalElementAnsatzValueTestDivProductIntegrand;
+
+    // Only meaningful once the test (divergenced) basis is vector-valued; in 1d it would coincide
+    // with the already-bound scalar LocalElementProductIntegrand.
+    if (d > 1)
+      LocalElementAnsatzValueTestDivProductIntegrand<G, E>::bind(m);
+    // add your extra dimensions here
+    // ...
+    LocalElementAnsatzValueTestDivProductIntegrand_for_all_grids<Dune::XT::Common::tuple_tail_t<GridTypes>>::bind(m);
+  }
+};
+
+template <>
+struct LocalElementAnsatzValueTestDivProductIntegrand_for_all_grids<Dune::XT::Common::tuple_null_type>
+{
+  static void bind(pybind11::module& /*m*/) {}
+};
+
+
+PYBIND11_MODULE(_local_integrands_element_div, m)
+{
+  namespace py = pybind11;
+  using namespace Dune;
+  using namespace Dune::XT;
+  using namespace Dune::GDT;
+
+  py::module::import("dune.xt.common");
+  py::module::import("dune.xt.la");
+  py::module::import("dune.xt.grid");
+  py::module::import("dune.xt.functions");
+
+  py::module::import("dune.gdt._local_integrands_binary_element_interface");
+
+  LocalElementAnsatzValueTestDivProductIntegrand_for_all_grids<XT::Grid::bindings::AvailableGridTypes>::bind(m);
+}

--- a/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
@@ -29,6 +29,7 @@
 #include <python/xt/dune/xt/common/fvector.hh>
 #include <python/xt/dune/xt/common/parameter.hh>
 #include <python/xt/dune/xt/grid/grids.bindings.hh>
+#include <python/xt/dune/xt/grid/traits.hh>
 #include <python/xt/dune/xt/grid/walker.hh>
 #include <python/xt/dune/xt/la/traits.hh>
 
@@ -152,13 +153,39 @@ public:
     addbind_methods(c);
 
     // factories
+    //
+    // The (ansatz_range, test_range) tags disambiguate between the (s_r, r_r) rank combinations
+    // sharing this FactoryName in the same module (all of a grid's square and rectangular bilinear
+    // forms, e.g. for a Taylor-Hood Stokes system: a d-by-d one for the velocity Laplacian and a
+    // 1-by-d one, source=pressure/range=velocity, for the divergence coupling): the plain (grid,
+    // logging_prefix) signature is identical across all four (s_r, r_r) instantiations, so pybind11
+    // would always resolve to the first-registered (here: scalar) overload without them. Only the
+    // scalar (1, 1) case gets defaults, matching the pre-existing zero-argument call sites.
     const auto FactoryName = XT::Common::to_camel_case(class_id);
-    m.def(
-        FactoryName.c_str(),
-        [](GP& grid, const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); },
-        "grid"_a,
-        "logging_prefix"_a = "",
-        py::keep_alive<0, 1>());
+    if constexpr (s_r == 1 && r_r == 1)
+      m.def(
+          FactoryName.c_str(),
+          [](GP& grid,
+             const XT::Grid::bindings::Dimension<s_r>&,
+             const XT::Grid::bindings::Dimension<r_r>&,
+             const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); },
+          "grid"_a,
+          "ansatz_range"_a = XT::Grid::bindings::Dimension<s_r>(),
+          "test_range"_a = XT::Grid::bindings::Dimension<r_r>(),
+          "logging_prefix"_a = "",
+          py::keep_alive<0, 1>());
+    else
+      m.def(
+          FactoryName.c_str(),
+          [](GP& grid,
+             const XT::Grid::bindings::Dimension<s_r>&,
+             const XT::Grid::bindings::Dimension<r_r>&,
+             const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); },
+          "grid"_a,
+          "ansatz_range"_a,
+          "test_range"_a,
+          "logging_prefix"_a = "",
+          py::keep_alive<0, 1>());
 
     return c;
 

--- a/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
@@ -127,6 +127,43 @@ public:
         py::call_guard<py::gil_scoped_release>());
   }
 
+private:
+  // Shared by bind_leaf/bind_coupling (only the "make a new instance from a grid" lambda
+  // differs between them): registers the two-overload factory below.
+  //
+  // The (ansatz_range, test_range) tags disambiguate between the (s_r, r_r) rank combinations
+  // sharing this FactoryName in the same module (all of a grid's square and rectangular bilinear
+  // forms, e.g. for a Taylor-Hood Stokes system: a d-by-d one for the velocity Laplacian and a
+  // 1-by-d one, source=pressure/range=velocity, for the divergence coupling): the plain (grid,
+  // logging_prefix) signature is identical across all four (s_r, r_r) instantiations, so pybind11
+  // would always resolve to the first-registered (here: scalar) overload without them. Only the
+  // scalar (1, 1) case gets defaults, matching the pre-existing zero-argument call sites.
+  template <class MakeInstance>
+  static void bind_factory(pybind11::module& m, const std::string& class_id, MakeInstance&& make_instance)
+  {
+    namespace py = pybind11;
+    using namespace pybind11::literals;
+
+    const auto FactoryName = XT::Common::to_camel_case(class_id);
+    if constexpr (s_r == 1 && r_r == 1)
+      m.def(FactoryName.c_str(),
+            std::forward<MakeInstance>(make_instance),
+            "grid"_a,
+            "ansatz_range"_a = XT::Grid::bindings::Dimension<s_r>(),
+            "test_range"_a = XT::Grid::bindings::Dimension<r_r>(),
+            "logging_prefix"_a = "",
+            py::keep_alive<0, 1>());
+    else
+      m.def(FactoryName.c_str(),
+            std::forward<MakeInstance>(make_instance),
+            "grid"_a,
+            "ansatz_range"_a,
+            "test_range"_a,
+            "logging_prefix"_a = "",
+            py::keep_alive<0, 1>());
+  } // ... bind_factory(...)
+
+public:
   static bound_type bind_leaf(pybind11::module& m,
                               const std::string& grid_id,
                               const std::string& layer_id = "",
@@ -152,36 +189,12 @@ public:
 
     addbind_methods(c);
 
-    // factories
-    //
-    // The (ansatz_range, test_range) tags disambiguate between the (s_r, r_r) rank combinations
-    // sharing this FactoryName in the same module (all of a grid's square and rectangular bilinear
-    // forms, e.g. for a Taylor-Hood Stokes system: a d-by-d one for the velocity Laplacian and a
-    // 1-by-d one, source=pressure/range=velocity, for the divergence coupling): the plain (grid,
-    // logging_prefix) signature is identical across all four (s_r, r_r) instantiations, so pybind11
-    // would always resolve to the first-registered (here: scalar) overload without them. Only the
-    // scalar (1, 1) case gets defaults, matching the pre-existing zero-argument call sites.
-    const auto FactoryName = XT::Common::to_camel_case(class_id);
-    auto factory_impl = [](GP& grid,
-                           const XT::Grid::bindings::Dimension<s_r>&,
-                           const XT::Grid::bindings::Dimension<r_r>&,
-                           const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); };
-    if constexpr (s_r == 1 && r_r == 1)
-      m.def(FactoryName.c_str(),
-            factory_impl,
-            "grid"_a,
-            "ansatz_range"_a = XT::Grid::bindings::Dimension<s_r>(),
-            "test_range"_a = XT::Grid::bindings::Dimension<r_r>(),
-            "logging_prefix"_a = "",
-            py::keep_alive<0, 1>());
-    else
-      m.def(FactoryName.c_str(),
-            factory_impl,
-            "grid"_a,
-            "ansatz_range"_a,
-            "test_range"_a,
-            "logging_prefix"_a = "",
-            py::keep_alive<0, 1>());
+    bind_factory(m,
+                 class_id,
+                 [](GP& grid,
+                    const XT::Grid::bindings::Dimension<s_r>&,
+                    const XT::Grid::bindings::Dimension<r_r>&,
+                    const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); });
 
     return c;
 
@@ -213,30 +226,12 @@ public:
 
     addbind_methods(c);
 
-    // factories: same (s_r, r_r) disambiguation as bind_leaf, see the comment there.
-    const auto FactoryName = XT::Common::to_camel_case(class_id);
-    auto factory_impl = [](XT::Grid::CouplingGridProvider<AGV>& grid,
-                           const XT::Grid::bindings::Dimension<s_r>&,
-                           const XT::Grid::bindings::Dimension<r_r>&,
-                           const std::string& logging_prefix) {
-      return new type(grid.coupling_view(), logging_prefix);
-    };
-    if constexpr (s_r == 1 && r_r == 1)
-      m.def(FactoryName.c_str(),
-            factory_impl,
-            "grid"_a,
-            "ansatz_range"_a = XT::Grid::bindings::Dimension<s_r>(),
-            "test_range"_a = XT::Grid::bindings::Dimension<r_r>(),
-            "logging_prefix"_a = "",
-            py::keep_alive<0, 1>());
-    else
-      m.def(FactoryName.c_str(),
-            factory_impl,
-            "grid"_a,
-            "ansatz_range"_a,
-            "test_range"_a,
-            "logging_prefix"_a = "",
-            py::keep_alive<0, 1>());
+    bind_factory(m,
+                 class_id,
+                 [](XT::Grid::CouplingGridProvider<AGV>& grid,
+                    const XT::Grid::bindings::Dimension<s_r>&,
+                    const XT::Grid::bindings::Dimension<r_r>&,
+                    const std::string& logging_prefix) { return new type(grid.coupling_view(), logging_prefix); });
 
     return c;
 

--- a/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/bilinear_form_for_all_grids.hh
@@ -162,30 +162,26 @@ public:
     // would always resolve to the first-registered (here: scalar) overload without them. Only the
     // scalar (1, 1) case gets defaults, matching the pre-existing zero-argument call sites.
     const auto FactoryName = XT::Common::to_camel_case(class_id);
+    auto factory_impl = [](GP& grid,
+                           const XT::Grid::bindings::Dimension<s_r>&,
+                           const XT::Grid::bindings::Dimension<r_r>&,
+                           const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); };
     if constexpr (s_r == 1 && r_r == 1)
-      m.def(
-          FactoryName.c_str(),
-          [](GP& grid,
-             const XT::Grid::bindings::Dimension<s_r>&,
-             const XT::Grid::bindings::Dimension<r_r>&,
-             const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); },
-          "grid"_a,
-          "ansatz_range"_a = XT::Grid::bindings::Dimension<s_r>(),
-          "test_range"_a = XT::Grid::bindings::Dimension<r_r>(),
-          "logging_prefix"_a = "",
-          py::keep_alive<0, 1>());
+      m.def(FactoryName.c_str(),
+            factory_impl,
+            "grid"_a,
+            "ansatz_range"_a = XT::Grid::bindings::Dimension<s_r>(),
+            "test_range"_a = XT::Grid::bindings::Dimension<r_r>(),
+            "logging_prefix"_a = "",
+            py::keep_alive<0, 1>());
     else
-      m.def(
-          FactoryName.c_str(),
-          [](GP& grid,
-             const XT::Grid::bindings::Dimension<s_r>&,
-             const XT::Grid::bindings::Dimension<r_r>&,
-             const std::string& logging_prefix) { return new type(grid.leaf_view(), logging_prefix); },
-          "grid"_a,
-          "ansatz_range"_a,
-          "test_range"_a,
-          "logging_prefix"_a = "",
-          py::keep_alive<0, 1>());
+      m.def(FactoryName.c_str(),
+            factory_impl,
+            "grid"_a,
+            "ansatz_range"_a,
+            "test_range"_a,
+            "logging_prefix"_a = "",
+            py::keep_alive<0, 1>());
 
     return c;
 
@@ -217,16 +213,30 @@ public:
 
     addbind_methods(c);
 
-    // factories
+    // factories: same (s_r, r_r) disambiguation as bind_leaf, see the comment there.
     const auto FactoryName = XT::Common::to_camel_case(class_id);
-    m.def(
-        FactoryName.c_str(),
-        [](XT::Grid::CouplingGridProvider<AGV>& grid, const std::string& logging_prefix) {
-          return new type(grid.coupling_view(), logging_prefix);
-        },
-        "grid"_a,
-        "logging_prefix"_a = "",
-        py::keep_alive<0, 1>());
+    auto factory_impl = [](XT::Grid::CouplingGridProvider<AGV>& grid,
+                           const XT::Grid::bindings::Dimension<s_r>&,
+                           const XT::Grid::bindings::Dimension<r_r>&,
+                           const std::string& logging_prefix) {
+      return new type(grid.coupling_view(), logging_prefix);
+    };
+    if constexpr (s_r == 1 && r_r == 1)
+      m.def(FactoryName.c_str(),
+            factory_impl,
+            "grid"_a,
+            "ansatz_range"_a = XT::Grid::bindings::Dimension<s_r>(),
+            "test_range"_a = XT::Grid::bindings::Dimension<r_r>(),
+            "logging_prefix"_a = "",
+            py::keep_alive<0, 1>());
+    else
+      m.def(FactoryName.c_str(),
+            factory_impl,
+            "grid"_a,
+            "ansatz_range"_a,
+            "test_range"_a,
+            "logging_prefix"_a = "",
+            py::keep_alive<0, 1>());
 
     return c;
 

--- a/python/gdt/dune/gdt/spaces/h1/continuous_lagrange_for_all_grids.hh
+++ b/python/gdt/dune/gdt/spaces/h1/continuous_lagrange_for_all_grids.hh
@@ -21,6 +21,7 @@ struct ContinuousLagrangeSpace_for_all_grids
 {
   using G = Dune::XT::Common::tuple_head_t<GridTypes>;
   using GV = typename G::LeafGridView;
+  static const constexpr size_t d = G::dimension;
 
   static void bind(pybind11::module& m)
   {
@@ -28,6 +29,8 @@ struct ContinuousLagrangeSpace_for_all_grids
     using Dune::XT::Grid::bindings::grid_name;
 
     ContinuousLagrangeSpace<GV>::bind(m, grid_name<G>::value());
+    if (d > 1)
+      ContinuousLagrangeSpace<GV, d>::bind(m, grid_name<G>::value());
     // add your extra dimensions here
     // ...
     ContinuousLagrangeSpace_for_all_grids<Dune::XT::Common::tuple_tail_t<GridTypes>>::bind(m);

--- a/python/gdt/test/test_hypothesis_spaces.py
+++ b/python/gdt/test/test_hypothesis_spaces.py
@@ -88,7 +88,9 @@ def test_vector_cg_dof_count_on_cube_grids(spec, order):
     grid = spec.make_grid()
     scalar_space = ContinuousLagrangeSpace(grid, order=order)
     vector_space = ContinuousLagrangeSpace(grid, order=order, dim_range=Dim(spec.dim))
-    assert vector_space.num_DoFs == cg_vector_dof_count(order, spec.num_elements, spec.dim)
+    assert vector_space.num_DoFs == cg_vector_dof_count(
+        order, spec.num_elements, spec.dim
+    )
     assert vector_space.num_DoFs == spec.dim * scalar_space.num_DoFs
 
 

--- a/python/gdt/test/test_hypothesis_spaces.py
+++ b/python/gdt/test/test_hypothesis_spaces.py
@@ -28,7 +28,13 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from dune.xt.test.hypothesis_strategies import GRID_COMBINATIONS, grid_specs, has_grid
+from dune.xt.test.hypothesis_strategies import (
+    GRID_COMBINATIONS,
+    cg_scalar_dof_count,
+    cg_vector_dof_count,
+    grid_specs,
+    has_grid,
+)
 
 # Skip cleanly on builds that bind no grids at all; element-specific tests below add their own
 # guard so a build without, e.g., ALUGrid (no simplex grids) skips just those.
@@ -65,8 +71,25 @@ def test_cg_dof_count_on_cube_grids(spec, order):
 
     space = ContinuousLagrangeSpace(spec.make_grid(), order=order)
     # tensor-product Lagrange nodes: order*n + 1 per axis
-    assert space.num_DoFs == int(np.prod([order * n + 1 for n in spec.num_elements]))
+    assert space.num_DoFs == cg_scalar_dof_count(order, spec.num_elements)
     assert space.min_polorder == space.max_polorder == order
+
+
+@_needs_cube
+@given(spec=grid_specs(elements=("cube",), dims=(2, 3)), order=st.integers(1, 3))
+def test_vector_cg_dof_count_on_cube_grids(spec, order):
+    """WP4 (#320): ContinuousLagrangeSpace(..., dim_range=Dim(d)) gets the same factory overload
+    DiscontinuousLagrangeSpace/FiniteVolumeSpace already had; its DoF count is exactly d times the
+    scalar space's (see cg_vector_dof_count).
+    """
+    from dune.gdt import ContinuousLagrangeSpace
+    from dune.xt.grid import Dim
+
+    grid = spec.make_grid()
+    scalar_space = ContinuousLagrangeSpace(grid, order=order)
+    vector_space = ContinuousLagrangeSpace(grid, order=order, dim_range=Dim(spec.dim))
+    assert vector_space.num_DoFs == cg_vector_dof_count(order, spec.num_elements, spec.dim)
+    assert vector_space.num_DoFs == spec.dim * scalar_space.num_DoFs
 
 
 @_needs_simplex
@@ -100,6 +123,24 @@ def test_fv_space_has_one_dof_per_element(spec):
     space = FiniteVolumeSpace(grid)
     assert space.num_DoFs == grid.size(0)
     assert space.min_polorder == space.max_polorder == 0
+
+
+@given(spec=grid_specs())
+def test_rt_space_order_zero_works_higher_orders_are_a_documented_contract_limit(spec):
+    """WP4 (#320): unlike the CG order boundary above (a subtle, grid-dependent mapper edge case),
+    RaviartThomasSpace order > 0 is unconditionally rejected (dune/gdt/spaces/hdiv/raviart-thomas.hh):
+    the higher-order local RT finite elements simply do not exist in this codebase yet. Encoding order=0
+    as the only value exercised here keeps that contract visible to the property suite.
+    """
+    from dune.gdt import RaviartThomasSpace
+    from dune.xt.common import DuneError
+
+    grid = spec.make_grid()
+    space = RaviartThomasSpace(grid, order=0)
+    assert space.min_polorder == space.max_polorder == 0
+
+    with pytest.raises(DuneError):
+        RaviartThomasSpace(grid, order=1)
 
 
 # This property crashes the interpreter with the current bindings: destroying the

--- a/python/gdt/test/test_hypothesis_spaces.py
+++ b/python/gdt/test/test_hypothesis_spaces.py
@@ -23,7 +23,6 @@ import subprocess
 import sys
 import textwrap
 
-import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st

--- a/python/gdt/test/test_hypothesis_spaces.py
+++ b/python/gdt/test/test_hypothesis_spaces.py
@@ -126,12 +126,17 @@ def test_fv_space_has_one_dof_per_element(spec):
     assert space.min_polorder == space.max_polorder == 0
 
 
-@given(spec=grid_specs())
+@given(spec=grid_specs(conforming_only=True))
 def test_rt_space_order_zero_works_higher_orders_are_a_documented_contract_limit(spec):
     """WP4 (#320): unlike the CG order boundary above (a subtle, grid-dependent mapper edge case),
     RaviartThomasSpace order > 0 is unconditionally rejected (dune/gdt/spaces/hdiv/raviart-thomas.hh):
     the higher-order local RT finite elements simply do not exist in this codebase yet. Encoding order=0
     as the only value exercised here keeps that contract visible to the property suite.
+
+    conforming_only=True: the class doc comment (raviart-thomas.hh) only claims order 0 works "on
+    simplices, cubes" without distinguishing conforming/nonconforming grids, so nonconforming ALU
+    draws are excluded here rather than assumed to work; all three dims are otherwise exercised
+    (1d is explicitly documented as working, unlike the CG vector test above which needs d > 1).
     """
     from dune.gdt import RaviartThomasSpace
     from dune.xt.common import DuneError

--- a/python/xt/dune/xt/test/hypothesis_strategies.py
+++ b/python/xt/dune/xt/test/hypothesis_strategies.py
@@ -424,6 +424,27 @@ def polynomials(draw, dim, max_order=3, coefficient_bound=100.0, min_order=0):
     return Polynomial(dim=dim, coefficients=coefficients)
 
 
+def cg_dofs_per_axis(order, num_elements):
+    """Tensor-product Lagrange node count per axis for a scalar CG space on a structured cube grid."""
+    return [order * n + 1 for n in num_elements]
+
+
+def cg_scalar_dof_count(order, num_elements):
+    """Expected `num_DoFs` of a scalar `ContinuousLagrangeSpace` on a structured cube `GridSpec`."""
+    return int(np.prod(cg_dofs_per_axis(order, num_elements)))
+
+
+def cg_vector_dof_count(order, num_elements, dim_range):
+    """Expected `num_DoFs` of a vector-valued CG space (`dim_range=Dim(dim_range)`) on a cube grid.
+
+    The mapper attaches `dim_range` copies of every scalar Lagrange DoF to the same (sub)entity (the
+    `ContinuousMapper` is generic in the local finite element family and does not special-case `r`), so
+    the global count is exactly `dim_range` times the scalar space's count -- the vector-CG factory
+    overloads added for WP4 (#320) generalize the scalar-only DoF-count property below to this formula.
+    """
+    return dim_range * cg_scalar_dof_count(order, num_elements)
+
+
 # --- unstructured (UG) grids: mixed-element and prism meshes --------------------------------
 #
 # UGGrid is the only bound grid manager that can hold a mesh with more than one geometry type (or

--- a/python/xt/test/test_hypothesis_strategies.py
+++ b/python/xt/test/test_hypothesis_strategies.py
@@ -328,6 +328,32 @@ def test_dg_dof_count_on_mixed_grid_sums_per_geometry():
     assert hs.dg_dof_count_on_mixed_grid(_FakeMixedGrid(), order=0) == 4
 
 
+# --- WP4 (#320): vector-valued CG DoF-count formula ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("order", "num_elements", "expected"),
+    [
+        (1, (2, 2), 9),  # P_1 nodes on a 2x2 quad grid: 3 per axis
+        (2, (2, 2), 25),  # P_2: 2*2+1 = 5 per axis
+        (1, (2, 2, 2), 27),  # 3d: 3 per axis, three axes
+    ],
+)
+def test_cg_scalar_dof_count(order, num_elements, expected):
+    assert hs.cg_scalar_dof_count(order, num_elements) == expected
+
+
+@pytest.mark.parametrize("dim_range", [1, 2, 3])
+@pytest.mark.parametrize(
+    ("order", "num_elements"),
+    [(1, (2, 2)), (2, (2, 2)), (1, (2, 2, 2)), (3, (1, 1))],
+)
+def test_cg_vector_dof_count_is_dim_range_times_scalar(order, num_elements, dim_range):
+    assert hs.cg_vector_dof_count(order, num_elements, dim_range) == dim_range * hs.cg_scalar_dof_count(
+        order, num_elements
+    )
+
+
 # --- against the real bindings, when this build actually provides them --------------------
 
 

--- a/python/xt/test/test_hypothesis_strategies.py
+++ b/python/xt/test/test_hypothesis_strategies.py
@@ -349,9 +349,9 @@ def test_cg_scalar_dof_count(order, num_elements, expected):
     [(1, (2, 2)), (2, (2, 2)), (1, (2, 2, 2)), (3, (1, 1))],
 )
 def test_cg_vector_dof_count_is_dim_range_times_scalar(order, num_elements, dim_range):
-    assert hs.cg_vector_dof_count(order, num_elements, dim_range) == dim_range * hs.cg_scalar_dof_count(
-        order, num_elements
-    )
+    assert hs.cg_vector_dof_count(
+        order, num_elements, dim_range
+    ) == dim_range * hs.cg_scalar_dof_count(order, num_elements)
 
 
 # --- against the real bindings, when this build actually provides them --------------------


### PR DESCRIPTION
## Summary

Implements WP4 of #320: vector-valued CG + space-limit fixes.

- **`ContinuousLagrangeSpace` gets the `dim_range=Dim(1)`/`Dim(d)` factory overload** that `DiscontinuousLagrangeSpace`/`FiniteVolumeSpace` already had. The `bindings::ContinuousLagrangeSpace` pybind11 wrapper already handled `r > 1` correctly; the only missing piece was the `if (d > 1) ContinuousLagrangeSpace<GV, d>::bind(...)` instantiation call in `continuous_lagrange_for_all_grids.hh`.
- **Both known space-limit contracts are documented, not fixed** (both are non-trivial, separately-scoped pieces of work):
  - `ContinuousMapper` order > 2 on non-cube grids: a genuine unresolved local-to-global DoF orientation problem (see the comment in `ContinuousMapper::global_index`), spelled out in `ContinuousLagrangeSpace`'s class doc comment; already covered by `_cg_orders` in the Python property suite.
  - `RaviartThomasSpace` order > 0: unconditionally rejected — higher-order local RT finite elements simply don't exist yet. Documented in the class comment, and now exercised by a new hypothesis test (order=0 works, order=1 raises `DuneError`).
- **`cg_scalar_dof_count` / `cg_vector_dof_count`** added to `dune.xt.test.hypothesis_strategies`: the vector CG DoF count is exactly `dim_range` times the scalar count (same generic `ContinuousMapper`, no per-`r` special-casing), with a new property test checking this against the factory on cube grids.
- **`example__stokes_taylor_hood.md`**: a Taylor-Hood P2/P1 Stokes notebook (`dune/gdt/test/stokes/stokes-taylorhood.hh` is the C++ reference), linked from `examples.md` so the docs CI job executes it as a bindings smoke test.

Getting the Stokes notebook to actually run needed two more small gaps closed:
- **Bind `LocalElementAnsatzValueTestDivProductIntegrand`** (`local/integrands/div.hh`) — the C++ class already existed, it just wasn't exposed to Python. New file `local/integrands/element_div.cc`, mirroring `element_product.cc`.
- **Fix `BilinearForm`'s factory-function ambiguity** for rectangular rank combinations: `BilinearForm(grid, ...)`'s top-level factory took only `(grid, logging_prefix)`, a signature identical across all four `(source_rank, range_rank)` instantiations sharing that name in one module, so it always resolved to the first-registered (scalar) overload. Added `ansatz_range`/`test_range` `Dimension` tags (defaulted only for the scalar case) to disambiguate — the same idiom CG/DG already use for `dim_range`.

The saddle-point system itself is solved directly in the notebook via `get_entry`/numpy, since `dune.xt.la` doesn't (yet) expose a saddle-point solver to Python — this mirrors the BC-lifting/pressure-pinning steps of the C++ reference test, just performed transparently in Python instead of hidden in solver machinery.

## Test plan

- [ ] CI build (C++ compile of the new/changed binding TUs)
- [ ] `python/gdt/test/test_hypothesis_spaces.py` (new vector-CG DoF-count test, new RT contract test)
- [ ] `python/xt/test/test_hypothesis_strategies.py` (new `cg_scalar_dof_count`/`cg_vector_dof_count` unit tests)
- [ ] docs job executes `example__stokes_taylor_hood.md` via myst-nb

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jok3fz6VHGuJUtUQh2UNdU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Python Taylor–Hood (P2/P1) stationary Stokes example with visualization and solution comparisons.
  * Added support for divergence coupling in mixed finite-element workflows.
  * Extended multidimensional continuous Lagrange space bindings, including vector-valued spaces.

* **Documentation**
  * Documented supported order limits for continuous Lagrange and Raviart–Thomas spaces.
  * Added the Stokes example to the examples index.

* **Tests**
  * Added validation for vector-valued degree-of-freedom counts and Raviart–Thomas order restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->