### PR TITLE
test(la): assert MatrixInverter agrees with numpy.linalg.inv (#344)

### DIFF
--- a/python/xt/test/test_hypothesis_la_matrix_inverter.py
+++ b/python/xt/test/test_hypothesis_la_matrix_inverter.py
@@ -12,7 +12,9 @@
 
 Each `<Matrix>MatrixInverter` dune.xt.la binds (real and complex Common dense/sparse and Eigen
 dense, discovered via discover_matrix_inverter_types) is checked by the defining property of an
-inverse: A @ inv(A) == inv(A) @ A == I. The compiled dune/xt/test/la/matrixinverter_for_*.tpl tests
+inverse: A @ inv(A) == inv(A) @ A == I, and against numpy.linalg.inv as an independent reference
+(the two agree for a well-conditioned, full-rank system: even the "moore_penrose" pseudo-inverse
+coincides with the true inverse there). The compiled dune/xt/test/la/matrixinverter_for_*.tpl tests
 pin a few fixed matrices to a hand-computed expected inverse; hypothesis instead generates a fresh
 well-conditioned (strictly diagonally dominant, hence invertible by Levy-Desplanques) system every
 run and iterates the full MatrixInverterOptions::types() list, the same way the .tpl suite does.
@@ -95,6 +97,13 @@ def assert_is_inverse(a, inv, context):
     )
     assert inv @ a == pytest.approx(identity, rel=RTOL, abs=ATOL), (
         f"{context}: inv@A != I"
+    )
+    # Independent reference: for a well-conditioned, full-rank system the bound inverse must
+    # agree entrywise with numpy's LAPACK-backed inverse (true inverse == Moore-Penrose inverse
+    # here), so this catches a wrong-but-still-nearly-orthogonal result the A@inv==I check alone
+    # could miss.
+    assert inv == pytest.approx(np.linalg.inv(a), rel=RTOL, abs=ATOL), (
+        f"{context}: disagrees with numpy.linalg.inv"
     )
 
 


### PR DESCRIPTION
## Summary

Closes #344 (Hypothesis test for `MatrixInverter`).

While picking up #344 I found that its core deliverable — `python/xt/test/test_hypothesis_la_matrix_inverter.py` — already landed on `main` as part of the broader coverage-extension push in #333, and it already covers the sub-issue's 0% target: it iterates every `MatrixInverterOptions::types()` entry for each bound matrix class, so the `"moore_penrose"` type on `EigenDenseMatrix` (`dune/xt/la/matrix-inverter/eigen.hh:39`) drives `internal::compute_moore_penrose_inverse_using_eigen` — the otherwise 0%-covered `dune/xt/la/matrix-inverter/internal/eigen.hh` — and incidentally lifts the `internal/base.hh` / `fmatrix.hh` partials.

The one thing the existing test did **not** do is the second half of #344's stated property: *"assert `A·A⁻¹ ≈ I` **and agreement with `numpy.linalg.inv`**"*. This PR closes that gap.

## Changes

- `test_hypothesis_la_matrix_inverter.py`: in `assert_is_inverse`, add an entrywise comparison of the bound inverse against `numpy.linalg.inv(a)`. For the well-conditioned, strictly diagonally-dominant systems the suite generates, the true inverse and the Moore–Penrose pseudo-inverse coincide, so numpy's LAPACK-backed inverse is a valid independent reference for every inversion `type`. This catches a wrong-but-still-nearly-orthogonal result that the `A·A⁻¹ ≈ I` identity alone could miss.
- Updated the module docstring to note the numpy reference check.

## Testing

- `ruff check` and `ruff format --check` pass on the file.
- The runtime property test requires the compiled `dune.xt.la` bindings (with Eigen) and is exercised by the pytest suite in CI; the new assertion reuses the same `RTOL`/`ATOL` already validated by the existing `A·A⁻¹ ≈ I` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLbGPwF64KWHM2kg87rjj)_