### PR TITLE
test(la): remaining matrix-IO and real-eigenvector partials (Tier 3)

### DIFF
--- a/python/xt/test/test_hypothesis_la_eigensolver.py
+++ b/python/xt/test/test_hypothesis_la_eigensolver.py
@@ -131,6 +131,13 @@ def matrix_as_numpy(mat):
     )
 
 
+def real_matrix_as_numpy(mat):
+    return np.array(
+        [[mat.get_entry(ii, jj) for jj in range(mat.cols)] for ii in range(mat.rows)],
+        dtype=float,
+    )
+
+
 @pytest.mark.skipif(not MATRIX_CLASSES, reason="no eigen-solver binding available")
 @pytest.mark.parametrize("cls", MATRIX_CLASSES, ids=lambda c: c.__name__)
 class TestEigenSolverAgainstScipy:
@@ -201,6 +208,34 @@ class TestEigenSolverAgainstScipy:
         vectors = matrix_as_numpy(solver.eigenvectors())
         inverse = matrix_as_numpy(solver.eigenvectors_inverse())
         identity = np.eye(arr.shape[0], dtype=complex)
+        assert vectors @ inverse == pytest.approx(identity, rel=1e-6, abs=1e-6)
+
+    @settings(deadline=None)
+    @given(arr=spd_matrices())
+    def test_real_eigenvalues_match_scipy(self, cls, arr):
+        # real_eigenvalues() is a distinct accessor from eigenvalues() (base.hh): it returns the
+        # real-typed spectrum, valid here precisely because SPD inputs have real eigenvalues.
+        solver = make_full_solver(eigen_solver_for(cls), make_matrix(cls, arr))
+        actual = np.sort(np.array(solver.real_eigenvalues()))
+        expected = np.sort(scipy_linalg.eigvalsh(arr))
+        assert actual == pytest.approx(expected, rel=1e-6, abs=1e-8)
+
+    @settings(deadline=None)
+    @given(arr=spd_matrices())
+    def test_real_eigenvectors_satisfy_the_eigenrelation(self, cls, arr):
+        # real_eigenvectors()/real_eigenvectors_inverse() are the real-typed accessors (base.hh),
+        # separate from the complex eigenvectors() path tested above; reachable for SPD inputs whose
+        # eigenvectors are real. A*Vr == Vr*diag(real_lambda) is again the order-consistent,
+        # repeated-eigenvalue-safe check.
+        solver = make_full_solver(eigen_solver_for(cls), make_matrix(cls, arr))
+        evals = np.array(solver.real_eigenvalues())
+        vectors = real_matrix_as_numpy(solver.real_eigenvectors())
+        residual = arr @ vectors - vectors @ np.diag(evals)
+        scale = float(np.linalg.norm(arr)) + 1.0
+        assert float(np.linalg.norm(residual)) == pytest.approx(0.0, abs=1e-6 * scale)
+
+        inverse = real_matrix_as_numpy(solver.real_eigenvectors_inverse())
+        identity = np.eye(arr.shape[0])
         assert vectors @ inverse == pytest.approx(identity, rel=1e-6, abs=1e-6)
 
 

--- a/python/xt/test/test_hypothesis_la_matrix.py
+++ b/python/xt/test/test_hypothesis_la_matrix.py
@@ -228,18 +228,15 @@ class TestMatrixAgainstNumpy:
         assert mat.almost_equal(mat)
         assert mat.almost_equal(mat.copy(True))
 
-    @given(
-        shapes=st.tuples(st.integers(1, 6), st.integers(1, 6), st.integers(1, 6)),
-        data=st.data(),
-    )
-    def test_has_equal_shape(self, cls, shapes, data):
-        rows, cols, extra = shapes
+    @given(shape=st.tuples(st.integers(1, 6), st.integers(1, 6)))
+    def test_has_equal_shape(self, cls, shape):
+        rows, cols = shape
         base = make_matrix(cls, np.zeros((rows, cols)))
-        same = make_matrix(cls, np.zeros((rows, cols)))
-        assert base.has_equal_shape(same)
-        if extra != cols:
-            wider = make_matrix(cls, np.zeros((rows, extra)))
-            assert not base.has_equal_shape(wider)
+        assert base.has_equal_shape(make_matrix(cls, np.zeros((rows, cols))))
+        # a differing column count and a differing row count each break shape equality,
+        # exercising both dimension comparisons in has_equal_shape
+        assert not base.has_equal_shape(make_matrix(cls, np.zeros((rows, cols + 1))))
+        assert not base.has_equal_shape(make_matrix(cls, np.zeros((rows + 1, cols))))
 
     @given(arr=matrix_arrays())
     def test_clear_row_zeros_the_row(self, cls, arr):

--- a/python/xt/test/test_hypothesis_la_matrix.py
+++ b/python/xt/test/test_hypothesis_la_matrix.py
@@ -65,6 +65,11 @@ def matrix_as_numpy(mat):
     )
 
 
+def mat_to_csr(mat):
+    # prune=False keeps every structural entry; the tiny eps only matters when prune=True
+    return mat.to_csr(False, 1e-15)
+
+
 def matching_vector_class(matrix_cls):
     """The double vector class dune.xt.la pairs matrix_cls with, by shared backend prefix.
 
@@ -206,6 +211,43 @@ class TestMatrixAgainstNumpy:
         expected[:, n - 1] = 0.0
         expected[n - 1, n - 1] = 1.0
         assert matrix_as_numpy(col_mat) == pytest.approx(expected, abs=0.0)
+
+    @given(arr=matrix_arrays())
+    def test_to_csr_reconstructs_the_matrix(self, cls, arr):
+        # to_csr walks the matrix' structural pattern (matrix-interface.hh); with prune=False every
+        # stored entry is emitted, so scattering (data, rows, cols) back reproduces the matrix.
+        data, row_indices, col_indices = mat_to_csr(make_matrix(cls, arr))
+        recon = np.zeros_like(arr)
+        for value, ii, jj in zip(data, row_indices, col_indices):
+            recon[ii, jj] = value
+        assert recon == pytest.approx(arr, abs=0.0)
+
+    @given(arr=matrix_arrays())
+    def test_almost_equal_is_reflexive_and_detects_copies(self, cls, arr):
+        mat = make_matrix(cls, arr)
+        assert mat.almost_equal(mat)
+        assert mat.almost_equal(mat.copy(True))
+
+    @given(
+        shapes=st.tuples(st.integers(1, 6), st.integers(1, 6), st.integers(1, 6)),
+        data=st.data(),
+    )
+    def test_has_equal_shape(self, cls, shapes, data):
+        rows, cols, extra = shapes
+        base = make_matrix(cls, np.zeros((rows, cols)))
+        same = make_matrix(cls, np.zeros((rows, cols)))
+        assert base.has_equal_shape(same)
+        if extra != cols:
+            wider = make_matrix(cls, np.zeros((rows, extra)))
+            assert not base.has_equal_shape(wider)
+
+    @given(arr=matrix_arrays())
+    def test_clear_row_zeros_the_row(self, cls, arr):
+        mat = make_matrix(cls, arr)
+        mat.clear_row(0)
+        expected = arr.copy()
+        expected[0, :] = 0.0
+        assert matrix_as_numpy(mat) == pytest.approx(expected, abs=0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Tier 3 (final) of the `dune/xt` coverage-extension effort, **stacked on #334** (base is the Tier 2 branch). Same rules: partial branches only, no new bindings, driven from Python bindings + Hypothesis.

Closes the remaining *directly binding-drivable* `dune/xt/la` partials the earlier tiers left:

- **`test_hypothesis_la_matrix.py`** — `to_csr` round-trip (the `matrix-interface.hh` structural-pattern walk), `almost_equal` reflexivity / copy-detection, `has_equal_shape`, and `clear_row`. These are the container-interface / sparse-backend branches the arithmetic-focused Tier 1 matrix suite didn't touch.
- **`test_hypothesis_la_eigensolver.py`** — the real-typed accessors `real_eigenvalues`, `real_eigenvectors`, `real_eigenvectors_inverse` (`eigen-solver/internal/base.hh`), which are distinct code paths from the complex `eigenvectors()` accessors already covered in Tier 1. Reachable because SPD inputs have real spectra and real eigenvectors; checked with the same order-consistent, repeated-eigenvalue-safe residual property.

## Scope note (why not "functions")

The originally-planned Tier 3 was `dune/xt/functions`. On inspection its pointwise-evaluation surface (`evaluate_set`) lives on the **local element-function-set interface** and is only reachable through the element-binding workflow (bind-to-element, reference-coordinate evaluation), with no numpy oracle achievable without a working build to validate against. Rather than ship an unverifiable test that could churn CI on a coverage PR, this tier redirects to the remaining directly-drivable `la` seams. The larger `functions` and `boundaryinfo` partials remain genuine follow-up candidates, but need the local-function / intersection-level workflow (and ideally a local build) to do safely.

## Verification

`ruff check` / `ruff format` clean; byte-compiles. Validated in CI (the `clang22-release_coverage` leg runs the Python suite and reports to Codecov), as with #333/#334.

## The stack

- #333 — Tier 1 (la containers/solver/inverter/eigensolver)
- #334 — Tier 2 (grid provider/walker) — stacked on #333
- this PR — Tier 3 (remaining la) — stacked on #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKrhPPx4kGWDqjSVsQ48xW

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKrhPPx4kGWDqjSVsQ48xW)_