### PR TITLE
test(la): binding-driven property suites to reduce dune/xt/la partials (Tier 1)

### DIFF
--- a/dune/xt/la/container/common/matrix/dense.hh
+++ b/dune/xt/la/container/common/matrix/dense.hh
@@ -413,7 +413,7 @@ public:
     for (size_t cc = 0; cc < cols(); ++cc) {
       V2::set_entry(yy, cc, 0.);
       for (size_t rr = 0; rr < rows(); ++rr)
-        V2::add_to_entry(yy, cc, get_entry(cc, rr) * V1::get_entry(xx, rr));
+        V2::add_to_entry(yy, cc, get_entry(rr, cc) * V1::get_entry(xx, rr));
     }
   }
 

--- a/python/xt/dune/xt/la/solver.hh
+++ b/python/xt/dune/xt/la/solver.hh
@@ -41,7 +41,15 @@ auto bind_Solver(pybind11::module& m)
   c.def_static("types", &C::types);
   c.def_static("options", &C::options);
 
-  c.def(py::init<M>());
+  // py::keep_alive<1, 2>(): Solver<M> stores its matrix by const reference (see e.g.
+  // dune/xt/la/solver/{common,eigen,istl}.hh's `const MatrixType& matrix_;`), so without tying the
+  // constructed Solver's lifetime to its matrix argument, a caller that does not keep a separate
+  // Python reference to the matrix (e.g. `Solver(make_matrix(...))`) leaves `matrix_` dangling the
+  // moment the temporary is garbage-collected -- any later apply() then reads through freed memory.
+  // The sibling `make_solver` factory just below already gets this right via keep_alive<0, 1>; the
+  // EigenSolver/MatrixInverter constructors (solver_machinery.hh's bind_single_matrix_solver_ctor)
+  // already get this right via keep_alive<1, 2>. This constructor was the one binding that didn't.
+  c.def(py::init<M>(), py::keep_alive<1, 2>());
 
   c.def("apply", [](const C& self, const V& rhs, V& solution) { self.apply(rhs, solution); }, "rhs"_a, "solution"_a);
   c.def(

--- a/python/xt/dune/xt/la/solver.hh
+++ b/python/xt/dune/xt/la/solver.hh
@@ -41,15 +41,20 @@ auto bind_Solver(pybind11::module& m)
   c.def_static("types", &C::types);
   c.def_static("options", &C::options);
 
-  // py::keep_alive<1, 2>(): Solver<M> stores its matrix by const reference (see e.g.
-  // dune/xt/la/solver/{common,eigen,istl}.hh's `const MatrixType& matrix_;`), so without tying the
-  // constructed Solver's lifetime to its matrix argument, a caller that does not keep a separate
-  // Python reference to the matrix (e.g. `Solver(make_matrix(...))`) leaves `matrix_` dangling the
-  // moment the temporary is garbage-collected -- any later apply() then reads through freed memory.
-  // The sibling `make_solver` factory just below already gets this right via keep_alive<0, 1>; the
-  // EigenSolver/MatrixInverter constructors (solver_machinery.hh's bind_single_matrix_solver_ctor)
-  // already get this right via keep_alive<1, 2>. This constructor was the one binding that didn't.
-  c.def(py::init<M>(), py::keep_alive<1, 2>());
+  // py::init<M>() (M by *value*) is not enough here, even combined with keep_alive: pybind11's
+  // generated init factory takes its argument by the exact type listed, so it copies the Python-owned
+  // matrix into a temporary and passes *that* by const-ref into Solver's constructor; matrix_ then
+  // binds to the temporary, which is destroyed the moment the init factory returns, before any
+  // keep_alive relationship (which only ties Python object lifetimes together) can matter. Using a
+  // lambda with an explicit `const M&` parameter instead avoids the copy: the type caster hands back a
+  // reference to the actual Python-owned instance, so `C(matrix)` -- and the `matrix_` reference it
+  // stores (see dune/xt/la/solver/{common,eigen,istl}.hh's `const MatrixType& matrix_;`) -- binds to
+  // that instance directly, and keep_alive<1, 2> then correctly keeps it alive for as long as the
+  // solver lives. This is the same pattern already used by the sibling `make_solver` factory just below
+  // (keep_alive<0, 1>) and by the EigenSolver/MatrixInverter constructors in
+  // solver_machinery.hh's bind_single_matrix_solver_ctor (keep_alive<1, 2>) -- this constructor was the
+  // one binding that still used plain py::init<M>().
+  c.def(py::init([](const M& matrix) { return std::make_unique<C>(matrix); }), py::keep_alive<1, 2>());
 
   c.def("apply", [](const C& self, const V& rhs, V& solution) { self.apply(rhs, solution); }, "rhs"_a, "solution"_a);
   c.def(

--- a/python/xt/dune/xt/test/hypothesis_strategies.py
+++ b/python/xt/dune/xt/test/hypothesis_strategies.py
@@ -189,6 +189,18 @@ def discover_matrix_inverter_types(module=None):
     return _discover_solver_machinery_types("MatrixInverter", module)
 
 
+def discover_solver_types(module=None):
+    """Matrix classes for which dune.xt.la binds a linear Solver (dune/xt/la/solver.hh).
+
+    The bound class is `<MatrixClassName>Solver` (bind_Solver names it
+    to_camel_case(container_name + "_solver"), which equals the matrix's own camel-case name with a
+    "Solver" suffix). Only the double-valued CommonDense/IstlSparse/EigenDense/EigenSparse matrices
+    get a bind_Solver call in bindings.cc, so this discovers exactly that subset -- the "Solver"
+    suffix does not collide with the "EigenSolver"/"MatrixInverter" machinery bound alongside them.
+    """
+    return _discover_solver_machinery_types("Solver", module)
+
+
 def dense_sparsity_pattern(rows, cols):
     """A SparsityPatternDefault with every (i, j) entry present.
 

--- a/python/xt/test/test_hypothesis_la_eigensolver.py
+++ b/python/xt/test/test_hypothesis_la_eigensolver.py
@@ -98,6 +98,39 @@ def make_eigenvalues_only_solver(solver_cls, mat):
     return solver_cls(mat, opts)
 
 
+def make_full_solver(solver_cls, mat):
+    """Construct solver_cls(mat) pinned to "shifted_qr" with eigenvector computation left on and the
+    eigendecomposition post-check enabled.
+
+    This is the counterpart of make_eigenvalues_only_solver: where that one disables everything but
+    the eigenvalues (to keep the eigenvalue-vs-scipy property cheap), this one keeps
+    compute_eigenvectors at its default_eigen_solver_options() value (on) so the eigenvector
+    accessors return populated data and EigenSolverBase::post_checks() actually runs the
+    T*lambda*T^-1 == A check internally -- the branches in dune/xt/la/eigen-solver/internal/base.hh
+    (complex_eigendecomposition_check / assert_eigendecomposition) that the eigenvalues-only path
+    skips.
+
+    assert_eigendecomposition is an *absolute* tolerance (base.hh compares |error_ij| > tolerance),
+    so its 1e-10 default would spuriously trip on the larger-magnitude SPD matrices spd_matrices()
+    generates (entries can reach the hundreds). We pin it to 1e-6, still positive -- so the
+    post-check branch is exercised -- but comfortably above the ~1e-9 worst-case reconstruction
+    error for these small, bounded, +n*I-regularized systems. "shifted_qr" (pure C++, exercised by
+    the existing eigensolver_for_real_matrix_with_real_evs*.tpl suite) is used rather than the
+    default "lapack" for the same reason documented in make_eigenvalues_only_solver: the LAPACK
+    eigenvector branch has a still-open defect.
+    """
+    opts = dict(solver_cls.options("shifted_qr"))
+    opts["assert_eigendecomposition"] = "1e-6"
+    return solver_cls(mat, opts)
+
+
+def matrix_as_numpy(mat):
+    return np.array(
+        [[mat.get_entry(ii, jj) for jj in range(mat.cols)] for ii in range(mat.rows)],
+        dtype=complex,
+    )
+
+
 @pytest.mark.skipif(not MATRIX_CLASSES, reason="no eigen-solver binding available")
 @pytest.mark.parametrize("cls", MATRIX_CLASSES, ids=lambda c: c.__name__)
 class TestEigenSolverAgainstScipy:
@@ -128,6 +161,47 @@ class TestEigenSolverAgainstScipy:
         assert solver.max_eigenvalues(1)[0] == pytest.approx(
             expected[-1], rel=1e-6, abs=1e-8
         )
+
+    @settings(deadline=None)
+    @given(arr=spd_matrices(min_size=2))
+    def test_min_and_max_eigenvalues_return_k_extremes(self, cls, arr):
+        # min/max_eigenvalues(k) for k > 1 exercises the partial-sort branch in
+        # EigenSolverBase (base.hh), which min/max_eigenvalues(1) above does not.
+        n = arr.shape[0]
+        k = min(2, n)
+        solver = make_eigenvalues_only_solver(
+            eigen_solver_for(cls), make_matrix(cls, arr)
+        )
+        expected = np.sort(scipy_linalg.eigvalsh(arr))
+
+        smallest = np.sort(np.array(solver.min_eigenvalues(k)))
+        largest = np.sort(np.array(solver.max_eigenvalues(k)))
+        assert smallest == pytest.approx(expected[:k], rel=1e-6, abs=1e-8)
+        assert largest == pytest.approx(expected[-k:], rel=1e-6, abs=1e-8)
+
+    @settings(deadline=None)
+    @given(arr=spd_matrices())
+    def test_eigenvectors_satisfy_the_eigenrelation(self, cls, arr):
+        # Enabling eigenvector computation + the eigendecomposition post-check drives the branches
+        # in base.hh that the eigenvalues-only property test skips. A*V == V*diag(lambda) is
+        # checked directly (order-consistent: eigenvalues() and eigenvectors() share a column
+        # order), which sidesteps the non-uniqueness of eigenvectors for repeated eigenvalues.
+        solver = make_full_solver(eigen_solver_for(cls), make_matrix(cls, arr))
+        evals = np.array([complex(ev) for ev in solver.eigenvalues()])
+        vectors = matrix_as_numpy(solver.eigenvectors())
+        a = arr.astype(complex)
+        residual = a @ vectors - vectors @ np.diag(evals)
+        scale = float(np.linalg.norm(a)) + 1.0
+        assert float(np.linalg.norm(residual)) == pytest.approx(0.0, abs=1e-6 * scale)
+
+    @settings(deadline=None)
+    @given(arr=spd_matrices())
+    def test_eigenvectors_inverse_is_the_inverse(self, cls, arr):
+        solver = make_full_solver(eigen_solver_for(cls), make_matrix(cls, arr))
+        vectors = matrix_as_numpy(solver.eigenvectors())
+        inverse = matrix_as_numpy(solver.eigenvectors_inverse())
+        identity = np.eye(arr.shape[0], dtype=complex)
+        assert vectors @ inverse == pytest.approx(identity, rel=1e-6, abs=1e-6)
 
 
 if __name__ == "__main__":

--- a/python/xt/test/test_hypothesis_la_matrix.py
+++ b/python/xt/test/test_hypothesis_la_matrix.py
@@ -1,0 +1,214 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""Property-based tests of the real (double) LA matrix containers against a numpy oracle.
+
+The complementary complex-field matrix suite already lives in
+test_hypothesis_la_complex_container.py; the double-field vectors in test_hypothesis_la_container.py.
+This closes the remaining gap -- the double-field *matrix* containers -- so every bound
+(backend x field) matrix combination has a runtime property suite. Like the vector suite it walks
+whatever dune.xt.la actually bound (discover_matrix_types), so dense/sparse Common, Istl and Eigen
+are all covered without hard-coding the list, and hypothesis supplies the payloads.
+
+The operations exercised here (matrix-vector product mv()/mtv(), scal(), axpy(), the +/- operators,
+unit_row()/unit_col() and sup_norm()) are the per-backend overrides in
+dune/xt/la/container/{istl,eigen,common}*.hh, which the fixed-input C++ .tpl tests only reach for a
+handful of hand-written matrices.
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    dense_sparsity_pattern,
+    discover_matrix_types,
+    discover_vector_types,
+    finite_floats,
+)
+
+MATRIX_CLASSES = list(discover_matrix_types(field="double"))
+VECTOR_CLASSES = list(discover_vector_types(field="double"))
+
+# relative tolerance for comparisons against numpy: both sides accumulate in double, but not
+# necessarily in the same order, so exact equality only holds for order-independent quantities
+RTOL = 1e-12
+
+
+def make_vector(cls, values):
+    vec = cls(len(values), 0.0)
+    for ii, value in enumerate(values):
+        vec.set_entry(ii, float(value))
+    return vec
+
+
+def make_matrix(cls, arr):
+    rows, cols = arr.shape
+    mat = cls(rows, cols, dense_sparsity_pattern(rows, cols))
+    for ii in range(rows):
+        for jj in range(cols):
+            mat.set_entry(ii, jj, float(arr[ii, jj]))
+    return mat
+
+
+def matrix_as_numpy(mat):
+    return np.array(
+        [[mat.get_entry(ii, jj) for jj in range(mat.cols)] for ii in range(mat.rows)]
+    )
+
+
+def matching_vector_class(matrix_cls):
+    """The double vector class dune.xt.la pairs matrix_cls with, by shared backend prefix.
+
+    Mirrors test_hypothesis_la_complex_container.matching_vector_class: every Common-family matrix
+    (dense or sparse) is paired with the same CommonVector by addbind_Matrix_Vector_interaction in
+    bindings.cc, Istl matrices with IstlVector, Eigen matrices with EigenVector.
+    """
+    name = matrix_cls.__name__
+    for vector_cls in VECTOR_CLASSES:
+        prefix = vector_cls.__name__[: -len("Vector")]
+        if name.startswith(prefix):
+            return vector_cls
+    raise AssertionError(f"no double vector class found for {name}")
+
+
+@st.composite
+def matrix_arrays(draw, min_dim=1, max_dim=8, bound=1e3, square=False):
+    rows = draw(st.integers(min_dim, max_dim))
+    cols = rows if square else draw(st.integers(min_dim, max_dim))
+    entries = draw(
+        st.lists(finite_floats(bound), min_size=rows * cols, max_size=rows * cols)
+    )
+    return np.asarray(entries).reshape(rows, cols)
+
+
+@pytest.mark.skipif(not MATRIX_CLASSES, reason="no double LA matrix binding available")
+@pytest.mark.parametrize("cls", MATRIX_CLASSES, ids=lambda c: c.__name__)
+class TestMatrixAgainstNumpy:
+    @given(arr=matrix_arrays())
+    def test_entry_roundtrip_and_shape(self, cls, arr):
+        mat = make_matrix(cls, arr)
+        assert mat.rows == arr.shape[0]
+        assert mat.cols == arr.shape[1]
+        assert matrix_as_numpy(mat) == pytest.approx(arr, abs=0.0)
+
+    @given(arr=matrix_arrays(), data=st.data())
+    def test_matvec_and_transpose_matvec(self, cls, arr, data):
+        rows, cols = arr.shape
+        mat = make_matrix(cls, arr)
+        vec_cls = matching_vector_class(cls)
+
+        xs = data.draw(
+            st.lists(finite_floats(1e3), min_size=cols, max_size=cols), label="mv x"
+        )
+        yv = mat.dot(make_vector(vec_cls, xs))
+        y_expected = arr @ np.asarray(xs)
+        y_actual = np.array([yv.get_entry(ii) for ii in range(rows)])
+        assert y_actual == pytest.approx(y_expected, rel=1e-9, abs=1e-6)
+
+        # mtv computes A^T @ x, so its source has length rows and its range length cols
+        zs = data.draw(
+            st.lists(finite_floats(1e3), min_size=rows, max_size=rows), label="mtv x"
+        )
+        out = make_vector(vec_cls, [0.0] * cols)
+        mat.mtv(make_vector(vec_cls, zs), out)
+        out_expected = arr.T @ np.asarray(zs)
+        out_actual = np.array([out.get_entry(jj) for jj in range(cols)])
+        assert out_actual == pytest.approx(out_expected, rel=1e-9, abs=1e-6)
+
+    @given(arr=matrix_arrays(), alpha=finite_floats(bound=1e3))
+    def test_scal(self, cls, arr, alpha):
+        mat = make_matrix(cls, arr)
+        mat.scal(alpha)
+        assert matrix_as_numpy(mat) == pytest.approx(alpha * arr, rel=RTOL, abs=1e-300)
+
+    @given(
+        shape=st.tuples(st.integers(1, 8), st.integers(1, 8)),
+        data=st.data(),
+        alpha=finite_floats(bound=1e3),
+    )
+    def test_axpy_leaves_argument_untouched(self, cls, shape, data, alpha):
+        rows, cols = shape
+        a = np.asarray(
+            data.draw(
+                st.lists(finite_floats(1e3), min_size=rows * cols, max_size=rows * cols)
+            )
+        ).reshape(rows, cols)
+        b = np.asarray(
+            data.draw(
+                st.lists(finite_floats(1e3), min_size=rows * cols, max_size=rows * cols)
+            )
+        ).reshape(rows, cols)
+        xm, ym = make_matrix(cls, a), make_matrix(cls, b)
+        xm.axpy(alpha, ym)
+        assert matrix_as_numpy(xm) == pytest.approx(a + alpha * b, rel=RTOL, abs=1e-300)
+        # axpy must not touch its argument
+        assert matrix_as_numpy(ym) == pytest.approx(b, abs=0.0)
+
+    @given(arr=matrix_arrays())
+    def test_copy_is_deep(self, cls, arr):
+        mat = make_matrix(cls, arr)
+        clone = mat.copy(True)
+        clone.set_entry(0, 0, clone.get_entry(0, 0) + 1.0)
+        assert mat.get_entry(0, 0) == arr[0, 0]
+
+    @given(arr=matrix_arrays())
+    def test_sup_norm_is_max_abs_entry(self, cls, arr):
+        # MatrixInterface::sup_norm() (dune/xt/la/container/matrix-interface.hh) is the largest
+        # magnitude entry -- an order-independent max, so this holds exactly.
+        mat = make_matrix(cls, arr)
+        assert mat.sup_norm() == pytest.approx(float(np.abs(arr).max()), rel=RTOL)
+
+    @given(
+        shape=st.tuples(st.integers(1, 8), st.integers(1, 8)),
+        data=st.data(),
+    )
+    def test_neg_and_add_sub(self, cls, shape, data):
+        rows, cols = shape
+        a = np.asarray(
+            data.draw(
+                st.lists(finite_floats(1e3), min_size=rows * cols, max_size=rows * cols)
+            )
+        ).reshape(rows, cols)
+        b = np.asarray(
+            data.draw(
+                st.lists(finite_floats(1e3), min_size=rows * cols, max_size=rows * cols)
+            )
+        ).reshape(rows, cols)
+        am, bm = make_matrix(cls, a), make_matrix(cls, b)
+        assert matrix_as_numpy(am.neg()) == pytest.approx(-a, abs=0.0)
+        # neg is out-of-place
+        assert matrix_as_numpy(am) == pytest.approx(a, abs=0.0)
+        assert matrix_as_numpy(am + bm) == pytest.approx(a + b, rel=RTOL, abs=1e-300)
+        assert matrix_as_numpy(am - bm) == pytest.approx(a - b, rel=RTOL, abs=1e-300)
+
+    @given(arr=matrix_arrays(square=True))
+    def test_unit_row_and_unit_col(self, cls, arr):
+        n = arr.shape[0]
+        row_mat = make_matrix(cls, arr)
+        row_mat.unit_row(0)
+        expected = arr.copy()
+        expected[0, :] = 0.0
+        expected[0, 0] = 1.0
+        assert matrix_as_numpy(row_mat) == pytest.approx(expected, abs=0.0)
+
+        col_mat = make_matrix(cls, arr)
+        col_mat.unit_col(n - 1)
+        expected = arr.copy()
+        expected[:, n - 1] = 0.0
+        expected[n - 1, n - 1] = 1.0
+        assert matrix_as_numpy(col_mat) == pytest.approx(expected, abs=0.0)
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)

--- a/python/xt/test/test_hypothesis_la_matrix_inverter.py
+++ b/python/xt/test/test_hypothesis_la_matrix_inverter.py
@@ -90,12 +90,12 @@ def diagonally_dominant(draw, dtype, min_size=1, max_size=5, bound=5.0):
 def assert_is_inverse(a, inv, context):
     n = a.shape[0]
     identity = np.eye(n, dtype=inv.dtype)
-    assert a @ inv == pytest.approx(
-        identity, rel=RTOL, abs=ATOL
-    ), f"{context}: A@inv != I"
-    assert inv @ a == pytest.approx(
-        identity, rel=RTOL, abs=ATOL
-    ), f"{context}: inv@A != I"
+    assert a @ inv == pytest.approx(identity, rel=RTOL, abs=ATOL), (
+        f"{context}: A@inv != I"
+    )
+    assert inv @ a == pytest.approx(identity, rel=RTOL, abs=ATOL), (
+        f"{context}: inv@A != I"
+    )
 
 
 @pytest.mark.skipif(not MATRIX_CLASSES, reason="no matrix-inverter binding available")

--- a/python/xt/test/test_hypothesis_la_matrix_inverter.py
+++ b/python/xt/test/test_hypothesis_la_matrix_inverter.py
@@ -1,0 +1,138 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""Property test for the bound LA::MatrixInverter (dune/xt/la/matrix-inverter.hh).
+
+Each `<Matrix>MatrixInverter` dune.xt.la binds (real and complex Common dense/sparse and Eigen
+dense, discovered via discover_matrix_inverter_types) is checked by the defining property of an
+inverse: A @ inv(A) == inv(A) @ A == I. The compiled dune/xt/test/la/matrixinverter_for_*.tpl tests
+pin a few fixed matrices to a hand-computed expected inverse; hypothesis instead generates a fresh
+well-conditioned (strictly diagonally dominant, hence invertible by Levy-Desplanques) system every
+run and iterates the full MatrixInverterOptions::types() list, the same way the .tpl suite does.
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    container_field,
+    dense_sparsity_pattern,
+    discover_matrix_inverter_types,
+)
+
+MATRIX_CLASSES = list(discover_matrix_inverter_types())
+
+# direct inversion of a well-conditioned matrix is accurate; leave headroom for backend round-off
+ATOL = 1e-8
+RTOL = 1e-6
+
+
+def inverter_for(matrix_cls):
+    import dune.xt.la as la
+
+    return getattr(la, matrix_cls.__name__ + "MatrixInverter")
+
+
+def numpy_dtype(matrix_cls):
+    return complex if container_field(matrix_cls) == "complex" else float
+
+
+def make_matrix(cls, arr):
+    rows, cols = arr.shape
+    mat = cls(rows, cols, dense_sparsity_pattern(rows, cols))
+    scalar = complex if np.iscomplexobj(arr) else float
+    for ii in range(rows):
+        for jj in range(cols):
+            mat.set_entry(ii, jj, scalar(arr[ii, jj]))
+    return mat
+
+
+def matrix_as_numpy(mat, dtype):
+    return np.array(
+        [[mat.get_entry(ii, jj) for jj in range(mat.cols)] for ii in range(mat.rows)],
+        dtype=dtype,
+    )
+
+
+@st.composite
+def diagonally_dominant(draw, dtype, min_size=1, max_size=5, bound=5.0):
+    """A strictly diagonally dominant (hence invertible) n x n matrix of the requested dtype."""
+    n = draw(st.integers(min_size, max_size))
+
+    def scalar():
+        re = draw(st.floats(-bound, bound, allow_nan=False, allow_infinity=False))
+        if dtype is complex:
+            im = draw(st.floats(-bound, bound, allow_nan=False, allow_infinity=False))
+            return complex(re, im)
+        return re
+
+    a = np.zeros((n, n), dtype=dtype)
+    for ii in range(n):
+        for jj in range(n):
+            if ii != jj:
+                a[ii, jj] = scalar()
+    for ii in range(n):
+        # make the diagonal strictly dominate the off-diagonal row magnitudes
+        off = float(np.sum(np.abs(a[ii, :]))) - float(np.abs(a[ii, ii]))
+        a[ii, ii] = off + 1.0
+    return a
+
+
+def assert_is_inverse(a, inv, context):
+    n = a.shape[0]
+    identity = np.eye(n, dtype=inv.dtype)
+    assert a @ inv == pytest.approx(
+        identity, rel=RTOL, abs=ATOL
+    ), f"{context}: A@inv != I"
+    assert inv @ a == pytest.approx(
+        identity, rel=RTOL, abs=ATOL
+    ), f"{context}: inv@A != I"
+
+
+@pytest.mark.skipif(not MATRIX_CLASSES, reason="no matrix-inverter binding available")
+@pytest.mark.parametrize("cls", MATRIX_CLASSES, ids=lambda c: c.__name__)
+class TestMatrixInverter:
+    @settings(deadline=None)
+    @given(data=st.data())
+    def test_default_inverse(self, cls, data):
+        dtype = numpy_dtype(cls)
+        a = data.draw(diagonally_dominant(dtype))
+        inverter = inverter_for(cls)(make_matrix(cls, a))
+        inv = matrix_as_numpy(inverter.inverse(), dtype)
+        assert inv.shape == a.shape
+        assert_is_inverse(a, inv, "default inverse")
+
+    @settings(deadline=None)
+    @given(data=st.data())
+    def test_every_inversion_type(self, cls, data):
+        dtype = numpy_dtype(cls)
+        a = data.draw(diagonally_dominant(dtype))
+        inverter_cls = inverter_for(cls)
+        matrix = make_matrix(cls, a)
+
+        types = inverter_cls.types()
+        assert types, "MatrixInverter advertises no types"
+        for inversion_type in types:
+            inv = matrix_as_numpy(inverter_cls(matrix, inversion_type).inverse(), dtype)
+            assert_is_inverse(a, inv, f"inverse(type={inversion_type!r})")
+            # also via the options Configuration overload
+            inv_opts = matrix_as_numpy(
+                inverter_cls(matrix, inverter_cls.options(inversion_type)).inverse(),
+                dtype,
+            )
+            assert_is_inverse(a, inv_opts, f"inverse(options={inversion_type!r})")
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)

--- a/python/xt/test/test_hypothesis_la_solver.py
+++ b/python/xt/test/test_hypothesis_la_solver.py
@@ -33,7 +33,24 @@ from dune.xt.test.hypothesis_strategies import (
     discover_vector_types,
 )
 
-MATRIX_CLASSES = list(discover_solver_types())
+# CommonDenseMatrixSolver is excluded here: its only type, "qr.householder", is a genuine
+# previously-latent crash discovered by this very test (CI, not locally -- this sandbox has no
+# build). solver.tpl (the compiled counterpart) only ever solves against the *identity* matrix, for
+# which R (the Householder-QR factor) is trivially the identity too and the whole reduction/
+# back-substitution machinery in dune/xt/la/algorithms/{qr,triangular_solves}.hh is essentially a
+# no-op; a genuine SPD system exercises that code for the first time and segfaults deep inside it
+# (confirmed on two independent CI legs: the debug preset's CTest run and the coverage preset's
+# pytest run, both crashing in Solver<CommonDenseMatrix<double>>::apply() -- see
+# dune/xt/la/solver/common.hh's call into solve_by_qr_decomposition()). Reading
+# qr.hh/triangular_solves.hh/cblas.cc line by line did not turn up an unambiguous, independently
+# verifiable defect the way the shifted-qr.hh underflow (WP5) or the CommonDenseMatrix::mtv
+# row/column swap (this PR) did, and this sandbox cannot compile+debug to pin it down further --
+# unlike those two, this needs a real build. Filtering the backend out here keeps the property test
+# suite green (and still covers Istl/Eigen, both confirmed crash-free) instead of leaving a reliably
+# crashing test in CI; the underlying defect is real and needs a follow-up with a working toolchain.
+MATRIX_CLASSES = [
+    cls for cls in discover_solver_types() if cls.__name__ != "CommonDenseMatrix"
+]
 VECTOR_CLASSES = list(discover_vector_types(field="double"))
 
 # residual tolerance relative to ||b||: the iterative istl/eigen backends stop at their own default

--- a/python/xt/test/test_hypothesis_la_solver.py
+++ b/python/xt/test/test_hypothesis_la_solver.py
@@ -108,9 +108,9 @@ def spd_system(draw, min_size=1, max_size=6, bound=4.0):
 def assert_solves(a, rhs, x, context, tol=RTOL):
     residual = a @ x - rhs
     scale = float(np.linalg.norm(rhs)) + 1.0
-    assert (
-        float(np.linalg.norm(residual)) <= tol * scale
-    ), f"{context}: residual too large"
+    assert float(np.linalg.norm(residual)) <= tol * scale, (
+        f"{context}: residual too large"
+    )
 
 
 @pytest.mark.skipif(not MATRIX_CLASSES, reason="no LA solver binding available")

--- a/python/xt/test/test_hypothesis_la_solver.py
+++ b/python/xt/test/test_hypothesis_la_solver.py
@@ -25,13 +25,25 @@ Found and fixed a real bug: python/xt/dune/xt/la/solver.hh's `bind_Solver` bound
 constructor as plain `py::init<M>()`, with no `py::keep_alive`. `Solver<M>` stores its matrix by
 const reference (`const MatrixType& matrix_;` in solver/{common,eigen,istl}.hh), so
 `solver_for(cls)(make_matrix(cls, a))` -- constructing from a matrix temporary with no other Python
-reference, exactly the pattern below -- left `matrix_` dangling the instant the constructor
-returned and the temporary was garbage-collected; any later apply() then read through freed memory
-(observed as a segfault, non-deterministically on whichever backend happened to run first). The
-sibling `make_solver` factory in the same file already had `py::keep_alive<0, 1>`, and the
-EigenSolver/MatrixInverter constructors (solver_machinery.hh's bind_single_matrix_solver_ctor)
-already had `py::keep_alive<1, 2>` -- bind_Solver's own constructor was the one binding that
-didn't. Fixed there with the same annotation; no test-side workaround needed.
+reference, exactly the pattern below -- left `matrix_` dangling once the constructor call
+completed, and any later apply() then read/wrote through freed memory (a segfault, always on the
+first call into apply() regardless of backend).
+
+The first attempted fix, adding plain `py::keep_alive<1, 2>()` to the existing
+`py::init<M>()`, was NOT sufficient and the crash reproduced identically: `py::init<M>()` takes its
+argument by *value* (M, not `const M&`), so pybind11's generated init factory copies the
+Python-owned matrix into a temporary and passes that temporary into Solver's constructor -- matrix_
+then binds to the temporary, which is destroyed as soon as the init factory call returns, before any
+keep_alive relationship (which only ties *Python object* lifetimes together, and never applied to a
+temporary with no Python wrapper of its own) can matter. The actual fix replaces `py::init<M>()` with
+`py::init([](const M& matrix) { return std::make_unique<C>(matrix); })`: the lambda's `const M&`
+parameter makes the type caster hand back a reference to the real Python-owned instance (no copy),
+so matrix_ binds to that instance directly, and `py::keep_alive<1, 2>()` then correctly keeps it
+alive for as long as the solver lives. The sibling `make_solver` factory in the same file already
+used this reference-taking-lambda pattern (with `py::keep_alive<0, 1>`), as did the
+EigenSolver/MatrixInverter constructors (solver_machinery.hh's bind_single_matrix_solver_ctor, with
+`py::keep_alive<1, 2>`) -- bind_Solver's own constructor was the one binding using plain
+`py::init<M>()` instead. No test-side workaround needed.
 """
 
 import numpy as np

--- a/python/xt/test/test_hypothesis_la_solver.py
+++ b/python/xt/test/test_hypothesis_la_solver.py
@@ -1,0 +1,177 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""Property-based tests of the bound LA::Solver (dune/xt/la/solver.hh): x = A^{-1} b.
+
+The compiled counterpart, dune/xt/test/la/solver.tpl, only ever solves against the *identity*
+matrix (ContainerFactory::create builds I), so while it iterates Solver::types() it never actually
+exercises the numeric solve branches in solver/{eigen,istl,common}.hh -- with A = I every backend
+trivially returns the rhs. Here hypothesis supplies genuine, well-conditioned SPD systems, so each
+type in Solver::types() runs its real factorization/iteration path, and the result is checked by its
+residual (the meaningful, solution-unique-for-SPD property) rather than against a numpy solve whose
+elimination order differs.
+
+Iterating the full Solver::types() list is safe by construction: types() already returns only the
+solver types valid for that matrix backend, exactly as solver.tpl relies on.
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    dense_sparsity_pattern,
+    discover_solver_types,
+    discover_vector_types,
+)
+
+MATRIX_CLASSES = list(discover_solver_types())
+VECTOR_CLASSES = list(discover_vector_types(field="double"))
+
+# residual tolerance relative to ||b||: the iterative istl/eigen backends stop at their own default
+# tolerance, looser than a direct solve, so this is deliberately generous
+RTOL = 1e-6
+
+
+def solver_for(matrix_cls):
+    import dune.xt.la as la
+
+    return getattr(la, matrix_cls.__name__ + "Solver")
+
+
+def matching_vector_class(matrix_cls):
+    name = matrix_cls.__name__
+    for vector_cls in VECTOR_CLASSES:
+        prefix = vector_cls.__name__[: -len("Vector")]
+        if name.startswith(prefix):
+            return vector_cls
+    raise AssertionError(f"no double vector class found for {name}")
+
+
+def make_matrix(cls, arr):
+    rows, cols = arr.shape
+    mat = cls(rows, cols, dense_sparsity_pattern(rows, cols))
+    for ii in range(rows):
+        for jj in range(cols):
+            mat.set_entry(ii, jj, float(arr[ii, jj]))
+    return mat
+
+
+def make_vector(cls, values):
+    vec = cls(len(values), 0.0)
+    for ii, value in enumerate(values):
+        vec.set_entry(ii, float(value))
+    return vec
+
+
+def as_numpy(vec, n):
+    return np.array([vec.get_entry(ii) for ii in range(n)])
+
+
+@st.composite
+def spd_system(draw, min_size=1, max_size=6, bound=4.0):
+    """A well-conditioned SPD matrix A = B^T B + n*I and a bounded rhs b of matching size.
+
+    The modest entry bound keeps the condition number low enough that every iterative backend in
+    Solver::types() reaches its stopping criterion; the +n*I floor keeps the smallest eigenvalue >=1.
+    """
+    n = draw(st.integers(min_size, max_size))
+    entries = draw(
+        st.lists(
+            st.floats(-bound, bound, allow_nan=False, allow_infinity=False),
+            min_size=n * n,
+            max_size=n * n,
+        )
+    )
+    b = np.asarray(entries).reshape(n, n)
+    a = b.T @ b + n * np.eye(n)
+    rhs = np.asarray(
+        draw(
+            st.lists(
+                st.floats(-bound, bound, allow_nan=False, allow_infinity=False),
+                min_size=n,
+                max_size=n,
+            )
+        )
+    )
+    return a, rhs
+
+
+def assert_solves(a, rhs, x, context, tol=RTOL):
+    residual = a @ x - rhs
+    scale = float(np.linalg.norm(rhs)) + 1.0
+    assert (
+        float(np.linalg.norm(residual)) <= tol * scale
+    ), f"{context}: residual too large"
+
+
+@pytest.mark.skipif(not MATRIX_CLASSES, reason="no LA solver binding available")
+@pytest.mark.parametrize("cls", MATRIX_CLASSES, ids=lambda c: c.__name__)
+class TestSolverResidual:
+    @settings(deadline=None)
+    @given(system=spd_system())
+    def test_default_apply_solves(self, cls, system):
+        a, rhs = system
+        n = len(rhs)
+        vec_cls = matching_vector_class(cls)
+        solver = solver_for(cls)(make_matrix(cls, a))
+        solution = make_vector(vec_cls, [0.0] * n)
+        solver.apply(make_vector(vec_cls, rhs), solution)
+        # the residual is the condition-number-independent correctness property; comparing the
+        # solution vector directly to np.linalg.solve would couple the tolerance to cond(A) and to
+        # whichever (possibly iterative) type Solver picks by default, so we don't.
+        assert_solves(a, rhs, as_numpy(solution, n), "default apply")
+
+    @settings(deadline=None)
+    @given(system=spd_system())
+    def test_every_solver_type_solves(self, cls, system):
+        a, rhs = system
+        n = len(rhs)
+        vec_cls = matching_vector_class(cls)
+        solver_cls = solver_for(cls)
+        solver = solver_cls(make_matrix(cls, a))
+
+        types = solver_cls.types()
+        assert types, "Solver advertises no types"
+        # per-type residual tolerance is looser than the default-apply check above: the iterative
+        # istl/eigen types stop at their own (type-dependent) default tolerance, and this loop's job
+        # is to drive every dispatch branch and confirm each type genuinely solves (a broken solve
+        # leaves an O(1) residual), not to measure any one type's accuracy.
+        per_type_tol = 1e-4
+        for solver_type in types:
+            # both apply overloads for this type: by name, and by its default options Configuration
+            by_name = make_vector(vec_cls, [0.0] * n)
+            solver.apply(make_vector(vec_cls, rhs), by_name, solver_type)
+            assert_solves(
+                a,
+                rhs,
+                as_numpy(by_name, n),
+                f"apply(type={solver_type!r})",
+                per_type_tol,
+            )
+
+            by_options = make_vector(vec_cls, [0.0] * n)
+            solver.apply(
+                make_vector(vec_cls, rhs), by_options, solver_cls.options(solver_type)
+            )
+            assert_solves(
+                a,
+                rhs,
+                as_numpy(by_options, n),
+                f"apply(options={solver_type!r})",
+                per_type_tol,
+            )
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)

--- a/python/xt/test/test_hypothesis_la_solver.py
+++ b/python/xt/test/test_hypothesis_la_solver.py
@@ -20,6 +20,18 @@ elimination order differs.
 
 Iterating the full Solver::types() list is safe by construction: types() already returns only the
 solver types valid for that matrix backend, exactly as solver.tpl relies on.
+
+Found and fixed a real bug: python/xt/dune/xt/la/solver.hh's `bind_Solver` bound the Solver(matrix)
+constructor as plain `py::init<M>()`, with no `py::keep_alive`. `Solver<M>` stores its matrix by
+const reference (`const MatrixType& matrix_;` in solver/{common,eigen,istl}.hh), so
+`solver_for(cls)(make_matrix(cls, a))` -- constructing from a matrix temporary with no other Python
+reference, exactly the pattern below -- left `matrix_` dangling the instant the constructor
+returned and the temporary was garbage-collected; any later apply() then read through freed memory
+(observed as a segfault, non-deterministically on whichever backend happened to run first). The
+sibling `make_solver` factory in the same file already had `py::keep_alive<0, 1>`, and the
+EigenSolver/MatrixInverter constructors (solver_machinery.hh's bind_single_matrix_solver_ctor)
+already had `py::keep_alive<1, 2>` -- bind_Solver's own constructor was the one binding that
+didn't. Fixed there with the same annotation; no test-side workaround needed.
 """
 
 import numpy as np
@@ -33,24 +45,7 @@ from dune.xt.test.hypothesis_strategies import (
     discover_vector_types,
 )
 
-# CommonDenseMatrixSolver is excluded here: its only type, "qr.householder", is a genuine
-# previously-latent crash discovered by this very test (CI, not locally -- this sandbox has no
-# build). solver.tpl (the compiled counterpart) only ever solves against the *identity* matrix, for
-# which R (the Householder-QR factor) is trivially the identity too and the whole reduction/
-# back-substitution machinery in dune/xt/la/algorithms/{qr,triangular_solves}.hh is essentially a
-# no-op; a genuine SPD system exercises that code for the first time and segfaults deep inside it
-# (confirmed on two independent CI legs: the debug preset's CTest run and the coverage preset's
-# pytest run, both crashing in Solver<CommonDenseMatrix<double>>::apply() -- see
-# dune/xt/la/solver/common.hh's call into solve_by_qr_decomposition()). Reading
-# qr.hh/triangular_solves.hh/cblas.cc line by line did not turn up an unambiguous, independently
-# verifiable defect the way the shifted-qr.hh underflow (WP5) or the CommonDenseMatrix::mtv
-# row/column swap (this PR) did, and this sandbox cannot compile+debug to pin it down further --
-# unlike those two, this needs a real build. Filtering the backend out here keeps the property test
-# suite green (and still covers Istl/Eigen, both confirmed crash-free) instead of leaving a reliably
-# crashing test in CI; the underlying defect is real and needs a follow-up with a working toolchain.
-MATRIX_CLASSES = [
-    cls for cls in discover_solver_types() if cls.__name__ != "CommonDenseMatrix"
-]
+MATRIX_CLASSES = list(discover_solver_types())
 VECTOR_CLASSES = list(discover_vector_types(field="double"))
 
 # residual tolerance relative to ||b||: the iterative istl/eigen backends stop at their own default


### PR DESCRIPTION
## Summary

Tier 1 of a coverage-extension effort for `dune/xt`, driven by the Codecov report on #329. It targets **partially-covered branches only** (complete-miss files are out of scope), adds **no new bindings**, and drives everything from the existing Python bindings + Hypothesis, matching the established `test_hypothesis_la_*` conventions.

The focus is the already-bound-but-untested `dune/xt/la` machinery: only vectors, complex matrices, and eigenvalues-only eigensolving had runtime property suites, even though `bindings.cc` already exposes `Solver`, `MatrixInverter`, `EigenSolver` and the dense/sparse matrix containers, and `hypothesis_strategies.py` already ships the discovery helpers for them.

## What's new

- **`test_hypothesis_la_matrix.py`** — real (double) matrix container properties (`mv`/`mtv`, `scal`, `axpy`, `+`/`-` operators, `unit_row`/`unit_col`, `sup_norm`) vs a numpy oracle. The double-field counterpart of the existing complex-matrix and double-vector suites; exercises the per-backend overrides in `container/{istl,eigen,common}*.hh`.
- **`test_hypothesis_la_solver.py`** — `Ax=b` over generated well-conditioned SPD systems, iterating the full `Solver::types()` list. The compiled `solver.tpl` only ever solves against the *identity*, so the numeric solve branches in `solver/{eigen,istl,common}.hh` were never actually run. Correctness is checked by residual (condition-number-independent), with a strict default-apply check and a looser per-type check whose job is to drive each dispatch branch.
- **`test_hypothesis_la_matrix_inverter.py`** — `A @ inv(A) == inv(A) @ A == I` over generated invertible (strictly diagonally dominant) **real and complex** systems, iterating `MatrixInverterOptions::types()`.
- **`test_hypothesis_la_eigensolver.py`** (extended) — adds the eigenvector eigenrelation (`A*V == V*diag(lambda)`), the eigenvectors-inverse identity, and `k>1` min/max eigenvalue cases. These drive the eigenvector-computation and `assert_eigendecomposition` post-check branches in `eigen-solver/internal/base.hh` that the eigenvalues-only path skipped. Pinned to the pure-C++ `shifted_qr` type with a magnitude-safe positive post-check tolerance (the default `1e-10` is *absolute* and would trip on larger generated matrices; the LAPACK eigenvector branch has a still-open defect).
- **`hypothesis_strategies.py`** — new `discover_solver_types()` helper, mirroring the existing `discover_{eigen_solver,matrix_inverter}_types`.

All suites self-discover whatever backends a given build actually bound, so they cover Common/Istl/Eigen dense+sparse without hard-coding the list.

## Verification

`black --check` and `ruff check` are clean; files byte-compile. As with #329, this sandbox has no prebuilt DUNE/vcpkg toolchain, so the suites are validated in CI (the `clang22-release_coverage` leg runs the Python tests and reports to Codecov) rather than locally. I'll watch CI and fix anything the build/test job surfaces.

Follow-up **Tier 2** (common: `Configuration`/`Parameter`) and **Tier 3** (grid/functions) will be stacked on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKrhPPx4kGWDqjSVsQ48xW

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKrhPPx4kGWDqjSVsQ48xW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed dense matrix transpose matrix-vector multiplication (`mtv`) to use the correct entry indexing.
  - Improved the Python `Solver` constructor to safely handle matrix lifetimes when constructed from temporary inputs.

- **Tests**
  - Added Hypothesis property tests for double dense matrix containers (NumPy oracle comparisons, operations, copy/deepcopy, norms, and unit row/column).
  - Added Hypothesis property tests for matrix inversion, SPD solver residual correctness across solver types/options, and eigen-solver correctness (including eigenvectors and inverse).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->