### PR TITLE
fix(xt): register walker/parallel coverage tests skipped by broken meta-ini

### DIFF
--- a/dune/xt/test/common/parallel.mini
+++ b/dune/xt/test/common/parallel.mini
@@ -1,5 +1,3 @@
 __name = _{threading.max_count}-threads
 
-threads = dummy, dummy, dummy
-threading.max_count = 1, 2, 4 | expand threads
-1, TBB_FOUND, TBB_FOUND | expand threads | cmake_guard
+threading.max_count = 1, 2, 4 | expand

--- a/dune/xt/test/grid/walker.mini
+++ b/dune/xt/test/grid/walker.mini
@@ -1,5 +1,3 @@
 __name = _{threading.max_count}-threads
 
-threads = dummy, dummy, dummy
-threading.max_count = 1, 2, 4 | expand threads
-1, TBB_FOUND, TBB_FOUND | expand threads | cmake_guard
+threading.max_count = 1, 2, 4 | expand


### PR DESCRIPTION
## Problem

`dune/xt/test/grid/walker.cc` and `dune/xt/test/common/parallel.cc` reported **0% coverage as test files** — the coverage CTest run never executed them. Issue #350 hypothesised label filtering, an MPI requirement, or a timeout; investigation showed it is **none of those**: their `.mini` meta-ini configs register **zero ctest tests**.

## Root cause

Both files carry a `cmake_guard` added in `f51f6c1cb` (2022):

```
threads = dummy, dummy, dummy
threading.max_count = 1, 2, 4 | expand threads
1, TBB_FOUND, TBB_FOUND | expand threads | cmake_guard
```

A `cmake_guard` makes dune-testtools emit **static (compile-time) executable variants**, named numerically (`test_walker_0000`/`_0001`) because there is **no `__exec_suffix`**. The **dynamic** ini variants use `__name` → `_1-threads`/`_2-threads`/`_4-threads`. `add_system_test_per_target` only registers a test when `test_<base>_<ini-suffix>` matches a static target name — `_1-threads` never equals `_0000` — so the executables build but **no runnable ctest test is ever added**. An unexecuted translation unit reports 0%.

Contrast `float_cmp.mini`, which works precisely because its `__exec_suffix` and `__name` use the same variables. (`grids.mini` shares the guard-without-`__exec_suffix` shape but is safe — it is include-only; its includers supply a correlated `__exec_suffix`.)

## Fix

TBB is now a **mandatory** vcpkg dependency (`config.h` hard-defines `HAVE_TBB 1`), so the `TBB_FOUND` guard is obsolete — it only broke registration and tripled the compiled-binary count (walker.cc → 3× ~13 MB). Revert both `.mini` files to the pre-guard **pure-dynamic** form: one executable, three runtime thread-count variants.

## Verification

Reconfigured the `clang22-debug` tree:

- 6 tests now register (was 0): `test_{walker,parallel}__{1,2,4}-threads`, each labelled `dune-gdt-test` so the coverage preset's label filter includes them.
- All build and **pass**, ~0.4 s each — no timeout concern.

This also corrects two mis-diagnoses in `af4380428`: `parallel.cc` was never a "runtime crash under instrumentation" and `walker.cc` never timed out — **both were simply never registered**. walker.cc's grid stays at level 8 (now that it genuinely runs, keeping it small is correct).

Closes #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)