### PR TITLE
test(xt): cover the grid boundary-detector functor via Python grid-walker

### DIFF
--- a/python/xt/dune/xt/test/hypothesis_strategies.py
+++ b/python/xt/dune/xt/test/hypothesis_strategies.py
@@ -314,6 +314,31 @@ class GridSpec:
         # vertices (Freudenthal/Kuhn triangulation), so this holds for both element types.
         return int(np.prod([n + 1 for n in self.num_elements]))
 
+    @property
+    def num_boundary_faces(self):
+        """Codim-1 faces of the structured cube skeleton lying on the domain boundary.
+
+        Two faces are perpendicular to each axis (the low and high side of the box); the face
+        perpendicular to axis k is tiled by the ``prod_{j != k} num_elements[j]`` cells touching it.
+        """
+        return 2 * sum(
+            int(np.prod([n for jj, n in enumerate(self.num_elements) if jj != kk]))
+            for kk in range(self.dim)
+        )
+
+    @property
+    def expected_num_boundary_intersections(self):
+        """Number of leaf boundary intersections of the (unrefined) grid.
+
+        A cube grid keeps every boundary cube-face as one intersection. Splitting the cubes into
+        simplices triangulates each *boundary* cube-face into ``SIMPLICES_PER_CUBE[dim - 1]``
+        sub-faces (a 2d square boundary face -> 2 triangles in 3d; a 1d edge stays one edge in 2d,
+        a 0d vertex stays one point in 1d), while the diagonals introduced by the split are interior.
+        """
+        if self.element == "cube":
+            return self.num_boundary_faces
+        return SIMPLICES_PER_CUBE.get(self.dim - 1, 1) * self.num_boundary_faces
+
 
 @st.composite
 def bounding_boxes(draw, dim, coordinate_range=100.0, min_extent=0.1, max_extent=100.0):

--- a/python/xt/test/test_hypothesis_grid_boundary_detector.py
+++ b/python/xt/test/test_hypothesis_grid_boundary_detector.py
@@ -1,0 +1,121 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""BoundaryDetectorFunctor: counting boundary intersections of a walked grid.
+
+dune/xt/grid/functors/boundary-detector.hh counts, while a Walker walks a grid view, the
+intersections whose ``BoundaryInfo`` type equals a requested ``BoundaryType`` (its ``compute_locally``
+returns ``boundary_info.type(intersection) == boundary_type``, accumulated in ``apply_local`` and read
+back through ``result``). The C++ test (dune/xt/test/grid/walker.cc::check_boundaries) fixes a single
+grid and only the ``AllDirichletBoundaryInfo``/``DirichletBoundary`` pairing; here the grid geometry
+and type are drawn by hypothesis and the functor is cross-checked against the grid's own geometry.
+
+The ``All<Kind>BoundaryInfo`` classes all mark exactly the domain-boundary intersections with their
+respective ``<Kind>Boundary`` type (alldirichlet.hh / allneumann.hh / allreflecting.hh), so a detector
+built from a matching (info, type) pair must report exactly the number of boundary intersections --
+which is independently counted here by walking the grid and testing ``intersection.boundary``, and,
+for the structured grids, is also known in closed form (GridSpec.expected_num_boundary_intersections).
+A detector built from a *mismatched* pair (Dirichlet info, Neumann type) must report zero, exercising
+the ``compute_locally`` branch that returns 0 on every intersection.
+"""
+
+import pytest
+from hypothesis import given
+
+from dune.xt.test.hypothesis_strategies import GRID_COMBINATIONS, grid_specs
+
+# Skip cleanly on builds that bind no grids at all (nothing to draw from otherwise).
+pytestmark = pytest.mark.skipif(
+    not GRID_COMBINATIONS, reason="no grid bindings available in this build"
+)
+
+
+def _count_boundary_intersections(grid):
+    """Independently count the leaf boundary intersections by walking the grid geometry.
+
+    apply_on_each_intersection visits every inner intersection once from each adjacent element and
+    every boundary intersection once, so counting the visits with ``intersection.boundary`` set gives
+    exactly the number of boundary intersections -- the geometric ground truth the functor must hit.
+    """
+    visited = []
+    grid.apply_on_each_intersection(
+        lambda intersection: intersection.boundary and visited.append(1)
+    )
+    return len(visited)
+
+
+def _detect(grid, boundary_info, boundary_type):
+    """Walk ``grid`` with a BoundaryDetectorFunctor and return its result."""
+    from dune.xt.grid import BoundaryDetectorFunctor, Walker
+
+    detector = BoundaryDetectorFunctor(grid, boundary_info, boundary_type)
+    walker = Walker(grid)
+    walker.append(detector)
+    walker.walk()
+    return detector.result
+
+
+@given(spec=grid_specs(max_elements_per_dim=3))
+def test_detects_all_boundary_intersections(spec):
+    from dune.xt.grid import AllDirichletBoundaryInfo, DirichletBoundary
+
+    grid = spec.make_grid()
+    detected = _detect(grid, AllDirichletBoundaryInfo(grid), DirichletBoundary())
+
+    # the detector must agree with the grid's own boundary geometry ...
+    assert detected == _count_boundary_intersections(grid)
+    # ... and a closed structured box always has some boundary
+    assert detected > 0
+
+
+@given(spec=grid_specs(max_elements_per_dim=3))
+def test_detected_count_matches_closed_form(spec):
+    from dune.xt.grid import AllDirichletBoundaryInfo, DirichletBoundary
+
+    grid = spec.make_grid()
+    detected = _detect(grid, AllDirichletBoundaryInfo(grid), DirichletBoundary())
+    assert detected == spec.expected_num_boundary_intersections
+
+
+@given(spec=grid_specs(max_elements_per_dim=3))
+def test_boundary_info_kind_does_not_change_the_count(spec):
+    # AllDirichlet/AllNeumann/AllReflecting each tag exactly the boundary intersections with their own
+    # BoundaryType, so a detector matched to each must report the same boundary-intersection count.
+    from dune.xt.grid import (
+        AllDirichletBoundaryInfo,
+        AllNeumannBoundaryInfo,
+        AllReflectingBoundaryInfo,
+        DirichletBoundary,
+        NeumannBoundary,
+        ReflectingBoundary,
+    )
+
+    grid = spec.make_grid()
+    dirichlet = _detect(grid, AllDirichletBoundaryInfo(grid), DirichletBoundary())
+    neumann = _detect(grid, AllNeumannBoundaryInfo(grid), NeumannBoundary())
+    reflecting = _detect(grid, AllReflectingBoundaryInfo(grid), ReflectingBoundary())
+
+    assert dirichlet == neumann == reflecting
+
+
+@given(spec=grid_specs(max_elements_per_dim=3))
+def test_mismatched_boundary_type_detects_nothing(spec):
+    # AllDirichletBoundaryInfo never reports NeumannBoundary, so compute_locally returns 0 on every
+    # intersection and the accumulated result is exactly zero.
+    from dune.xt.grid import AllDirichletBoundaryInfo, NeumannBoundary
+
+    grid = spec.make_grid()
+    assert _detect(grid, AllDirichletBoundaryInfo(grid), NeumannBoundary()) == 0
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)

--- a/python/xt/test/test_hypothesis_strategies.py
+++ b/python/xt/test/test_hypothesis_strategies.py
@@ -282,6 +282,38 @@ def test_grid_spec_defaults_to_the_conforming_default_implementation():
     assert spec.conforming is True
 
 
+@pytest.mark.parametrize(
+    ("dim", "element", "num_elements", "expected"),
+    [
+        # 1d: two endpoints, independent of the resolution and of cube/simplex (P_k == Q_k in 1d)
+        (1, "cube", (3,), 2),
+        (1, "simplex", (3,), 2),
+        # 2d: the box perimeter is tiled by n_x + n_x + n_y + n_y edges; splitting each cube into
+        # two triangles leaves every boundary edge intact (only the interior diagonal is added)
+        (2, "cube", (2, 3), 10),
+        (2, "simplex", (2, 3), 10),
+        # 3d: each of the 2*(n_y*n_z + n_x*n_z + n_x*n_y) boundary squares stays one face on a cube
+        # grid, but is triangulated into two boundary triangles when the cubes become simplices
+        (3, "cube", (1, 1, 1), 6),
+        (3, "simplex", (1, 1, 1), 12),
+        (3, "cube", (2, 2, 2), 24),
+        (3, "simplex", (2, 2, 2), 48),
+    ],
+)
+def test_expected_num_boundary_intersections(dim, element, num_elements, expected):
+    spec = hs.GridSpec(
+        dim=dim,
+        element=element,
+        lower_left=(0.0,) * dim,
+        upper_right=(1.0,) * dim,
+        num_elements=num_elements,
+    )
+    assert spec.expected_num_boundary_intersections == expected
+    # a cube grid keeps one intersection per boundary cube-face; the simplex split only re-tiles them
+    if element == "cube":
+        assert spec.num_boundary_faces == expected
+
+
 def test_sampled_grid_bindings_filters_dims_elements_and_conformity(monkeypatch):
     # A stub mirroring the bindable ALUGrid build (#320 WP1): the 3d cube slice exposes both the
     # structured YASP grid and the nonconforming ALU hexahedral grid, while every simplex slice has


### PR DESCRIPTION
## Summary

Covers `dune/xt/grid/functors/boundary-detector.hh` (previously **0%**, ~35 lines) by driving the already-bound `BoundaryDetectorFunctor` from Python with a `Walker` over Hypothesis-generated grids — no new bindings, per the rules in #341.

Implements sub-issue #345 (part of the `dune/xt` Codecov-driven coverage work package #341).

## Approach

`python/xt/test/test_hypothesis_grid_boundary_detector.py` attaches a `BoundaryDetectorFunctor` to a `Walker`, walks a grid drawn from `grid_specs()`, and reads back `detector.result`. The detected boundary-intersection count is cross-checked against the grid's own geometry in several independent ways:

- **against the grid geometry** — an independent boundary count from `apply_on_each_intersection` + `intersection.boundary`;
- **against a closed form** — `GridSpec.expected_num_boundary_intersections`;
- **across boundary-info kinds** — `AllDirichlet` / `AllNeumann` / `AllReflecting` each tag exactly the boundary intersections with their own `BoundaryType`, so all three matched detectors must agree;
- **mismatch path** — a `(AllDirichletBoundaryInfo, NeumannBoundary())` pair must detect nothing, exercising the `compute_locally` branch that returns 0 on every intersection.

Together these drive `prepare` / `apply_local` / `compute_locally` (both branches) / `result` / `finalize` of the functor.

## Supporting change

`GridSpec` (in `python/xt/dune/xt/test/hypothesis_strategies.py`) gains two pure-Python geometry helpers used for the closed-form check, in the style of the existing `expected_num_elements` / `expected_num_vertices`:

- `num_boundary_faces` — codim-1 faces of the structured cube skeleton on the domain boundary;
- `expected_num_boundary_intersections` — the above for cube grids, and `SIMPLICES_PER_CUBE[dim-1] ×` that for simplex grids (a 3d boundary square splits into two triangles; 1d/2d boundary faces are unchanged).

A parametrized unit test for these helpers is added to `test_hypothesis_strategies.py` (runs without the compiled bindings).

## Testing

- `ruff check` and `ruff format --check` pass on all changed files.
- The new pure-Python geometry helper and its unit test were validated locally (1d/2d/3d, cube and simplex).
- The Hypothesis test skips cleanly on builds with no grid bindings; the functor assertions run in the compiled coverage build in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9hbKDhjKdcErhHsg5xUMK)_