### PR TITLE
fix(xt): avoid one-past-the-end operator[] in BlockedFieldVector::end()

### DIFF
--- a/dune/xt/common/fvector-2.6.hh
+++ b/dune/xt/common/fvector-2.6.hh
@@ -331,12 +331,15 @@ public:
 
   K* end()
   {
-    return &(backend_[num_blocks - 1][block_size]);
+    // one-past-the-end pointer via pointer arithmetic on the last block's first (valid) entry:
+    // &backend_[num_blocks - 1][block_size] would call FieldVector::operator[](block_size), an
+    // out-of-bounds index (valid range is [0, block_size)) that a hardened libstdc++ aborts on.
+    return &(backend_[num_blocks - 1][0]) + block_size;
   }
 
   const K* end() const
   {
-    return &(backend_[num_blocks - 1][block_size]);
+    return &(backend_[num_blocks - 1][0]) + block_size;
   }
 
   ThisType& operator*=(const K& val)

--- a/dune/xt/common/fvector-2.7.hh
+++ b/dune/xt/common/fvector-2.7.hh
@@ -331,12 +331,15 @@ public:
 
   K* end()
   {
-    return &(backend_[num_blocks - 1][block_size]);
+    // one-past-the-end pointer via pointer arithmetic on the last block's first (valid) entry:
+    // &backend_[num_blocks - 1][block_size] would call FieldVector::operator[](block_size), an
+    // out-of-bounds index (valid range is [0, block_size)) that a hardened libstdc++ aborts on.
+    return &(backend_[num_blocks - 1][0]) + block_size;
   }
 
   const K* end() const
   {
-    return &(backend_[num_blocks - 1][block_size]);
+    return &(backend_[num_blocks - 1][0]) + block_size;
   }
 
   ThisType& operator*=(const K& val)


### PR DESCRIPTION
## Summary

`BlockedFieldVector::end()` (in both `dune/xt/common/fvector-2.6.hh` and `fvector-2.7.hh`) computed its one-past-the-end pointer via:

```cpp
return &(backend_[num_blocks - 1][block_size]);
```

`backend_[num_blocks - 1][block_size]` calls `FieldVector::operator[](block_size)` on the last block — `block_size` is out of range (valid indices are `[0, block_size)`). This is undefined behavior that happened to be harmless on unhardened `libstdc++`, but aborts under GCC 15's `-O0` default `_GLIBCXX_ASSERTIONS` hardening (`Assertion '__n < this->size()' failed`), currently surfacing as `test_fvector`'s `blockedfieldvector.creation_and_calculations` crashing in CI on `ubuntu-26.04` runners.

Same bug shape as the `CommonDenseMatrix::mv` one-past-the-end deref fixed in a1c2478090 (PR #331): a legal one-past-the-end pointer should be built via pointer arithmetic on a *valid* element, not by indexing one past the end.

## Fix

```cpp
return &(backend_[num_blocks - 1][0]) + block_size;
```

Same address, computed via pointer arithmetic on the last block's valid first entry instead of an out-of-range `operator[]` call.

## Test plan

- [ ] CI: `test_fvector` (`blockedfieldvector.creation_and_calculations`) passes on the `clang22-debug` (ubuntu-26.04, `-O0`, GCC 15 libstdc++ hardening) leg without any assertion-suppression flag.
- [ ] No behavior change for callers of `begin()`/`end()` — verified locally that the computed pointer is bit-identical to the old (undefined-behavior) one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BpNa6YnXSP2vP5hUbc39LK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed end-iterator handling for blocked field vectors.
  * Prevented potential out-of-bounds access errors when using hardened standard libraries.
  * Applied the fix consistently to both mutable and read-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->