### PR TITLE
Bump astral-sh/setup-uv from 8.2.0 to 8.3.2

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -211,7 +211,7 @@ jobs:
     - name: Set up uv
       # Both legs run the Python test suite, which the ctest xt_test_python /
       # gdt_test_python tests execute via `uv run` (no manually-managed venv).
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         # gate the uv cache to trusted runs (pushes/merge queue and same-repo
         # PRs); disable it for external-fork PRs so a fork cannot poison the cache
@@ -518,7 +518,7 @@ jobs:
     # uv provides and manages the Python interpreter itself, so there is no
     # separate actions/setup-python step; all execution below goes through uv.
     - name: Set up uv
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         # gate the uv cache to trusted runs (pushes/merge queue and same-repo
         # PRs); disable it for external-fork PRs so a fork cannot poison the cache


### PR DESCRIPTION
Bumps the `github-actions-dependencies` group with 1 update: [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv).

Updates `astral-sh/setup-uv` from 8.2.0 to 8.3.2.

## Changes

Updated the pinned commit SHA in `.github/workflows/non_docker_build.yml` (two occurrences — the "Set up uv" steps in both build legs):

- Before: `astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0`
- After: `astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2`

The SHA `11f9893` corresponds to the v8.3.2 release ([compare view](https://github.com/astral-sh/setup-uv/compare/fac544c07dec837d0ccb6301d7b5580bf5edae39...11f9893b081a58869d3b5fccaea48c9e9e46f990)).

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ak5dREVAXxs42zevxWkCN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and documentation workflows to use a newer version of the UV setup action.
  * No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->