### PR TITLE
test(gdt): extend coverage for the dune/gdt subdir

### DIFF
--- a/dune/gdt/test/interpolations/default.hh
+++ b/dune/gdt/test/interpolations/default.hh
@@ -24,6 +24,7 @@
 #include <dune/xt/functions/grid-function.hh>
 
 #include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/interpolations.hh>
 #include <dune/gdt/interpolations/boundary.hh>
 #include <dune/gdt/local/bilinear-forms/integrals.hh>
 #include <dune/gdt/local/integrands/product.hh>
@@ -108,6 +109,13 @@ struct DefaultInterpolationOnLeafViewTest : public ::testing::Test
     default_interpolation(*source, *range, space->grid_view());
     const auto l2_error = l2_norm(space->grid_view(), XT::Functions::make_grid_function<E>(*source) - *range);
     EXPECT_LT(l2_error, expected_l2_error)
+        << "XT::Common::Test::get_unique_test_name() = '" << XT::Common::Test::get_unique_test_name() << "'";
+    // Additionally exercise the top-level interpolate(...) dispatcher (dune/gdt/interpolations.hh): for a non
+    // Raviart-Thomas target space it forwards to default_interpolation, so the freshly created discrete function
+    // must coincide with *range down to round-off.
+    const auto dispatched = interpolate<V>(*source, *space);
+    const auto dispatch_difference = dispatched.dofs().vector() - range->dofs().vector();
+    EXPECT_LT(dispatch_difference.sup_norm(), 1e-13)
         << "XT::Common::Test::get_unique_test_name() = '" << XT::Common::Test::get_unique_test_name() << "'";
     const auto local_range = range->local_discrete_function();
     for (auto&& element : Dune::elements(space->grid_view())) {

--- a/dune/gdt/test/interpolations/default.hh
+++ b/dune/gdt/test/interpolations/default.hh
@@ -113,7 +113,7 @@ struct DefaultInterpolationOnLeafViewTest : public ::testing::Test
     // Additionally exercise the top-level interpolate(...) dispatcher (dune/gdt/interpolations.hh): for a non
     // Raviart-Thomas target space it forwards to default_interpolation, so the freshly created discrete function
     // must coincide with *range down to round-off.
-    const auto dispatched = interpolate<V>(*source, *space);
+    const auto dispatched = interpolate<V>(XT::Functions::make_grid_function<E>(*source), *space);
     const auto dispatch_difference = dispatched.dofs().vector() - range->dofs().vector();
     EXPECT_LT(dispatch_difference.sup_norm(), 1e-13)
         << "XT::Common::Test::get_unique_test_name() = '" << XT::Common::Test::get_unique_test_name() << "'";

--- a/dune/gdt/test/interpolations/raviart-thomas.hh
+++ b/dune/gdt/test/interpolations/raviart-thomas.hh
@@ -31,6 +31,7 @@
 #include <dune/xt/la/container/istl.hh>
 
 #include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/interpolations.hh>
 #include <dune/gdt/interpolations/raviart-thomas.hh>
 #include <dune/gdt/spaces/hdiv/raviart-thomas.hh>
 
@@ -171,6 +172,13 @@ struct RaviartThomasInterpolationOnLeafViewTest : public ::testing::Test
     // (6) create new target with default vector type, uses target_space.grid_view()
     auto range_6 = raviart_thomas_interpolation(source, *space);
     check_reproduces_constant(range_6);
+    // (7) + (8): the top-level interpolate(...) dispatcher (dune/gdt/interpolations.hh) must route a Raviart-Thomas
+    //            target space to raviart_thomas_interpolation (the rC == 1 && r == d && type() == raviart_thomas
+    //            branch), both for an explicitly given and for the default vector type.
+    auto range_7 = interpolate<V>(source, *space);
+    check_reproduces_constant(range_7);
+    auto range_8 = interpolate(source, *space);
+    check_reproduces_constant(range_8);
   } // ... all_overloads_reproduce_constant_field(...)
 
   // interpolates a linear (non-RT0) field and asserts the resulting discrete function has continuous normal components

--- a/dune/gdt/test/misc/tools_euler.cc
+++ b/dune/gdt/test/misc/tools_euler.cc
@@ -1,0 +1,268 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-gdt developers
+
+#ifndef DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS
+#  define DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS 1
+#endif
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <cmath>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/functions/constant.hh>
+#include <dune/xt/functions/grid-function.hh>
+
+#include <dune/gdt/tools/euler.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+
+// A physically meaningful conservative state w = (rho, rho*v, E) built from primitive variables with strictly positive
+// density and pressure, so that the speed of sound a = sqrt(gamma * p / rho) (and thus the eigendecomposition) is real
+// and well defined.
+template <size_t d>
+XT::Common::FieldVector<double, d + 2>
+make_state(const EulerTools<d>& euler, const double rho, const XT::Common::FieldVector<double, d>& v, const double p)
+{
+  XT::Common::FieldVector<double, 1> rho_fv(rho);
+  XT::Common::FieldVector<double, 1> p_fv(p);
+  return euler.conservative(rho_fv, v, p_fv);
+}
+
+
+// primitives(conservative(rho, v, p)) reproduces (rho, v, p) exactly, and conservative(primitives(w)) reproduces w:
+// the two conversions are inverse to each other.
+template <size_t d>
+void check_primitive_conservative_roundtrip()
+{
+  const EulerTools<d> euler(1.4);
+  const double rho = 2.0;
+  const double p = 1.5;
+  XT::Common::FieldVector<double, d> v(0.);
+  for (size_t ii = 0; ii < d; ++ii)
+    v[ii] = 0.3 - 0.1 * ii;
+
+  const auto w = make_state<d>(euler, rho, v, p);
+
+  // conservative -> primitive
+  const auto rho_v_p = euler.primitives(w);
+  EXPECT_NEAR(rho, std::get<0>(rho_v_p)[0], 1e-13);
+  for (size_t ii = 0; ii < d; ++ii)
+    EXPECT_NEAR(v[ii], std::get<1>(rho_v_p)[ii], 1e-13);
+  EXPECT_NEAR(p, std::get<2>(rho_v_p)[0], 1e-13);
+
+  // the packed variant primitive(w) must agree with primitives(w)
+  const auto packed = euler.primitive(w);
+  EXPECT_NEAR(rho, packed[euler.density_index()], 1e-13);
+  for (size_t ii = 0; ii < d; ++ii)
+    EXPECT_NEAR(v[ii], packed[euler.velocity_indices()[ii]], 1e-13);
+  EXPECT_NEAR(p, packed[euler.pressure_index()], 1e-13);
+
+  // individual accessors
+  EXPECT_NEAR(rho, euler.density(w)[0], 1e-13);
+  for (size_t ii = 0; ii < d; ++ii)
+    EXPECT_NEAR(v[ii], euler.velocity(w)[ii], 1e-13);
+  EXPECT_NEAR(p, euler.pressure(w)[0], 1e-13);
+
+  // primitive -> conservative reproduces w
+  const auto w2 = make_state<d>(euler, rho, v, p);
+  for (size_t ii = 0; ii < d + 2; ++ii)
+    EXPECT_NEAR(w[ii], w2[ii], 1e-13);
+}
+
+
+// The derived scalar quantities are consistent with their closed forms.
+template <size_t d>
+void check_derived_quantities()
+{
+  const EulerTools<d> euler(1.4);
+  const double gamma = 1.4;
+  const double rho = 1.3;
+  const double p = 0.7;
+  XT::Common::FieldVector<double, d> v(0.);
+  for (size_t ii = 0; ii < d; ++ii)
+    v[ii] = 0.2 * (ii + 1);
+  const auto w = make_state<d>(euler, rho, v, p);
+
+  // a^2 = gamma * p / rho, computed identically from w and from (rho, p)
+  const double a2_expected = gamma * p / rho;
+  EXPECT_NEAR(a2_expected, euler.speed_of_sound2(w), 1e-13);
+  EXPECT_NEAR(std::sqrt(a2_expected), euler.speed_of_sound(w), 1e-13);
+  XT::Common::FieldVector<double, 1> rho_fv(rho);
+  XT::Common::FieldVector<double, 1> p_fv(p);
+  EXPECT_NEAR(a2_expected, euler.speed_of_sound2(rho_fv, p_fv), 1e-13);
+
+  // Mach number M = |v| / a
+  EXPECT_NEAR(v.two_norm() / std::sqrt(a2_expected), euler.mach_number(w), 1e-13);
+  EXPECT_NEAR(v.two_norm() / std::sqrt(a2_expected), euler.mach_number(rho_fv, v, p_fv), 1e-13);
+
+  // enthalpy H = (E + p) / rho
+  const auto E = euler.energy(w);
+  EXPECT_NEAR((E[0] + p) / rho, euler.enthalpy(w), 1e-13);
+}
+
+
+// The Euler flux at v = 0: mass flux vanishes, the momentum flux is the pressure on the diagonal and the energy flux
+// vanishes (a simple hand-verifiable special case that pins flux()).
+template <size_t d>
+void check_flux_at_rest()
+{
+  const EulerTools<d> euler(1.4);
+  const double rho = 1.1;
+  const double p = 0.9;
+  XT::Common::FieldVector<double, d> v(0.);
+  const auto w = make_state<d>(euler, rho, v, p);
+
+  const auto f = euler.flux(w); // f is a (d x m) matrix, row s is the flux in direction s
+  for (size_t s = 0; s < d; ++s) {
+    EXPECT_NEAR(0., f[s][euler.density_index()], 1e-13);
+    for (size_t ii = 0; ii < d; ++ii)
+      EXPECT_NEAR((s == ii) ? p : 0., f[s][euler.velocity_indices()[ii]], 1e-13);
+    EXPECT_NEAR(0., f[s][euler.energy_index()], 1e-13);
+  }
+
+  // at an impermeable wall (v.n = 0) only the pressure contributes to the momentum components
+  XT::Common::FieldVector<double, d> n(0.);
+  n[0] = 1.;
+  const auto wall_flux = euler.flux_at_impermeable_walls(w, n);
+  EXPECT_NEAR(0., wall_flux[euler.density_index()], 1e-13);
+  EXPECT_NEAR(0., wall_flux[euler.energy_index()], 1e-13);
+  for (size_t ii = 0; ii < d; ++ii)
+    EXPECT_NEAR((ii == 0) ? p : 0., wall_flux[euler.velocity_indices()[ii]], 1e-13);
+}
+
+
+// The eigendecomposition of P = sum_s n_s A_s (the flux jacobian contracted with a unit normal n) must satisfy
+// P T = T Lambda (i.e. P t_i = lambda_i t_i for every eigenvector column t_i) and T^{-1} T = I. This exercises
+// flux_jacobian(), eigenvalues_flux_jacobian(), eigenvectors_flux_jacobian() and eigenvectors_inv_flux_jacobian()
+// together and is only defined for d in {1, 2} (higher dimensions throw NotImplemented, see below).
+template <size_t d>
+void check_eigendecomposition(const XT::Common::FieldVector<double, d>& n)
+{
+  static constexpr size_t m = d + 2;
+  const EulerTools<d> euler(1.4);
+  const double rho = 1.4;
+  const double p = 1.2;
+  XT::Common::FieldVector<double, d> v(0.);
+  for (size_t ii = 0; ii < d; ++ii)
+    v[ii] = 0.15 * (ii + 1);
+  const auto w = make_state<d>(euler, rho, v, p);
+
+  // P = sum_s n_s A_s
+  const auto jacobian = euler.flux_jacobian(w);
+  XT::Common::FieldMatrix<double, m, m> P(0.);
+  for (size_t s = 0; s < d; ++s)
+    for (size_t row = 0; row < m; ++row)
+      for (size_t col = 0; col < m; ++col)
+        P[row][col] += n[s] * jacobian[s][row][col];
+
+  const auto evs = euler.eigenvalues_flux_jacobian(w, n);
+  const auto T = euler.eigenvectors_flux_jacobian(w, n);
+  const auto T_inv = euler.eigenvectors_inv_flux_jacobian(w, n);
+
+  // P t_i = lambda_i t_i for the i-th eigenvector (i-th column of T)
+  for (size_t i = 0; i < m; ++i) {
+    XT::Common::FieldVector<double, m> t_i(0.);
+    for (size_t row = 0; row < m; ++row)
+      t_i[row] = T[row][i];
+    XT::Common::FieldVector<double, m> Pt(0.);
+    P.mv(t_i, Pt);
+    for (size_t row = 0; row < m; ++row)
+      EXPECT_NEAR(evs[i] * t_i[row], Pt[row], 1e-10);
+  }
+
+  // T^{-1} T = I
+  for (size_t i = 0; i < m; ++i) {
+    for (size_t j = 0; j < m; ++j) {
+      double entry = 0.;
+      for (size_t k = 0; k < m; ++k)
+        entry += T_inv[i][k] * T[k][j];
+      EXPECT_NEAR((i == j) ? 1. : 0., entry, 1e-10);
+    }
+  }
+}
+
+
+TEST(euler_tools, primitive_conservative_roundtrip)
+{
+  check_primitive_conservative_roundtrip<1>();
+  check_primitive_conservative_roundtrip<2>();
+  check_primitive_conservative_roundtrip<3>();
+}
+
+TEST(euler_tools, derived_quantities)
+{
+  check_derived_quantities<1>();
+  check_derived_quantities<2>();
+  check_derived_quantities<3>();
+}
+
+TEST(euler_tools, flux_at_rest_and_impermeable_walls)
+{
+  check_flux_at_rest<1>();
+  check_flux_at_rest<2>();
+  check_flux_at_rest<3>();
+}
+
+TEST(euler_tools, eigendecomposition_1d)
+{
+  XT::Common::FieldVector<double, 1> n(1.);
+  check_eigendecomposition<1>(n);
+}
+
+TEST(euler_tools, eigendecomposition_2d)
+{
+  // axis-aligned and a genuinely oblique unit normal
+  XT::Common::FieldVector<double, 2> n_x{1., 0.};
+  XT::Common::FieldVector<double, 2> n_y{0., 1.};
+  XT::Common::FieldVector<double, 2> n_oblique{0.6, 0.8};
+  check_eigendecomposition<2>(n_x);
+  check_eigendecomposition<2>(n_y);
+  check_eigendecomposition<2>(n_oblique);
+}
+
+TEST(euler_tools, jacobian_and_eigendecomposition_not_implemented_in_3d)
+{
+  const EulerTools<3> euler(1.4);
+  XT::Common::FieldVector<double, 3> v{0.1, 0.2, 0.3};
+  const auto w = make_state<3>(euler, 1.2, v, 0.8);
+  XT::Common::FieldVector<double, 3> n{1., 0., 0.};
+  EXPECT_THROW(euler.flux_jacobian(w), Dune::NotImplemented);
+  EXPECT_THROW(euler.eigenvalues_flux_jacobian(w, n), Dune::NotImplemented);
+  EXPECT_THROW(euler.eigenvectors_flux_jacobian(w, n), Dune::NotImplemented);
+  EXPECT_THROW(euler.eigenvectors_inv_flux_jacobian(w, n), Dune::NotImplemented);
+}
+
+TEST(euler_tools, visualize_conservative_state)
+{
+  static constexpr size_t d = 2;
+  static constexpr size_t m = d + 2;
+  using G = YASP_2D_EQUIDISTANT_OFFSET;
+  using GV = typename G::LeafGridView;
+  using E = XT::Grid::extract_entity_t<GV>;
+
+  const EulerTools<d> euler(1.4);
+  auto grid = XT::Grid::make_cube_grid<G>(/*lower_left=*/0., /*upper_right=*/1., /*num_elements=*/2);
+  auto grid_view = grid.leaf_view();
+
+  // a constant, physically valid conservative state w = (rho, rho*v, E)
+  XT::Common::FieldVector<double, d> v{0.1, -0.2};
+  const auto w0 = make_state<d>(euler, 1.0, v, 1.0);
+  XT::Functions::ConstantFunction<d, m, 1, double> constant_w(w0);
+  const auto u_conservative = XT::Functions::make_grid_function<E>(constant_w);
+
+  // just assert the visualization (density, momentum, energy, velocity, pressure) runs without throwing
+  EXPECT_NO_THROW(euler.visualize(u_conservative, grid_view, "tools_euler_test", "0"));
+}

--- a/dune/gdt/test/misc/tools_euler.cc
+++ b/dune/gdt/test/misc/tools_euler.cc
@@ -76,8 +76,9 @@ void check_primitive_conservative_roundtrip()
     EXPECT_NEAR(v[ii], euler.velocity(w)[ii], 1e-13);
   EXPECT_NEAR(p, euler.pressure(w)[0], 1e-13);
 
-  // primitive -> conservative reproduces w
-  const auto w2 = make_state<d>(euler, rho, v, p);
+  // primitive -> conservative: feeding the *extracted* primitives back through conservative(...) must reproduce w
+  // (reconstructing from std::get<...>(rho_v_p), not from the original scalar inputs, actually exercises the inverse)
+  const auto w2 = euler.conservative(std::get<0>(rho_v_p), std::get<1>(rho_v_p), std::get<2>(rho_v_p));
   for (size_t ii = 0; ii < d + 2; ++ii)
     EXPECT_NEAR(w[ii], w2[ii], 1e-13);
 }

--- a/dune/gdt/test/misc/tools_euler.cc
+++ b/dune/gdt/test/misc/tools_euler.cc
@@ -184,7 +184,7 @@ void check_eigendecomposition(const XT::Common::FieldVector<double, d>& n)
       EXPECT_NEAR(evs[i] * t_i[row], Pt[row], 1e-10);
   }
 
-  // T^{-1} T = I
+  // the inverse eigenvector matrix left-multiplied by the eigenvector matrix must yield the identity
   for (size_t i = 0; i < m; ++i) {
     for (size_t j = 0; j < m; ++j) {
       double entry = 0.;

--- a/python/gdt/test/test_hypothesis_grid_quality.py
+++ b/python/gdt/test/test_hypothesis_grid_quality.py
@@ -18,7 +18,7 @@ the ones that hold independently of the concrete mesh:
 
   * estimate_element_to_intersection_equivalence_constant is a *ratio* of element and intersection diameters, so
     it is invariant under a uniform scaling of the domain and under uniform refinement (both leave the mesh
-    self-similar), and strictly positive in dimension >= 2;
+    self-similar), and strictly positive in every dimension;
   * the eigen-solver-based estimate_inverse_inequality_constant / estimate_combined_inverse_trace_inequality_constant
     are finite and strictly positive wherever the generalized eigen-solver dependency (LAPACKE) is available.
 """
@@ -69,6 +69,7 @@ def _inverse_inequality_available():
             ContinuousLagrangeSpace,
             estimate_inverse_inequality_constant,
         )
+        from dune.xt.common import DuneError
         from dune.xt.test.hypothesis_strategies import GridSpec
 
         grid = GridSpec(
@@ -81,7 +82,7 @@ def _inverse_inequality_available():
         space = ContinuousLagrangeSpace(grid, order=1)
         estimate_inverse_inequality_constant(space)
         return True
-    except Exception:
+    except DuneError:
         return False
 
 
@@ -91,8 +92,10 @@ _needs_eigen_solver = pytest.mark.skipif(
 )
 
 
-# the equivalence constant degenerates in 1d (intersections are points of diameter 0), so only d >= 2 is exercised
-@given(spec=grid_specs(dims=(2, 3), max_elements_per_dim=3))
+# the C++ default intersection_diameter callback special-cases d == 1 (averaging the two adjacent element
+# diameters, or using the boundary element's own diameter) precisely to avoid the degenerate "intersections
+# are points of diameter 0" case, so 1d is exercised on equal footing with 2d/3d here.
+@given(spec=grid_specs(dims=(1, 2, 3), max_elements_per_dim=3))
 def test_element_to_intersection_equivalence_constant_is_positive_and_finite(spec):
     from dune.gdt import estimate_element_to_intersection_equivalence_constant
 
@@ -102,7 +105,7 @@ def test_element_to_intersection_equivalence_constant_is_positive_and_finite(spe
 
 
 @given(
-    spec=grid_specs(dims=(2, 3), max_elements_per_dim=3),
+    spec=grid_specs(dims=(1, 2, 3), max_elements_per_dim=3),
     factor=st.floats(0.25, 4.0, allow_nan=False, allow_infinity=False),
 )
 def test_equivalence_constant_is_scale_invariant(spec, factor):
@@ -118,7 +121,7 @@ def test_equivalence_constant_is_scale_invariant(spec, factor):
 
 # cube elements refine self-similarly (each element splits into 2^d congruent children); simplicial
 # bisection does not preserve element shape, so the diameter ratio is only invariant on cube grids.
-@given(spec=grid_specs(dims=(2, 3), elements=("cube",), max_elements_per_dim=2))
+@given(spec=grid_specs(dims=(1, 2, 3), elements=("cube",), max_elements_per_dim=2))
 def test_equivalence_constant_is_refinement_invariant(spec):
     """Uniform refinement keeps a cube mesh self-similar, hence keeps the (diameter-ratio) constant."""
     from dune.gdt import estimate_element_to_intersection_equivalence_constant

--- a/python/gdt/test/test_hypothesis_grid_quality.py
+++ b/python/gdt/test/test_hypothesis_grid_quality.py
@@ -1,0 +1,152 @@
+# ~~~
+# This file is part of the dune-gdt project:
+#   https://github.com/dune-gdt/dune-gdt
+# Copyright 2010-2026 dune-gdt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""Geometric- and functional-analytic invariants of the grid-quality estimators.
+
+The estimators in dune/gdt/tools/grid-quality-estimates.hh return mesh-dependent constants that enter
+inverse and trace inequalities. The C++ counterpart (dune/gdt/test/misc/tools_grid_quality_estimates.cc)
+pins their value on a single fixed 4x4 / 2x2 YASP square; here the same three functions are exercised across
+the whole hypothesis-generated (grid geometry x element type x order) product, and the properties asserted are
+the ones that hold independently of the concrete mesh:
+
+  * estimate_element_to_intersection_equivalence_constant is a *ratio* of element and intersection diameters, so
+    it is invariant under a uniform scaling of the domain and under uniform refinement (both leave the mesh
+    self-similar), and strictly positive in dimension >= 2;
+  * the eigen-solver-based estimate_inverse_inequality_constant / estimate_combined_inverse_trace_inequality_constant
+    are finite and strictly positive wherever the generalized eigen-solver dependency (LAPACKE) is available.
+"""
+
+import functools
+import math
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    GRID_COMBINATIONS,
+    grid_specs,
+)
+
+# Skip cleanly on builds that bind no grids at all (nothing to draw from otherwise).
+pytestmark = pytest.mark.skipif(
+    not GRID_COMBINATIONS, reason="no grid bindings available in this build"
+)
+
+
+def _scaled_spec(spec, factor):
+    """A geometrically similar copy of spec, with the bounding box scaled about the origin by factor."""
+    from dune.xt.test.hypothesis_strategies import GridSpec
+
+    return GridSpec(
+        dim=spec.dim,
+        element=spec.element,
+        lower_left=tuple(factor * x for x in spec.lower_left),
+        upper_right=tuple(factor * x for x in spec.upper_right),
+        num_elements=spec.num_elements,
+        impl=spec.impl,
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def _inverse_inequality_available():
+    """Whether the generalized eigen-solver backing the inverse/trace estimators is present (LAPACKE).
+
+    Mirrors the ``XT::Common::Lapacke::available()`` guard of the C++ test: on a build without LAPACKE both
+    estimators throw, and the two properties below are skipped rather than reported as failures.
+    """
+    if not GRID_COMBINATIONS:
+        return False
+    try:
+        from dune.gdt import (
+            ContinuousLagrangeSpace,
+            estimate_inverse_inequality_constant,
+        )
+        from dune.xt.test.hypothesis_strategies import GridSpec
+
+        grid = GridSpec(
+            dim=2,
+            element="cube",
+            lower_left=(0.0, 0.0),
+            upper_right=(1.0, 1.0),
+            num_elements=(2, 2),
+        ).make_grid()
+        space = ContinuousLagrangeSpace(grid, order=1)
+        estimate_inverse_inequality_constant(space)
+        return True
+    except Exception:
+        return False
+
+
+_needs_eigen_solver = pytest.mark.skipif(
+    not _inverse_inequality_available(),
+    reason="the generalized eigen-solver dependency (LAPACKE) is unavailable in this build",
+)
+
+
+# the equivalence constant degenerates in 1d (intersections are points of diameter 0), so only d >= 2 is exercised
+@given(spec=grid_specs(dims=(2, 3), max_elements_per_dim=3))
+def test_element_to_intersection_equivalence_constant_is_positive_and_finite(spec):
+    from dune.gdt import estimate_element_to_intersection_equivalence_constant
+
+    constant = estimate_element_to_intersection_equivalence_constant(spec.make_grid())
+    assert math.isfinite(constant)
+    assert constant > 0.0
+
+
+@given(
+    spec=grid_specs(dims=(2, 3), max_elements_per_dim=3),
+    factor=st.floats(0.25, 4.0, allow_nan=False, allow_infinity=False),
+)
+def test_equivalence_constant_is_scale_invariant(spec, factor):
+    """The constant is a ratio of diameters, so scaling the whole domain leaves it unchanged."""
+    from dune.gdt import estimate_element_to_intersection_equivalence_constant
+
+    reference = estimate_element_to_intersection_equivalence_constant(spec.make_grid())
+    scaled = estimate_element_to_intersection_equivalence_constant(
+        _scaled_spec(spec, factor).make_grid()
+    )
+    assert scaled == pytest.approx(reference, rel=1e-12, abs=1e-12)
+
+
+# cube elements refine self-similarly (each element splits into 2^d congruent children); simplicial
+# bisection does not preserve element shape, so the diameter ratio is only invariant on cube grids.
+@given(spec=grid_specs(dims=(2, 3), elements=("cube",), max_elements_per_dim=2))
+def test_equivalence_constant_is_refinement_invariant(spec):
+    """Uniform refinement keeps a cube mesh self-similar, hence keeps the (diameter-ratio) constant."""
+    from dune.gdt import estimate_element_to_intersection_equivalence_constant
+
+    grid = spec.make_grid()
+    coarse = estimate_element_to_intersection_equivalence_constant(grid)
+    grid.global_refine(1)
+    refined = estimate_element_to_intersection_equivalence_constant(grid)
+    assert refined == pytest.approx(coarse, rel=1e-12, abs=1e-12)
+
+
+@_needs_eigen_solver
+@given(spec=grid_specs(max_elements_per_dim=3), order=st.integers(1, 2))
+def test_inverse_inequality_constants_are_positive_and_finite(spec, order):
+    from dune.gdt import (
+        ContinuousLagrangeSpace,
+        estimate_combined_inverse_trace_inequality_constant,
+        estimate_inverse_inequality_constant,
+    )
+
+    space = ContinuousLagrangeSpace(spec.make_grid(), order=order)
+    inverse = estimate_inverse_inequality_constant(space)
+    combined = estimate_combined_inverse_trace_inequality_constant(space)
+    assert math.isfinite(inverse) and inverse > 0.0
+    assert math.isfinite(combined) and combined > 0.0
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)

--- a/python/gdt/test/test_hypothesis_operator_interface.py
+++ b/python/gdt/test/test_hypothesis_operator_interface.py
@@ -1,0 +1,244 @@
+# ~~~
+# This file is part of the dune-gdt project:
+#   https://github.com/dune-gdt/dune-gdt
+# Copyright 2010-2026 dune-gdt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""Operator-interface algebra: apply, linearity and linear combinations of assembled MatrixOperators.
+
+Scenario 5 (test_hypothesis_operators.py) drives the *assembly* stack and inspects only ``op.matrix``. This
+module instead exercises the *operator interface* itself (dune/gdt/operators/interfaces.hh) and the linear
+combination operators it returns (dune/gdt/operators/lincomb.hh), which the C++ suite covers only indirectly:
+
+  * ``op.apply(x)`` reproduces the plain matrix-vector product ``op.matrix @ x`` (the matrix-based operator is,
+    by definition, the linear map represented by its assembled matrix);
+  * ``apply`` is linear: ``op.apply(a*x + y) == a*op.apply(x) + op.apply(y)`` exactly (up to accumulation);
+  * the linear combination ``a*L + b*M`` (an operator returned by ``L*a + M*b``) applies as
+    ``a*L.apply(x) + b*M.apply(x)`` and reports ``num_ops == 2``; negation ``-L`` flips the sign of apply;
+  * every assembled matrix operator reports ``linear == True``.
+
+All inputs (grid geometry, order, the two scalar coefficients and the probe vectors) are hypothesis-generated;
+only the five binding-instantiated grid types are fixed.
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    GRID_COMBINATIONS,
+    grid_specs,
+)
+
+# Skip cleanly on builds that bind no grids at all (nothing to draw from otherwise).
+pytestmark = pytest.mark.skipif(
+    not GRID_COMBINATIONS, reason="no grid bindings available in this build"
+)
+
+
+def _matrix_operator(grid, space, integrand):
+    from dune.gdt import (
+        BilinearForm,
+        LocalElementIntegralBilinearForm,
+        MatrixOperator,
+        make_element_sparsity_pattern,
+    )
+
+    form = BilinearForm(grid)
+    form += LocalElementIntegralBilinearForm(integrand)
+    op = MatrixOperator(
+        grid,
+        source_space=space,
+        range_space=space,
+        sparsity_pattern=make_element_sparsity_pattern(space),
+    )
+    op.append(form)
+    op.assemble()
+    return op
+
+
+def _laplace_operator(grid, space, kappa):
+    from dune.gdt import LocalLaplaceIntegrand
+    from dune.xt.functions import GridFunction as GF
+    from dune.xt.grid import Dim
+
+    d = grid.dimension
+    return _matrix_operator(
+        grid, space, LocalLaplaceIntegrand(GF(grid, kappa, dim_range=(Dim(d), Dim(d))))
+    )
+
+
+def _l2_operator(grid, space, weight):
+    from dune.gdt import LocalElementProductIntegrand
+    from dune.xt.functions import GridFunction as GF
+
+    return _matrix_operator(grid, space, LocalElementProductIntegrand(GF(grid, weight)))
+
+
+def _make_vector(size, values):
+    from dune.xt.la import IstlVector
+
+    vec = IstlVector(size, 0.0)
+    for ii, value in enumerate(values):
+        vec.set_entry(ii, float(value))
+    return vec
+
+
+def _matvec(matrix, vec):
+    from dune.xt.la import IstlVector
+
+    result = IstlVector(len(vec), 0.0)
+    matrix.mv(vec, result)
+    return result
+
+
+def _sup_diff(a, b):
+    """sup norm of a - b, without assuming Python-level vector subtraction is bound."""
+    diff = _make_vector(len(a), np.zeros(len(a)))
+    diff.axpy(1.0, a)
+    diff.axpy(-1.0, b)
+    return diff.sup_norm()
+
+
+def _probe_values(data, num_dofs, label):
+    entry = st.floats(
+        -1.0, 1.0, allow_nan=False, allow_infinity=False, allow_subnormal=False
+    )
+    return np.array(
+        data.draw(st.lists(entry, min_size=num_dofs, max_size=num_dofs), label=label),
+        dtype=float,
+    )
+
+
+GRIDS = grid_specs(unit_box=True, max_elements_per_dim=3)
+KAPPAS = st.floats(1e-2, 1e2, allow_nan=False, allow_infinity=False)
+ORDERS = st.integers(1, 2)
+SCALARS = st.floats(
+    -10.0, 10.0, allow_nan=False, allow_infinity=False, allow_subnormal=False
+)
+
+
+@given(data=st.data(), spec=GRIDS, kappa=KAPPAS, order=ORDERS)
+def test_apply_equals_matrix_vector_product(data, spec, kappa, order):
+    from dune.gdt import ContinuousLagrangeSpace
+
+    grid = spec.make_grid()
+    space = ContinuousLagrangeSpace(grid, order=order)
+    op = _laplace_operator(grid, space, kappa)
+
+    x = _make_vector(space.num_DoFs, _probe_values(data, space.num_DoFs, "x"))
+    applied = op.apply(x)
+    expected = _matvec(op.matrix, x)
+    assert op.linear is True
+    scale = kappa * space.num_DoFs + 1.0
+    assert _sup_diff(applied, expected) <= 1e-10 * scale
+
+
+@given(data=st.data(), spec=GRIDS, kappa=KAPPAS, order=ORDERS, scalar=SCALARS)
+def test_apply_is_linear(data, spec, kappa, order, scalar):
+    from dune.gdt import ContinuousLagrangeSpace
+
+    grid = spec.make_grid()
+    space = ContinuousLagrangeSpace(grid, order=order)
+    op = _laplace_operator(grid, space, kappa)
+
+    n = space.num_DoFs
+    x_vals = _probe_values(data, n, "x")
+    y_vals = _probe_values(data, n, "y")
+    x = _make_vector(n, x_vals)
+    y = _make_vector(n, y_vals)
+    combo = _make_vector(n, scalar * x_vals + y_vals)
+
+    lhs = op.apply(combo)
+    rhs = op.apply(x)
+    rhs.scal(scalar)
+    rhs.axpy(1.0, op.apply(y))
+
+    scale = kappa * n * (abs(scalar) + 1.0) + 1.0
+    assert _sup_diff(lhs, rhs) <= 1e-9 * scale
+
+
+@given(data=st.data(), spec=GRIDS, kappa=KAPPAS, order=ORDERS)
+def test_apply2_binding_returns_none_but_executes(data, spec, kappa, order):
+    """The C++ apply2 is exercised for coverage; its pybind11 wrapper currently returns void (None).
+
+    This mirrors the documented-contract style of test_hypothesis_spaces.py: the call must still run without
+    error on every generated example, and if the binding is ever changed to return the value this assertion is
+    the single place that records the current behaviour.
+    """
+    from dune.gdt import ContinuousLagrangeSpace
+
+    grid = spec.make_grid()
+    space = ContinuousLagrangeSpace(grid, order=order)
+    op = _laplace_operator(grid, space, kappa)
+
+    x = _make_vector(space.num_DoFs, _probe_values(data, space.num_DoFs, "x"))
+    y = _make_vector(space.num_DoFs, _probe_values(data, space.num_DoFs, "y"))
+    assert op.apply2(y, x) is None
+
+
+@given(
+    data=st.data(),
+    spec=GRIDS,
+    kappa=KAPPAS,
+    weight=st.floats(1e-2, 1e2, allow_nan=False, allow_infinity=False),
+    order=ORDERS,
+    a=SCALARS,
+    b=SCALARS,
+)
+def test_linear_combination_applies_componentwise(
+    data, spec, kappa, weight, order, a, b
+):
+    from dune.gdt import ContinuousLagrangeSpace
+
+    grid = spec.make_grid()
+    space = ContinuousLagrangeSpace(grid, order=order)
+    laplace = _laplace_operator(grid, space, kappa)
+    mass = _l2_operator(grid, space, weight)
+
+    # a*L + b*M is returned as a lincomb operator (dune/gdt/operators/lincomb.hh)
+    combined = laplace * a + mass * b
+    assert combined.num_ops == 2
+
+    n = space.num_DoFs
+    x = _make_vector(n, _probe_values(data, n, "x"))
+
+    lhs = combined.apply(x)
+    rhs = laplace.apply(x)
+    rhs.scal(a)
+    mx = mass.apply(x)
+    mx.scal(b)
+    rhs.axpy(1.0, mx)
+
+    scale = (abs(a) * kappa + abs(b) * weight) * n + 1.0
+    assert _sup_diff(lhs, rhs) <= 1e-9 * scale
+
+
+@given(data=st.data(), spec=GRIDS, kappa=KAPPAS, order=ORDERS)
+def test_negation_flips_apply(data, spec, kappa, order):
+    from dune.gdt import ContinuousLagrangeSpace
+
+    grid = spec.make_grid()
+    space = ContinuousLagrangeSpace(grid, order=order)
+    op = _laplace_operator(grid, space, kappa)
+
+    n = space.num_DoFs
+    x = _make_vector(n, _probe_values(data, n, "x"))
+
+    negated = (-op).apply(x)
+    expected = op.apply(x)
+    expected.scal(-1.0)
+
+    scale = kappa * n + 1.0
+    assert _sup_diff(negated, expected) <= 1e-10 * scale
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)


### PR DESCRIPTION
## Summary

Extends test coverage for the `dune/gdt` subdirectory, using the Codecov data from #329 as the baseline. Following the requested priorities: **zero-coverage files first**, then the files with the **most missed lines**, driving new tests **through the existing Python bindings (with Hypothesis) wherever a binding exists**, and only writing native C++ tests where no binding is available. No new bindings are introduced, and reducing *partials* is out of scope for this package.

## Zero-coverage headers

| File | Before | Test added | Why native / binding |
|---|---|---|---|
| `dune/gdt/tools/euler.hh` | 0% (203 lines) | native `dune/gdt/test/misc/tools_euler.cc` | `EulerTools` has no Python binding |
| `dune/gdt/interpolations.hh` | 0% | extended the existing interpolation test bases | the top-level `interpolate(...)` dispatcher is not bound |

- **`tools_euler.cc`** exercises, for `d ∈ {1, 2, 3}`: the primitive↔conservative conversions (round-trip), the derived quantities (speed of sound, Mach number, enthalpy), the Euler flux at rest and at impermeable walls, the flux-jacobian eigendecomposition (`P tᵢ = λᵢ tᵢ` and `T⁻¹T = I` for `d ∈ {1,2}`, `NotImplemented` asserted for `d = 3`), and the conservative-state visualization. Auto-registered via the `misc` subdir's `GLOB_RECURSE` — no CMake change needed.
- **`interpolate(...)` dispatcher**: `dune/gdt/test/interpolations/default.hh` and `raviart-thomas.hh` now additionally call the top-level `interpolate<V>(source, space)` and compare against the branch-specific interpolation they already test, covering both the `default_interpolation` and the `raviart_thomas_interpolation` branch of the dispatcher.

## Most-missed, binding-driven (Hypothesis)

- **`dune/gdt/tools/grid-quality-estimates.hh`** → `python/gdt/test/test_hypothesis_grid_quality.py`: drives the three bound estimator functions across generated grids. Asserts positivity/finiteness and the scale- and refinement-invariance of the element-to-intersection equivalence constant (a diameter ratio). The two eigen-solver-based estimators are skipped where LAPACKE is unavailable, mirroring the `XT::Common::Lapacke::available()` guard of the existing C++ test.
- **`dune/gdt/operators/interfaces.hh` + `dune/gdt/operators/lincomb.hh`** → `python/gdt/test/test_hypothesis_operator_interface.py`: exercises the operator-interface algebra that the C++ suite only touches indirectly — `apply` equals the matrix-vector product, `apply` is linear, `apply2` executes, and the linear-combination operators returned by `L*a + M*b` and `-L` apply component-wise with `num_ops == 2`.

## Explicitly excluded

`dune/gdt/local/numerical-fluxes/vijayasundaram.hh` (0%) is left uncovered on purpose: its `apply()` and default flux-eigendecomposition are commented out (issue #106), and the existing C++ test is `DISABLED`. A test there would assert nothing until the flux is re-enabled.

## Verification

The dune stack cannot be built in the authoring environment, so the new tests are verified by the PR's coverage CI leg (the `clang22-release_coverage` preset runs the full C++ + Python `ctest` suite). Python files pass `ruff 0.15.21` (check + format) and the C++ files pass `clang-format 22.1.8`, matching the repo's pinned pre-commit versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuC8vXbyNzs5ArwBJyzdXq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuC8vXbyNzs5ArwBJyzdXq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded interpolation coverage to verify the generic interpolation interface for scalar and Raviart–Thomas fields.
  - Added comprehensive Euler-tools validation, including state conversions, derived quantities, fluxes, Jacobians, and visualization.
  - Added property-based tests for grid-quality estimator invariants across scaling, refinement, and polynomial orders.
  - Added property-based tests for operator application, linearity, combinations, negation, and matrix consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->