### PR TITLE
fix(cmake): detect LAPACKE/CBLAS via OpenBLAS fallback; add GeneralizedEigenSolver hypothesis test

### DIFF
--- a/cmake/modules/FindCBLAS.cmake
+++ b/cmake/modules/FindCBLAS.cmake
@@ -15,13 +15,15 @@ include(DuneXTHints)
 message("-- checking for cblas library")
 find_library(CBLAS_LIBRARY cblas HINTS ${LIB_HINTS})
 if("${CBLAS_LIBRARY}" MATCHES "CBLAS_LIBRARY-NOTFOUND")
-  # Standalone libcblas not found; vcpkg's OpenBLAS bundles CBLAS inside libopenblas
-  # (built static to avoid AVX512 dynamic-kernel failures on gcc-13), so try that as a
-  # fallback -- the cblas_* symbols and cblas.h header are present inside it.
+  # Standalone libcblas not found; vcpkg's OpenBLAS bundles CBLAS inside libopenblas (built static to avoid AVX512
+  # dynamic-kernel failures on gcc-13), so try that as a fallback -- the cblas_* symbols and cblas.h header are present
+  # inside it.
   find_library(_cblas_openblas_fallback openblas HINTS ${LIB_HINTS})
   if(NOT "${_cblas_openblas_fallback}" MATCHES "_cblas_openblas_fallback-NOTFOUND")
     message("--   standalone CBLAS not found; using OpenBLAS as CBLAS provider")
-    set(CBLAS_LIBRARY "${_cblas_openblas_fallback}" CACHE PATH "Path to the CBLAS library" FORCE)
+    set(CBLAS_LIBRARY
+        "${_cblas_openblas_fallback}"
+        CACHE PATH "Path to the CBLAS library" FORCE)
   else()
     message("--   CBLAS library not found, make sure you have CBLAS installed")
   endif()

--- a/cmake/modules/FindCBLAS.cmake
+++ b/cmake/modules/FindCBLAS.cmake
@@ -6,7 +6,7 @@
 #      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
 #          with "runtime exception" (http://www.dune-project.org/license.html)
 # Authors:
-#   René Fritze    (2018 - 2019)
+#   René Fritze    (2018 - 2019, 2026)
 #   Tobias Leibner (2018, 2020)
 # ~~~
 
@@ -15,14 +15,29 @@ include(DuneXTHints)
 message("-- checking for cblas library")
 find_library(CBLAS_LIBRARY cblas HINTS ${LIB_HINTS})
 if("${CBLAS_LIBRARY}" MATCHES "CBLAS_LIBRARY-NOTFOUND")
-  message("--   CBLAS library not found, make sure you have CBLAS installed")
-else("${CBLAS_LIBRARY}" MATCHES "CBLAS_LIBRARY-NOTFOUND")
+  # Standalone libcblas not found; vcpkg's OpenBLAS bundles CBLAS inside libopenblas
+  # (built static to avoid AVX512 dynamic-kernel failures on gcc-13), so try that as a
+  # fallback -- the cblas_* symbols and cblas.h header are present inside it.
+  find_library(_cblas_openblas_fallback openblas HINTS ${LIB_HINTS})
+  if(NOT "${_cblas_openblas_fallback}" MATCHES "_cblas_openblas_fallback-NOTFOUND")
+    message("--   standalone CBLAS not found; using OpenBLAS as CBLAS provider")
+    set(CBLAS_LIBRARY "${_cblas_openblas_fallback}" CACHE PATH "Path to the CBLAS library" FORCE)
+  else()
+    message("--   CBLAS library not found, make sure you have CBLAS installed")
+  endif()
+  unset(_cblas_openblas_fallback CACHE)
+else()
   message("--   found CBLAS library")
+endif()
+if(NOT "${CBLAS_LIBRARY}" MATCHES "CBLAS_LIBRARY-NOTFOUND")
   set(CBLAS_LIBRARIES "${CBLAS_LIBRARY}")
-endif("${CBLAS_LIBRARY}" MATCHES "CBLAS_LIBRARY-NOTFOUND")
+endif()
 
 message("-- checking for cblas.h header")
-find_path(CBLAS_INCLUDE_DIRS cblas.h HINTS ${INCLUDE_HINTS})
+set(CBLAS_HEADER_INCLUDE_HINTS "")
+append_to_each("${INCLUDE_HINTS}" "openblas/" CBLAS_HEADER_INCLUDE_HINTS)
+list(APPEND CBLAS_HEADER_INCLUDE_HINTS ${INCLUDE_HINTS})
+find_path(CBLAS_INCLUDE_DIRS cblas.h HINTS ${CBLAS_HEADER_INCLUDE_HINTS})
 if("${CBLAS_INCLUDE_DIRS}" MATCHES "CBLAS_INCLUDE_DIRS-NOTFOUND")
   message("--   cblas.h header not found")
 else("${CBLAS_INCLUDE_DIRS}" MATCHES "CBLAS_INCLUDE_DIRS-NOTFOUND")

--- a/cmake/modules/FindCBLAS.cmake
+++ b/cmake/modules/FindCBLAS.cmake
@@ -20,10 +20,17 @@ if("${CBLAS_LIBRARY}" MATCHES "CBLAS_LIBRARY-NOTFOUND")
   # inside it.
   find_library(_cblas_openblas_fallback openblas HINTS ${LIB_HINTS})
   if(NOT "${_cblas_openblas_fallback}" MATCHES "_cblas_openblas_fallback-NOTFOUND")
-    message("--   standalone CBLAS not found; using OpenBLAS as CBLAS provider")
-    set(CBLAS_LIBRARY
-        "${_cblas_openblas_fallback}"
-        CACHE PATH "Path to the CBLAS library" FORCE)
+    include(CheckLibraryExists)
+    check_library_exists("${_cblas_openblas_fallback}" cblas_dgemm "" _cblas_openblas_has_dgemm)
+    if(_cblas_openblas_has_dgemm)
+      message("--   standalone CBLAS not found; using OpenBLAS as CBLAS provider")
+      set(CBLAS_LIBRARY
+          "${_cblas_openblas_fallback}"
+          CACHE PATH "Path to the CBLAS library" FORCE)
+    else()
+      message("--   CBLAS library not found, make sure you have CBLAS installed")
+    endif()
+    unset(_cblas_openblas_has_dgemm CACHE)
   else()
     message("--   CBLAS library not found, make sure you have CBLAS installed")
   endif()

--- a/cmake/modules/FindLAPACKE.cmake
+++ b/cmake/modules/FindLAPACKE.cmake
@@ -15,16 +15,35 @@ include(DuneXTHints)
 
 message("-- checking for lapacke library")
 find_library(LAPACKE_LIBRARY lapacke HINTS ${LIB_HINTS})
+
+find_package(BLAS)
+find_package(LAPACK)
+
 if("${LAPACKE_LIBRARY}" MATCHES "LAPACKE_LIBRARY-NOTFOUND")
   # Standalone liblapacke not found; vcpkg's OpenBLAS bundles LAPACKE inside libopenblas (built static to avoid AVX512
   # dynamic-kernel failures on gcc-13), so try that as a fallback -- the LAPACKE_* symbols and lapacke.h header are
   # present inside it.
   find_library(_lapacke_openblas_fallback openblas HINTS ${LIB_HINTS})
   if(NOT "${_lapacke_openblas_fallback}" MATCHES "_lapacke_openblas_fallback-NOTFOUND")
-    message("--   standalone LAPACKE not found; using OpenBLAS as LAPACKE provider")
-    set(LAPACKE_LIBRARY
-        "${_lapacke_openblas_fallback}"
-        CACHE PATH "Path to the LAPACKE library" FORCE)
+    include(CheckLibraryExists)
+    # LAPACKE_dsygv wraps Fortran-compiled code; gfortran (and BLAS when available) are needed at link time.
+    set(_prev_cmake_required_libraries "${CMAKE_REQUIRED_LIBRARIES}")
+    set(CMAKE_REQUIRED_LIBRARIES gfortran)
+    if(BLAS_FOUND)
+      list(APPEND CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+    check_library_exists("${_lapacke_openblas_fallback}" LAPACKE_dsygv "" _lapacke_openblas_has_dsygv)
+    set(CMAKE_REQUIRED_LIBRARIES "${_prev_cmake_required_libraries}")
+    unset(_prev_cmake_required_libraries)
+    if(_lapacke_openblas_has_dsygv)
+      message("--   standalone LAPACKE not found; using OpenBLAS as LAPACKE provider")
+      set(LAPACKE_LIBRARY
+          "${_lapacke_openblas_fallback}"
+          CACHE PATH "Path to the LAPACKE library" FORCE)
+    else()
+      message("--   library 'LAPACKE' not found, make sure you have both LAPACK and LAPACKE installed")
+    endif()
+    unset(_lapacke_openblas_has_dsygv CACHE)
   else()
     message("--   library 'LAPACKE' not found, make sure you have both LAPACK and LAPACKE installed")
   endif()
@@ -49,12 +68,10 @@ else("${LAPACKE_INCLUDE_DIRS}" MATCHES "LAPACKE_INCLUDE_DIRS-NOTFOUND")
   include_sys_dir("${LAPACKE_INCLUDE_DIRS}")
 endif("${LAPACKE_INCLUDE_DIRS}" MATCHES "LAPACKE_INCLUDE_DIRS-NOTFOUND")
 
-find_package(BLAS)
 if(BLAS_FOUND)
   list(APPEND LAPACKE_LIBRARIES ${BLAS_LIBRARIES})
   list(APPEND LAPACKE_LIBRARIES gfortran)
 endif()
-find_package(LAPACK)
 if(LAPACK_FOUND)
   list(APPEND LAPACKE_LIBRARIES ${LAPACK_LIBRARIES})
 endif()

--- a/cmake/modules/FindLAPACKE.cmake
+++ b/cmake/modules/FindLAPACKE.cmake
@@ -7,7 +7,7 @@
 #          with "runtime exception" (http://www.dune-project.org/license.html)
 # Authors:
 #   Felix Schindler (2017)
-#   René Fritze     (2018 - 2019)
+#   René Fritze     (2018 - 2019, 2026)
 #   Tobias Leibner  (2017 - 2018, 2020)
 # ~~~
 
@@ -16,15 +16,28 @@ include(DuneXTHints)
 message("-- checking for lapacke library")
 find_library(LAPACKE_LIBRARY lapacke HINTS ${LIB_HINTS})
 if("${LAPACKE_LIBRARY}" MATCHES "LAPACKE_LIBRARY-NOTFOUND")
-  message("--   library 'LAPACKE' not found, make sure you have both LAPACK and LAPACKE installed")
-else("${LAPACKE_LIBRARY}" MATCHES "LAPACKE_LIBRARY-NOTFOUND")
+  # Standalone liblapacke not found; vcpkg's OpenBLAS bundles LAPACKE inside libopenblas
+  # (built static to avoid AVX512 dynamic-kernel failures on gcc-13), so try that as a
+  # fallback -- the LAPACKE_* symbols and lapacke.h header are present inside it.
+  find_library(_lapacke_openblas_fallback openblas HINTS ${LIB_HINTS})
+  if(NOT "${_lapacke_openblas_fallback}" MATCHES "_lapacke_openblas_fallback-NOTFOUND")
+    message("--   standalone LAPACKE not found; using OpenBLAS as LAPACKE provider")
+    set(LAPACKE_LIBRARY "${_lapacke_openblas_fallback}" CACHE PATH "Path to the LAPACKE library" FORCE)
+  else()
+    message("--   library 'LAPACKE' not found, make sure you have both LAPACK and LAPACKE installed")
+  endif()
+  unset(_lapacke_openblas_fallback CACHE)
+else()
   message("--   found LAPACKE library")
+endif()
+if(NOT "${LAPACKE_LIBRARY}" MATCHES "LAPACKE_LIBRARY-NOTFOUND")
   set(LAPACKE_LIBRARIES "${LAPACKE_LIBRARY}")
-endif("${LAPACKE_LIBRARY}" MATCHES "LAPACKE_LIBRARY-NOTFOUND")
+endif()
 
 message("-- checking for lapacke.h header")
 set(LAPACKE_HEADER_INCLUDE_HINTS "")
 append_to_each("${INCLUDE_HINTS}" "lapacke/" LAPACKE_HEADER_INCLUDE_HINTS)
+append_to_each("${INCLUDE_HINTS}" "openblas/" LAPACKE_HEADER_INCLUDE_HINTS)
 list(APPEND LAPACKE_HEADER_INCLUDE_HINTS ${INCLUDE_HINTS})
 find_path(LAPACKE_INCLUDE_DIRS lapacke.h HINTS ${LAPACKE_HEADER_INCLUDE_HINTS})
 if("${LAPACKE_INCLUDE_DIRS}" MATCHES "LAPACKE_INCLUDE_DIRS-NOTFOUND")

--- a/cmake/modules/FindLAPACKE.cmake
+++ b/cmake/modules/FindLAPACKE.cmake
@@ -16,13 +16,15 @@ include(DuneXTHints)
 message("-- checking for lapacke library")
 find_library(LAPACKE_LIBRARY lapacke HINTS ${LIB_HINTS})
 if("${LAPACKE_LIBRARY}" MATCHES "LAPACKE_LIBRARY-NOTFOUND")
-  # Standalone liblapacke not found; vcpkg's OpenBLAS bundles LAPACKE inside libopenblas
-  # (built static to avoid AVX512 dynamic-kernel failures on gcc-13), so try that as a
-  # fallback -- the LAPACKE_* symbols and lapacke.h header are present inside it.
+  # Standalone liblapacke not found; vcpkg's OpenBLAS bundles LAPACKE inside libopenblas (built static to avoid AVX512
+  # dynamic-kernel failures on gcc-13), so try that as a fallback -- the LAPACKE_* symbols and lapacke.h header are
+  # present inside it.
   find_library(_lapacke_openblas_fallback openblas HINTS ${LIB_HINTS})
   if(NOT "${_lapacke_openblas_fallback}" MATCHES "_lapacke_openblas_fallback-NOTFOUND")
     message("--   standalone LAPACKE not found; using OpenBLAS as LAPACKE provider")
-    set(LAPACKE_LIBRARY "${_lapacke_openblas_fallback}" CACHE PATH "Path to the LAPACKE library" FORCE)
+    set(LAPACKE_LIBRARY
+        "${_lapacke_openblas_fallback}"
+        CACHE PATH "Path to the LAPACKE library" FORCE)
   else()
     message("--   library 'LAPACKE' not found, make sure you have both LAPACK and LAPACKE installed")
   endif()

--- a/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
+++ b/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
@@ -44,18 +44,20 @@ def _has_lapack_backend(cls):
     """Return True iff cls's GeneralizedEigenSolver reports a usable 'lapack' type.
 
     GeneralizedEigenSolverOptions::types() (dune/xt/la/generalized-eigen-solver/default.hh)
-    throws Dune::Exception when LAPACKE is not linked (the types list would be empty). We
-    catch that here so the module-level MATRIX_CLASSES list stays empty and the test class
-    is skipped cleanly instead of failing at import time.
+    throws Dune::Exception (surfaced as DuneError in Python) when LAPACKE is not linked (the
+    types list would be empty). We catch precisely that here so the module-level
+    MATRIX_CLASSES list stays empty and the test class is skipped cleanly instead of failing
+    at import time; any other exception propagates so a real bug is not silently hidden.
     """
     import dune.xt.la as la
+    from dune.xt.common import DuneError
 
     solver_cls = getattr(la, cls.__name__ + "GeneralizedEigenSolver", None)
     if solver_cls is None:
         return False
     try:
         return "lapack" in solver_cls.types()
-    except Exception:
+    except DuneError:
         return False
 
 

--- a/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
+++ b/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
@@ -1,0 +1,187 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""Property test for the bound LA::GeneralizedEigenSolver (WP5, #349): generalized eigenvalues
+of random real symmetric positive-definite (SPD) matrix pairs must match scipy.linalg.eigh,
+exercising the LAPACKE dsygv code path that the cmake fix in issue #349 makes reachable in
+the coverage build.
+
+Each `<Matrix>GeneralizedEigenSolver` dune.xt.la binding (see python/xt/dune/xt/la/bindings.cc)
+is exercised for every matrix class
+dune.xt.test.hypothesis_strategies.discover_generalized_eigen_solver_types() finds -- so this
+automatically covers whichever combination a given build actually bound, and the test self-skips
+when LAPACKE is not linked (GeneralizedEigenSolverOptions::types() throws in that case, caught
+by _has_lapack_backend() at module load time).
+
+The generalized eigensolver has no pure-C++ fallback: the only available type is "lapack"
+(dune/xt/la/generalized-eigen-solver/default.hh), which calls LAPACKE_dsygv through
+Dune::XT::Common::Lapacke::dsygv (dune/xt/common/lapacke.cc). Linking LAPACKE (via the
+OpeBLAS fallback added to cmake/modules/FindLAPACKE.cmake) therefore unlocks both this test
+and the C++ coverage it measures.
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    dense_sparsity_pattern,
+    discover_generalized_eigen_solver_types,
+)
+
+scipy_linalg = pytest.importorskip("scipy.linalg")
+
+
+def _has_lapack_backend(cls):
+    """Return True iff cls's GeneralizedEigenSolver reports a usable 'lapack' type.
+
+    GeneralizedEigenSolverOptions::types() (dune/xt/la/generalized-eigen-solver/default.hh)
+    throws Dune::Exception when LAPACKE is not linked (the types list would be empty). We
+    catch that here so the module-level MATRIX_CLASSES list stays empty and the test class
+    is skipped cleanly instead of failing at import time.
+    """
+    import dune.xt.la as la
+
+    solver_cls = getattr(la, cls.__name__ + "GeneralizedEigenSolver", None)
+    if solver_cls is None:
+        return False
+    try:
+        return "lapack" in solver_cls.types()
+    except Exception:
+        return False
+
+
+MATRIX_CLASSES = [
+    cls for cls in discover_generalized_eigen_solver_types() if _has_lapack_backend(cls)
+]
+
+
+@st.composite
+def spd_matrix_pair(draw, min_size=1, max_size=6, bound=5.0):
+    """A pair of independent random real SPD matrices of the same size.
+
+    A = M^T M + n*I is symmetric and positive-definite for any M: M^T M is symmetric PSD
+    and the n*I shift raises every eigenvalue to at least n >= 1. Independent fill matrices
+    for lhs and rhs produce a non-trivial generalized problem lhs*v = lambda*rhs*v (if both
+    were the same matrix the problem would collapse to lambda=1 for all v).
+    """
+    n = draw(st.integers(min_size, max_size))
+    entries_lhs = draw(
+        st.lists(
+            st.floats(-bound, bound, allow_nan=False, allow_infinity=False),
+            min_size=n * n,
+            max_size=n * n,
+        )
+    )
+    entries_rhs = draw(
+        st.lists(
+            st.floats(-bound, bound, allow_nan=False, allow_infinity=False),
+            min_size=n * n,
+            max_size=n * n,
+        )
+    )
+    m_lhs = np.asarray(entries_lhs).reshape(n, n)
+    m_rhs = np.asarray(entries_rhs).reshape(n, n)
+    lhs = m_lhs.T @ m_lhs + n * np.eye(n)
+    rhs = m_rhs.T @ m_rhs + n * np.eye(n)
+    return lhs, rhs
+
+
+def make_matrix(cls, arr):
+    rows, cols = arr.shape
+    mat = cls(rows, cols, dense_sparsity_pattern(rows, cols))
+    for ii in range(rows):
+        for jj in range(cols):
+            mat.set_entry(ii, jj, float(arr[ii, jj]))
+    return mat
+
+
+def generalized_solver_for(cls):
+    import dune.xt.la as la
+
+    return getattr(la, cls.__name__ + "GeneralizedEigenSolver")
+
+
+@pytest.mark.skipif(
+    not MATRIX_CLASSES,
+    reason="no generalized eigen-solver with lapack backend available",
+)
+@pytest.mark.parametrize("cls", MATRIX_CLASSES, ids=lambda c: c.__name__)
+class TestGeneralizedEigenSolverAgainstScipy:
+    @settings(deadline=None)
+    @given(pair=spd_matrix_pair())
+    def test_eigenvalues_match_scipy(self, cls, pair):
+        lhs_arr, rhs_arr = pair
+        solver = generalized_solver_for(cls)(
+            make_matrix(cls, lhs_arr), make_matrix(cls, rhs_arr)
+        )
+
+        actual = np.sort(np.array([ev.real for ev in solver.eigenvalues()]))
+        actual_imag = np.array([ev.imag for ev in solver.eigenvalues()])
+        expected = np.sort(scipy_linalg.eigh(lhs_arr, rhs_arr, eigvals_only=True))
+
+        # SPD pair -> real positive eigenvalues (up to solver round-off)
+        assert actual_imag == pytest.approx(np.zeros_like(actual_imag), abs=1e-8)
+        assert actual == pytest.approx(expected, rel=1e-6, abs=1e-8)
+
+    @settings(deadline=None)
+    @given(pair=spd_matrix_pair())
+    def test_real_eigenvalues_match_scipy(self, cls, pair):
+        # real_eigenvalues() is a distinct accessor from eigenvalues() (base.hh): it returns
+        # the real-typed spectrum, valid here precisely because SPD pairs have real eigenvalues.
+        lhs_arr, rhs_arr = pair
+        solver = generalized_solver_for(cls)(
+            make_matrix(cls, lhs_arr), make_matrix(cls, rhs_arr)
+        )
+
+        actual = np.sort(np.array(solver.real_eigenvalues()))
+        expected = np.sort(scipy_linalg.eigh(lhs_arr, rhs_arr, eigvals_only=True))
+        assert actual == pytest.approx(expected, rel=1e-6, abs=1e-8)
+
+    @settings(deadline=None)
+    @given(pair=spd_matrix_pair())
+    def test_min_and_max_eigenvalue_match_scipy(self, cls, pair):
+        lhs_arr, rhs_arr = pair
+        solver = generalized_solver_for(cls)(
+            make_matrix(cls, lhs_arr), make_matrix(cls, rhs_arr)
+        )
+
+        expected = np.sort(scipy_linalg.eigh(lhs_arr, rhs_arr, eigvals_only=True))
+        assert solver.min_eigenvalues(1)[0] == pytest.approx(
+            expected[0], rel=1e-6, abs=1e-8
+        )
+        assert solver.max_eigenvalues(1)[0] == pytest.approx(
+            expected[-1], rel=1e-6, abs=1e-8
+        )
+
+    @settings(deadline=None)
+    @given(pair=spd_matrix_pair(min_size=2))
+    def test_min_and_max_eigenvalues_return_k_extremes(self, cls, pair):
+        # min/max_eigenvalues(k) for k > 1 exercises the partial-sort branch in
+        # GeneralizedEigenSolverBase (base.hh), which min/max_eigenvalues(1) above does not.
+        lhs_arr, rhs_arr = pair
+        n = lhs_arr.shape[0]
+        k = min(2, n)
+        solver = generalized_solver_for(cls)(
+            make_matrix(cls, lhs_arr), make_matrix(cls, rhs_arr)
+        )
+        expected = np.sort(scipy_linalg.eigh(lhs_arr, rhs_arr, eigvals_only=True))
+
+        smallest = np.sort(np.array(solver.min_eigenvalues(k)))
+        largest = np.sort(np.array(solver.max_eigenvalues(k)))
+        assert smallest == pytest.approx(expected[:k], rel=1e-6, abs=1e-8)
+        assert largest == pytest.approx(expected[-k:], rel=1e-6, abs=1e-8)
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)


### PR DESCRIPTION
Closes #349

## Root cause

The coverage build reports 0% coverage for `dune/xt/common/lapacke.cc` (125 missed lines) and `dune/xt/la/generalized-eigen-solver/internal/lapacke.hh` (66 missed) because the cmake find modules never set `HAVE_LAPACKE=1`, so every function in `lapacke.cc` compiled under `#if HAVE_MKL || HAVE_LAPACKE` becomes a `[[maybe_unused]]` stub.

The underlying reason: `FindLAPACKE.cmake` uses `find_library(LAPACKE_LIBRARY lapacke ...)` which searches for a standalone `liblapacke.so/.a`. That library does not exist in this build. The vcpkg triplet (`.vcpkg-overlays/triplets/x64-linux-shared.cmake`) forces OpenBLAS to build **static** (`VCPKG_LIBRARY_LINKAGE static` for the `openblas` port), because dynamic AVX512 dispatch kernels crash with gcc-13. The resulting `libopenblas.a` bundles BLAS + LAPACK + LAPACKE + CBLAS all in one archive — no standalone `liblapacke` is produced. `find_library` returns `LAPACKE_LIBRARY-NOTFOUND`, so `LAPACKE_FOUND` stays 0.

The same issue affects `FindCBLAS.cmake` and `libcblas`.

## Changes

### `cmake/modules/FindLAPACKE.cmake`

After `find_library(LAPACKE_LIBRARY lapacke ...)` returns `NOTFOUND`, try `find_library` for `openblas`. If found, override `LAPACKE_LIBRARY` with `CACHE PATH "" FORCE` so the `NOTFOUND` value is replaced for the current and subsequent cmake runs. Also add `openblas/` as an include hint so `lapacke.h` installed in the openblas include subdirectory is found. The `LAPACKE_LIBRARIES` assignment is moved after the fallback block so it fires regardless of which path succeeded.

### `cmake/modules/FindCBLAS.cmake`

Same pattern: fallback to `openblas` when standalone `libcblas` is missing, with an `openblas/` header hint for `cblas.h`. Note: `dune/xt/common/cblas.cc` is guarded by `#if HAVE_MKL` (not `#if HAVE_CBLAS`), so this does not improve `cblas.cc` coverage on non-MKL builds, but it is the correct detection behaviour when CBLAS is provided by OpenBLAS.

### `python/xt/test/test_hypothesis_la_generalized_eigensolver.py` (new)

Hypothesis property test for `LA::GeneralizedEigenSolver`, the C++ class that calls `LAPACKE_dsygv` through `Dune::XT::Common::Lapacke::dsygv`. This is the primary code path the cmake fix makes reachable.

The `GeneralizedEigenSolver` has **no pure-C++ fallback** — the only available type is `"lapack"` (`dune/xt/la/generalized-eigen-solver/default.hh`), and `types()` throws when LAPACKE is not linked. The test uses `_has_lapack_backend()` at module load time to probe availability and self-skips cleanly when LAPACKE is absent.

Test strategy — `spd_matrix_pair()` generates two independent SPD matrices via `A = M^T M + n·I` (guarantees symmetry and positive-definiteness for any fill matrix `M`, with minimum eigenvalue ≥ n ≥ 1). The generalized eigenvalue problem `lhs·v = λ·rhs·v` solved by `dsygv` is compared against `scipy.linalg.eigh(lhs, rhs, eigvals_only=True)`.

Tests:
- `test_eigenvalues_match_scipy` — complex `eigenvalues()` accessor, checks imaginary parts ≈ 0
- `test_real_eigenvalues_match_scipy` — real-typed `real_eigenvalues()` accessor
- `test_min_and_max_eigenvalue_match_scipy` — `min_eigenvalues(1)` / `max_eigenvalues(1)` single-extreme path
- `test_min_and_max_eigenvalues_return_k_extremes` — `min/max_eigenvalues(k)` partial-sort path (k > 1)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X86YL3Musgf6BXoWei2G7V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility Improvements**
  * Improved automatic detection of CBLAS and LAPACKE by falling back to OpenBLAS when standalone CBLAS/LAPACKE libraries are not found.
  * Expanded header search paths to include common OpenBLAS include subpaths.
* **Tests**
  * Added property-based tests comparing generalized eigenvalue solver results against SciPy, including real/complex outputs and min/max (and multiple eigenvalues) behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->