### PR TITLE
test(coverage): cover lincomb structured-opts jacobian and sparsity dispatcher (Tier 3)

### DIFF
--- a/dune/gdt/test/misc/sparsity_pattern.cc
+++ b/dune/gdt/test/misc/sparsity_pattern.cc
@@ -147,13 +147,19 @@ GTEST_TEST(sparsity_pattern, dispatcher_covers_remaining_branches)
   EXPECT_TRUE(is_row_wise_subset(rt_element, rt_auto));
   EXPECT_TRUE(is_row_wise_subset(rt_auto, rt_element));
 
-  // distinct test/ansatz spaces exercise the ansatz-side operands of the || short-circuit chain:
+  // distinct test/ansatz spaces exercise the ansatz-side operands of the || short-circuit chain; both dispatch to the
+  // element stencil, which we check for exactly (the row count alone cannot distinguish the stencils, as it is the
+  // test-space mapper size either way):
   //   ansatz.continuous(0) (a continuous-Lagrange ansatz) ...
   const auto mixed_cg_ansatz = make_sparsity_pattern(dg, cg, grid_view, Stencil::automatic);
-  EXPECT_EQ(dg.mapper().size(), mixed_cg_ansatz.size());
+  const auto mixed_cg_element = make_element_sparsity_pattern(dg, cg, grid_view);
+  EXPECT_TRUE(is_row_wise_subset(mixed_cg_element, mixed_cg_ansatz));
+  EXPECT_TRUE(is_row_wise_subset(mixed_cg_ansatz, mixed_cg_element));
   //   ... and ansatz.continuous_normal_components() (a Raviart-Thomas ansatz), with all earlier operands false
   const auto mixed_rt_ansatz = make_sparsity_pattern(dg, rt, grid_view, Stencil::automatic);
-  EXPECT_EQ(dg.mapper().size(), mixed_rt_ansatz.size());
+  const auto mixed_rt_element = make_element_sparsity_pattern(dg, rt, grid_view);
+  EXPECT_TRUE(is_row_wise_subset(mixed_rt_element, mixed_rt_ansatz));
+  EXPECT_TRUE(is_row_wise_subset(mixed_rt_ansatz, mixed_rt_element));
 
   // an unknown stencil value falls through to the terminal else and throws
   EXPECT_THROW(make_sparsity_pattern(dg, static_cast<Stencil>(99)), XT::Common::Exceptions::wrong_input_given);

--- a/dune/gdt/test/misc/sparsity_pattern.cc
+++ b/dune/gdt/test/misc/sparsity_pattern.cc
@@ -16,11 +16,13 @@
 #include <algorithm>
 #include <vector>
 
+#include <dune/xt/common/exceptions.hh>
 #include <dune/xt/grid/grids.hh>
 #include <dune/xt/grid/gridprovider/cube.hh>
 #include <dune/xt/la/container/pattern.hh>
 
 #include <dune/gdt/spaces/h1/continuous-lagrange.hh>
+#include <dune/gdt/spaces/hdiv/raviart-thomas.hh>
 #include <dune/gdt/spaces/l2/discontinuous-lagrange.hh>
 #include <dune/gdt/tools/sparsity-pattern.hh>
 
@@ -121,4 +123,38 @@ GTEST_TEST(sparsity_pattern, automatic_stencil_dispatch)
             count_entries(make_sparsity_pattern(cg, Stencil::element)));
   EXPECT_EQ(count_entries(make_intersection_sparsity_pattern(dg)),
             count_entries(make_sparsity_pattern(dg, Stencil::intersection)));
+}
+
+
+GTEST_TEST(sparsity_pattern, dispatcher_covers_remaining_branches)
+{
+  auto grid = XT::Grid::make_cube_grid<G>();
+  auto grid_view = grid.leaf_view();
+  const auto cg = make_continuous_lagrange_space(grid_view, 1);
+  const auto dg = make_discontinuous_lagrange_space(grid_view, 1);
+  // a Raviart-Thomas space is discontinuous but has continuous normal components
+  const auto rt = make_raviart_thomas_space(grid_view, 0);
+
+  // the explicit element_and_intersection stencil is the one dispatcher branch not hit above
+  const auto dg_element_and_intersection = make_element_and_intersection_sparsity_pattern(dg);
+  const auto dg_explicit = make_sparsity_pattern(dg, Stencil::element_and_intersection);
+  EXPECT_TRUE(is_row_wise_subset(dg_element_and_intersection, dg_explicit));
+  EXPECT_TRUE(is_row_wise_subset(dg_explicit, dg_element_and_intersection));
+
+  // automatic dispatch: continuous_normal_components() short-circuits the || chain to the element stencil
+  const auto rt_auto = make_sparsity_pattern(rt, Stencil::automatic);
+  const auto rt_element = make_element_sparsity_pattern(rt);
+  EXPECT_TRUE(is_row_wise_subset(rt_element, rt_auto));
+  EXPECT_TRUE(is_row_wise_subset(rt_auto, rt_element));
+
+  // distinct test/ansatz spaces exercise the ansatz-side operands of the || short-circuit chain:
+  //   ansatz.continuous(0) (a continuous-Lagrange ansatz) ...
+  const auto mixed_cg_ansatz = make_sparsity_pattern(dg, cg, grid_view, Stencil::automatic);
+  EXPECT_EQ(dg.mapper().size(), mixed_cg_ansatz.size());
+  //   ... and ansatz.continuous_normal_components() (a Raviart-Thomas ansatz), with all earlier operands false
+  const auto mixed_rt_ansatz = make_sparsity_pattern(dg, rt, grid_view, Stencil::automatic);
+  EXPECT_EQ(dg.mapper().size(), mixed_rt_ansatz.size());
+
+  // an unknown stencil value falls through to the terminal else and throws
+  EXPECT_THROW(make_sparsity_pattern(dg, static_cast<Stencil>(99)), XT::Common::Exceptions::wrong_input_given);
 }

--- a/dune/gdt/test/operators/operators_lincomb.cc
+++ b/dune/gdt/test/operators/operators_lincomb.cc
@@ -13,6 +13,8 @@
 
 #include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
 
+#include <dune/xt/common/configuration.hh>
+#include <dune/xt/common/string.hh>
 #include <dune/xt/grid/grids.hh>
 #include <dune/xt/grid/gridprovider/cube.hh>
 #include <dune/xt/la/container/istl.hh>
@@ -119,5 +121,64 @@ GTEST_TEST(operators_lincomb, operator_algebra_scaling_and_sum)
   for (size_t ii = 0; ii < n; ++ii) {
     const double expected = 2. * (range_a.get_entry(ii) + range_b.get_entry(ii));
     EXPECT_DOUBLE_EQ(expected, range.get_entry(ii));
+  }
+}
+
+
+GTEST_TEST(operators_lincomb, jacobian_with_structured_per_summand_opts)
+{
+  auto grid = XT::Grid::make_cube_grid<G>();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_continuous_lagrange_space(grid_view, 1);
+  const auto n = space.mapper().size();
+
+  const auto pattern = make_element_sparsity_pattern(space);
+  M matrix_a(n, n, pattern);
+  M matrix_b(n, n, pattern);
+  for (size_t ii = 0; ii < n; ++ii) {
+    matrix_a.set_entry(ii, ii, 1. + double(ii % 3));
+    matrix_b.set_entry(ii, ii, 2. + double(ii % 2));
+  }
+  auto op_a = make_matrix_operator(space, matrix_a);
+  auto op_b = make_matrix_operator(space, matrix_b);
+
+  const double a = 2.;
+  const double b = 3.;
+  auto lincomb = make_lincomb_operator(space);
+  lincomb.add(op_a, a);
+  lincomb.add(op_b, b);
+
+  V source(n, 0.);
+  for (size_t ii = 0; ii < n; ++ii)
+    source.set_entry(ii, 1. + double(ii));
+
+  // The plain jacobian(source) forwards the operator's default jacobian_options(): those carry no "op.<i>.opts"
+  // subtree, so inside LincombOperator::jacobian the two has_sub(...) checks are false and op_opts stays empty (the
+  // if (op_opts.empty()) branch is taken).
+  const auto jac_default = lincomb.jacobian(source);
+
+  // Passing structured per-summand opts flips all three: each "op.<i>.opts"/"back_op.<i>.opts" subtree makes the
+  // has_sub(...) checks true, and op_opts is then non-empty. The per-summand type is "matrix" (the summands are
+  // matrix operators), so both routes assemble the same linear combination.
+  XT::Common::Configuration opts;
+  opts["type"] = "lincomb";
+  for (size_t ii = 0; ii < lincomb.num_ops(); ++ii) {
+    const auto op_prefix = "op." + XT::Common::to_string(ii);
+    const auto back_op_prefix = "back_op." + XT::Common::to_string(ii);
+    opts[op_prefix + ".type"] = "matrix";
+    opts[op_prefix + ".opts.type"] = "matrix";
+    opts[back_op_prefix + ".type"] = "matrix";
+    opts[back_op_prefix + ".opts.type"] = "matrix";
+  }
+  const auto jac_structured = lincomb.jacobian(source, opts);
+
+  const auto& m_default = jac_default.matrix();
+  const auto& m_structured = jac_structured.matrix();
+  ASSERT_EQ(n, m_default.rows());
+  ASSERT_EQ(m_default.rows(), m_structured.rows());
+  for (size_t ii = 0; ii < n; ++ii) {
+    const double expected = a * matrix_a.get_entry(ii, ii) + b * matrix_b.get_entry(ii, ii);
+    EXPECT_DOUBLE_EQ(expected, m_default.get_entry(ii, ii));
+    EXPECT_DOUBLE_EQ(expected, m_structured.get_entry(ii, ii));
   }
 }

--- a/dune/gdt/test/operators/operators_lincomb.cc
+++ b/dune/gdt/test/operators/operators_lincomb.cc
@@ -19,6 +19,7 @@
 #include <dune/xt/grid/gridprovider/cube.hh>
 #include <dune/xt/la/container/istl.hh>
 
+#include <dune/gdt/exceptions.hh>
 #include <dune/gdt/operators/lincomb.hh>
 #include <dune/gdt/operators/matrix.hh>
 #include <dune/gdt/spaces/h1/continuous-lagrange.hh>
@@ -33,7 +34,12 @@ using M = XT::LA::IstlRowMajorSparseMatrix<double>;
 using V = XT::LA::IstlDenseVector<double>;
 
 
-GTEST_TEST(operators_lincomb, apply_and_jacobian_are_the_linear_combination)
+// Shared fixture for the lincomb tests: a continuous-Lagrange space with two diagonal matrix operators A and B, plus a
+// ramp source vector. The matrices must outlive the operators (and the operators the lincomb) that reference them, so
+// everything is built as locals here and handed to the test body via a callback, keeping all addresses stable for its
+// duration. Centralising the setup keeps it in a single place instead of being copy-pasted into every test.
+template <class TestBody>
+static void with_two_diagonal_operators(TestBody&& test_body)
 {
   auto grid = XT::Grid::make_cube_grid<G>();
   auto grid_view = grid.leaf_view();
@@ -41,8 +47,6 @@ GTEST_TEST(operators_lincomb, apply_and_jacobian_are_the_linear_combination)
   const auto n = space.mapper().size();
 
   const auto pattern = make_element_sparsity_pattern(space);
-
-  // two diagonal matrix operators A and B (must outlive the lincomb, which references them)
   M matrix_a(n, n, pattern);
   M matrix_b(n, n, pattern);
   for (size_t ii = 0; ii < n; ++ii) {
@@ -52,133 +56,152 @@ GTEST_TEST(operators_lincomb, apply_and_jacobian_are_the_linear_combination)
   auto op_a = make_matrix_operator(space, matrix_a);
   auto op_b = make_matrix_operator(space, matrix_b);
 
-  const double a = 2.;
-  const double b = 3.;
-
-  auto lincomb = make_lincomb_operator(space);
-  lincomb.add(op_a, a);
-  lincomb.add(op_b, b);
-
-  // the accessors report the two summands with their coefficients
-  ASSERT_EQ(2u, lincomb.num_ops());
-  EXPECT_DOUBLE_EQ(a, lincomb.coeff(0));
-  EXPECT_DOUBLE_EQ(b, lincomb.coeff(1));
-
   V source(n, 0.);
   for (size_t ii = 0; ii < n; ++ii)
     source.set_entry(ii, 1. + double(ii));
 
-  // apply(v) == a * A.apply(v) + b * B.apply(v)
-  const auto range = lincomb.apply(source);
-  const auto range_a = op_a.apply(source);
-  const auto range_b = op_b.apply(source);
-  ASSERT_EQ(n, range.size());
-  for (size_t ii = 0; ii < n; ++ii) {
-    const double expected = a * range_a.get_entry(ii) + b * range_b.get_entry(ii);
-    EXPECT_DOUBLE_EQ(expected, range.get_entry(ii));
-  }
+  test_body(space, n, matrix_a, matrix_b, op_a, op_b, source);
+}
 
-  // the jacobian is a * A + b * B (diagonal since both summands are diagonal)
-  const auto jac = lincomb.jacobian(source);
-  const auto& jac_matrix = jac.matrix();
-  ASSERT_EQ(n, jac_matrix.rows());
-  for (size_t ii = 0; ii < n; ++ii) {
-    const double expected = a * matrix_a.get_entry(ii, ii) + b * matrix_b.get_entry(ii, ii);
-    EXPECT_DOUBLE_EQ(expected, jac_matrix.get_entry(ii, ii));
-  }
+
+GTEST_TEST(operators_lincomb, apply_and_jacobian_are_the_linear_combination)
+{
+  with_two_diagonal_operators([](const auto& space,
+                                 const auto n,
+                                 const auto& matrix_a,
+                                 const auto& matrix_b,
+                                 auto& op_a,
+                                 auto& op_b,
+                                 const auto& source) {
+    const double a = 2.;
+    const double b = 3.;
+
+    auto lincomb = make_lincomb_operator(space);
+    lincomb.add(op_a, a);
+    lincomb.add(op_b, b);
+
+    // the accessors report the two summands with their coefficients
+    ASSERT_EQ(2u, lincomb.num_ops());
+    EXPECT_DOUBLE_EQ(a, lincomb.coeff(0));
+    EXPECT_DOUBLE_EQ(b, lincomb.coeff(1));
+
+    // apply(v) == a * A.apply(v) + b * B.apply(v)
+    const auto range = lincomb.apply(source);
+    const auto range_a = op_a.apply(source);
+    const auto range_b = op_b.apply(source);
+    ASSERT_EQ(n, range.size());
+    for (size_t ii = 0; ii < n; ++ii) {
+      const double expected = a * range_a.get_entry(ii) + b * range_b.get_entry(ii);
+      EXPECT_DOUBLE_EQ(expected, range.get_entry(ii));
+    }
+
+    // the jacobian is a * A + b * B (diagonal since both summands are diagonal)
+    const auto jac = lincomb.jacobian(source);
+    const auto& jac_matrix = jac.matrix();
+    ASSERT_EQ(n, jac_matrix.rows());
+    for (size_t ii = 0; ii < n; ++ii) {
+      const double expected = a * matrix_a.get_entry(ii, ii) + b * matrix_b.get_entry(ii, ii);
+      EXPECT_DOUBLE_EQ(expected, jac_matrix.get_entry(ii, ii));
+    }
+  });
 }
 
 
 GTEST_TEST(operators_lincomb, operator_algebra_scaling_and_sum)
 {
-  auto grid = XT::Grid::make_cube_grid<G>();
-  auto grid_view = grid.leaf_view();
-  const auto space = make_continuous_lagrange_space(grid_view, 1);
-  const auto n = space.mapper().size();
+  with_two_diagonal_operators([]([[maybe_unused]] const auto& space,
+                                 const auto n,
+                                 [[maybe_unused]] const auto& matrix_a,
+                                 [[maybe_unused]] const auto& matrix_b,
+                                 auto& op_a,
+                                 auto& op_b,
+                                 const auto& source) {
+    // build (A + B) via operator+ and scale it in place by *= 2
+    auto sum = op_a + op_b;
+    sum *= 2.;
+    ASSERT_EQ(2u, sum.num_ops());
 
-  const auto pattern = make_element_sparsity_pattern(space);
-  M matrix_a(n, n, pattern);
-  M matrix_b(n, n, pattern);
-  for (size_t ii = 0; ii < n; ++ii) {
-    matrix_a.set_entry(ii, ii, 1. + double(ii % 3));
-    matrix_b.set_entry(ii, ii, 2. + double(ii % 2));
-  }
-  auto op_a = make_matrix_operator(space, matrix_a);
-  auto op_b = make_matrix_operator(space, matrix_b);
-
-  V source(n, 0.);
-  for (size_t ii = 0; ii < n; ++ii)
-    source.set_entry(ii, 1. + double(ii));
-
-  // build (A + B) via operator+ and scale it in place by *= 2
-  auto sum = op_a + op_b;
-  sum *= 2.;
-  ASSERT_EQ(2u, sum.num_ops());
-
-  const auto range = sum.apply(source);
-  const auto range_a = op_a.apply(source);
-  const auto range_b = op_b.apply(source);
-  for (size_t ii = 0; ii < n; ++ii) {
-    const double expected = 2. * (range_a.get_entry(ii) + range_b.get_entry(ii));
-    EXPECT_DOUBLE_EQ(expected, range.get_entry(ii));
-  }
+    const auto range = sum.apply(source);
+    const auto range_a = op_a.apply(source);
+    const auto range_b = op_b.apply(source);
+    for (size_t ii = 0; ii < n; ++ii) {
+      const double expected = 2. * (range_a.get_entry(ii) + range_b.get_entry(ii));
+      EXPECT_DOUBLE_EQ(expected, range.get_entry(ii));
+    }
+  });
 }
 
 
 GTEST_TEST(operators_lincomb, jacobian_with_structured_per_summand_opts)
 {
-  auto grid = XT::Grid::make_cube_grid<G>();
-  auto grid_view = grid.leaf_view();
-  const auto space = make_continuous_lagrange_space(grid_view, 1);
-  const auto n = space.mapper().size();
+  with_two_diagonal_operators([](const auto& space,
+                                 const auto n,
+                                 const auto& matrix_a,
+                                 const auto& matrix_b,
+                                 auto& op_a,
+                                 auto& op_b,
+                                 const auto& source) {
+    const double a = 2.;
+    const double b = 3.;
+    auto lincomb = make_lincomb_operator(space);
+    lincomb.add(op_a, a);
+    lincomb.add(op_b, b);
 
-  const auto pattern = make_element_sparsity_pattern(space);
-  M matrix_a(n, n, pattern);
-  M matrix_b(n, n, pattern);
-  for (size_t ii = 0; ii < n; ++ii) {
-    matrix_a.set_entry(ii, ii, 1. + double(ii % 3));
-    matrix_b.set_entry(ii, ii, 2. + double(ii % 2));
-  }
-  auto op_a = make_matrix_operator(space, matrix_a);
-  auto op_b = make_matrix_operator(space, matrix_b);
+    // The plain jacobian(source) forwards the operator's default jacobian_options(): those carry no "op.<i>.opts"
+    // subtree, so inside LincombOperator::jacobian the two has_sub(...) checks are false and op_opts stays empty (the
+    // if (op_opts.empty()) branch is taken).
+    const auto jac_default = lincomb.jacobian(source);
 
-  const double a = 2.;
-  const double b = 3.;
-  auto lincomb = make_lincomb_operator(space);
-  lincomb.add(op_a, a);
-  lincomb.add(op_b, b);
+    // Passing structured per-summand opts flips all three: each "op.<i>.opts"/"back_op.<i>.opts" subtree makes the
+    // has_sub(...) checks true, and op_opts is then non-empty. The per-summand type is "matrix" (the summands are
+    // matrix operators), so both routes assemble the same linear combination.
+    XT::Common::Configuration opts;
+    opts["type"] = "lincomb";
+    for (size_t ii = 0; ii < lincomb.num_ops(); ++ii) {
+      const auto op_prefix = "op." + XT::Common::to_string(ii);
+      const auto back_op_prefix = "back_op." + XT::Common::to_string(ii);
+      opts[op_prefix + ".type"] = "matrix";
+      opts[op_prefix + ".opts.type"] = "matrix";
+      opts[back_op_prefix + ".type"] = "matrix";
+      opts[back_op_prefix + ".opts.type"] = "matrix";
+    }
+    const auto jac_structured = lincomb.jacobian(source, opts);
 
-  V source(n, 0.);
-  for (size_t ii = 0; ii < n; ++ii)
-    source.set_entry(ii, 1. + double(ii));
+    const auto& m_default = jac_default.matrix();
+    const auto& m_structured = jac_structured.matrix();
+    ASSERT_EQ(n, m_default.rows());
+    ASSERT_EQ(m_default.rows(), m_structured.rows());
+    for (size_t ii = 0; ii < n; ++ii) {
+      const double expected = a * matrix_a.get_entry(ii, ii) + b * matrix_b.get_entry(ii, ii);
+      EXPECT_DOUBLE_EQ(expected, m_default.get_entry(ii, ii));
+      EXPECT_DOUBLE_EQ(expected, m_structured.get_entry(ii, ii));
+    }
+  });
+}
 
-  // The plain jacobian(source) forwards the operator's default jacobian_options(): those carry no "op.<i>.opts"
-  // subtree, so inside LincombOperator::jacobian the two has_sub(...) checks are false and op_opts stays empty (the
-  // if (op_opts.empty()) branch is taken).
-  const auto jac_default = lincomb.jacobian(source);
 
-  // Passing structured per-summand opts flips all three: each "op.<i>.opts"/"back_op.<i>.opts" subtree makes the
-  // has_sub(...) checks true, and op_opts is then non-empty. The per-summand type is "matrix" (the summands are
-  // matrix operators), so both routes assemble the same linear combination.
-  XT::Common::Configuration opts;
-  opts["type"] = "lincomb";
-  for (size_t ii = 0; ii < lincomb.num_ops(); ++ii) {
-    const auto op_prefix = "op." + XT::Common::to_string(ii);
-    const auto back_op_prefix = "back_op." + XT::Common::to_string(ii);
-    opts[op_prefix + ".type"] = "matrix";
-    opts[op_prefix + ".opts.type"] = "matrix";
-    opts[back_op_prefix + ".type"] = "matrix";
-    opts[back_op_prefix + ".opts.type"] = "matrix";
-  }
-  const auto jac_structured = lincomb.jacobian(source, opts);
+GTEST_TEST(operators_lincomb, structured_per_summand_opts_are_forwarded_to_the_summand)
+{
+  with_two_diagonal_operators([](const auto& space,
+                                 [[maybe_unused]] const auto n,
+                                 [[maybe_unused]] const auto& matrix_a,
+                                 [[maybe_unused]] const auto& matrix_b,
+                                 auto& op_a,
+                                 [[maybe_unused]] auto& op_b,
+                                 const auto& source) {
+    auto lincomb = make_lincomb_operator(space);
+    lincomb.add(op_a, 1.);
 
-  const auto& m_default = jac_default.matrix();
-  const auto& m_structured = jac_structured.matrix();
-  ASSERT_EQ(n, m_default.rows());
-  ASSERT_EQ(m_default.rows(), m_structured.rows());
-  for (size_t ii = 0; ii < n; ++ii) {
-    const double expected = a * matrix_a.get_entry(ii, ii) + b * matrix_b.get_entry(ii, ii);
-    EXPECT_DOUBLE_EQ(expected, m_default.get_entry(ii, ii));
-    EXPECT_DOUBLE_EQ(expected, m_structured.get_entry(ii, ii));
-  }
+    // The "op.0.opts" subtree makes the has_sub(...) check fire, so op_opts is taken from "op.0" and forwarded to the
+    // summand. Its type is bogus, which the matrix operator's own jacobian-option validation must reject -- proving the
+    // per-summand opts are actually passed through rather than silently ignored. back_op.0 mirrors op.0 to keep the
+    // conflict guard from firing first (the lincomb has a single summand, so op.0 and back_op.0 coincide).
+    XT::Common::Configuration bad_opts;
+    bad_opts["type"] = "lincomb";
+    bad_opts["op.0.type"] = "not_a_valid_matrix_jacobian_type";
+    bad_opts["op.0.opts.type"] = "matrix";
+    bad_opts["back_op.0.type"] = "not_a_valid_matrix_jacobian_type";
+    bad_opts["back_op.0.opts.type"] = "matrix";
+    EXPECT_THROW(lincomb.jacobian(source, bad_opts), Exceptions::operator_error);
+  });
 }


### PR DESCRIPTION
## Summary

Closes #339 — Tier 3 (final) of the `dune/gdt` partials-reduction work package. Both targets are genuinely reachable runtime branches with **no covering Python binding**, so per this work package's rule they are exercised via native C++ tests instead of new bindings.

No new bindings introduced.

## Changes

### `dune/gdt/operators/lincomb.hh` lines 186, 189, 198 → `test/operators/operators_lincomb.cc`

Added `jacobian_with_structured_per_summand_opts`. The existing plain `jacobian(source)` path forwards the operator's default `jacobian_options()`, which carry no `op.<i>.opts` subtree — so `has_sub(...)` is false and `op_opts` stays empty (only the else/empty sides are hit). The new test additionally calls the structured-opts overload with per-summand `op.<i>.opts` / `back_op.<i>.opts` subtrees, flipping:
- `if (opts.has_sub("op.<i>.opts"))` (line 186) to true,
- `if (opts.has_sub("back_op.<back_i>.opts"))` (line 189) to true,
- `if (op_opts.empty())` (line 198) to the non-empty branch.

The per-summand type is `"matrix"` (the summands are matrix operators), and both routes are asserted to assemble the same `a·A + b·B`.

### `dune/gdt/tools/sparsity-pattern.hh` lines 176, 178, 179, 180 → `test/misc/sparsity_pattern.cc`

Added `dispatcher_covers_remaining_branches`, calling `make_sparsity_pattern(space, stencil)` directly to hit the branches the existing `automatic_stencil_dispatch` test leaves partial:
- the explicit `Stencil::element_and_intersection` case (line 176),
- a Raviart-Thomas space whose `continuous_normal_components()` short-circuits the `automatic` `||` chain to the element stencil (lines 179–180),
- mixed test/ansatz spaces (DG test with CG / RT ansatz) driving the ansatz-side operands of that `||` chain,
- an unknown `Stencil` value falling through to the terminal `else` throw (line 178 false side).

## Notes
- Both test dirs (`misc`, `operators`) are already registered via `add_subdir_tests` in `dune/gdt/test/CMakeLists.txt`, and the extended files already build — no CMake change needed.
- CI (`Test with CTest` + codecov) is the verifier, as no local build is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R26DfnAZBXmZTN6gQVahnJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded sparsity-pattern coverage for additional stencil modes, space combinations, and invalid input handling.
  * Added validation for automatic stencil behavior with Raviart–Thomas spaces.
  * Added coverage confirming structured per-summand options produce the same lincomb Jacobian as default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->