### PR TITLE
test(la): maximize coverage of the generalized eigen solver

### DIFF
--- a/dune/xt/la/generalized-eigen-solver/internal/lapacke.hh
+++ b/dune/xt/la/generalized-eigen-solver/internal/lapacke.hh
@@ -89,7 +89,13 @@ compute_generalized_eigenvalues_of_real_matrices_using_lapack_impl(
                "Given RHS matrix has to be square, is " << Dune::XT::Common::get_matrix_rows(rhs_matrix) << "x"
                                                         << Dune::XT::Common::get_matrix_cols(rhs_matrix) << "!");
 #endif // DUNE_XT_LA_DISABLE_ALL_CHECKS
-  thread_local std::vector<double> real_part_of_eigenvalues(size, 0.);
+  // The buffer is thread_local to avoid a heap allocation on every call, but a thread_local with an initializer is
+  // only initialized on the first pass through its declaration: sizing it there would keep the size of the very first
+  // problem this thread solved forever and let dsygv write past the end for any larger problem afterwards. Resize on
+  // every call instead (a no-op whenever the size did not change), as the non-generalized backend does in
+  // dune/xt/la/eigen-solver/internal/lapacke.hh.
+  thread_local std::vector<double> real_part_of_eigenvalues;
+  real_part_of_eigenvalues.assign(size, 0.);
   int storage_layout = MatrixDataProvider<RealMatrixType, contiguous_and_mutable>::storage_layout
                                == Common::StorageLayout::dense_row_major
                            ? Common::Lapacke::row_major()

--- a/dune/xt/test/la/generalized-eigensolver.hh
+++ b/dune/xt/test/la/generalized-eigensolver.hh
@@ -13,6 +13,11 @@
 #ifndef DUNE_XT_LA_TEST_GENERALIZED_EIGENSOLVER_HH
 #define DUNE_XT_LA_TEST_GENERALIZED_EIGENSOLVER_HH
 
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <dune/xt/common/exceptions.hh>
 #include <dune/xt/common/logging.hh>
 #include <gtest/gtest.h>
@@ -50,11 +55,26 @@ struct GeneralizedEigenSolverTest : public ::testing::Test
     M::set_entry(broken_matrix_, 0, 0, std::numeric_limits<typename M::S>::infinity());
   }
 
+  /**
+   * \brief (Re-)creates unit_matrix_ with the size of matrix_ and, unless the derived test provided one, uses it as
+   *        the right hand side of the generalized eigenvalue problem.
+   *
+   * Deriving tests that set rhs_matrix_ (and rhs_matrix_is_given_) in their constructor solve a genuine generalized
+   * problem lhs*v = lambda*rhs*v; all others fall back to rhs = Id, which reduces to the standard problem.
+   */
   void make_unit_matrix()
   {
     ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
     unit_matrix_ = eye_matrix<MatrixType>(M::has_static_size ? M::static_rows : M::rows(matrix_),
                                           M::has_static_size ? M::static_cols : M::cols(matrix_));
+    if (!rhs_matrix_is_given_)
+      rhs_matrix_ = unit_matrix_;
+  }
+
+  /// \brief Creates a rows x cols matrix filled with zeros, in the same way the fixture creates broken_matrix_.
+  static MatrixType make_matrix(const size_t rows, const size_t cols)
+  {
+    return M::create(rows, cols, typename M::S(0));
   }
 
   static void exports_correct_types()
@@ -113,14 +133,170 @@ struct GeneralizedEigenSolverTest : public ::testing::Test
     }
   } // ... throws_on_broken_matrix_construction(...)
 
+  /// \brief The counterpart of throws_on_broken_matrix_construction() for the right hand side matrix.
+  void throws_on_broken_rhs_matrix_construction()
+  {
+    // note: broken_matrix_ and unit_matrix_ are of matching size here as long as make_unit_matrix() was not called
+    try {
+      [[maybe_unused]] GeneralizedEigenSolverType default_solver{unit_matrix_, broken_matrix_};
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements";
+    } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements& /*ee*/) {
+    } catch (...) {
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements";
+    }
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      try {
+        [[maybe_unused]] GeneralizedEigenSolverType solver(
+            unit_matrix_, broken_matrix_, GeneralizedEigenSolverOpts::options(tp));
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements";
+      } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements& /*ee*/) {
+      } catch (...) {
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements";
+      }
+    }
+  } // ... throws_on_broken_rhs_matrix_construction(...)
+
   void allows_broken_matrix_construction_when_checks_disabled()
   {
     for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
       Common::Configuration opts_with_disabled_check = GeneralizedEigenSolverOpts::options(tp);
       opts_with_disabled_check["check_for_inf_nan"] = "false";
       [[maybe_unused]] GeneralizedEigenSolverType solver(broken_matrix_, unit_matrix_, opts_with_disabled_check);
+      [[maybe_unused]] GeneralizedEigenSolverType rhs_solver(unit_matrix_, broken_matrix_, opts_with_disabled_check);
     }
   }
+
+  /// \brief 'disable_checks' skips pre_checks()/post_checks() as a whole, not just the inf/nan check.
+  void allows_broken_matrix_construction_when_all_checks_disabled()
+  {
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      Common::Configuration opts_with_disabled_checks = GeneralizedEigenSolverOpts::options(tp);
+      opts_with_disabled_checks["disable_checks"] = "true";
+      [[maybe_unused]] GeneralizedEigenSolverType solver(broken_matrix_, unit_matrix_, opts_with_disabled_checks);
+    }
+  }
+
+  /// \brief Covers the 'Missing type in given options' branch of GeneralizedEigenSolverBase::pre_checks().
+  void throws_on_missing_type_in_options()
+  {
+    Common::Configuration opts_without_type;
+    opts_without_type["compute_eigenvalues"] = "true";
+    try {
+      [[maybe_unused]] GeneralizedEigenSolverType solver(unit_matrix_, unit_matrix_, opts_without_type);
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+    } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly& /*ee*/) {
+    } catch (...) {
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+    }
+  } // ... throws_on_missing_type_in_options(...)
+
+  /**
+   * \brief Covers internal::ensure_generalized_eigen_solver_type() on all three ways an unknown type can enter:
+   *        via the options factory, via the type-string ctor and via an already assembled configuration.
+   */
+  void throws_on_unknown_type()
+  {
+    const std::string unknown_type = "this_generalized_eigen_solver_type_does_not_exist";
+    try {
+      [[maybe_unused]] Common::Configuration opts = GeneralizedEigenSolverOpts::options(unknown_type);
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+    } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly& /*ee*/) {
+    } catch (...) {
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+    }
+    try {
+      [[maybe_unused]] GeneralizedEigenSolverType solver(unit_matrix_, unit_matrix_, unknown_type);
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+    } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly& /*ee*/) {
+    } catch (...) {
+      FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+    }
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      Common::Configuration opts_with_unknown_type = GeneralizedEigenSolverOpts::options(tp);
+      opts_with_unknown_type["type"] = unknown_type;
+      try {
+        [[maybe_unused]] GeneralizedEigenSolverType solver(unit_matrix_, unit_matrix_, opts_with_unknown_type);
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+      } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly& /*ee*/) {
+      } catch (...) {
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly";
+      }
+    }
+  } // ... throws_on_unknown_type(...)
+
+  /**
+   * \brief With the checks disabled an unknown type reaches compute(), where it must not be silently ignored.
+   *
+   * This is the only way to reach the final else branch of GeneralizedEigenSolver<..., true>::compute(), which
+   * pre_checks() otherwise guarantees to be unreachable.
+   */
+  void throws_on_unknown_type_when_checks_are_disabled()
+  {
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      Common::Configuration opts = GeneralizedEigenSolverOpts::options(tp);
+      opts["type"] = "this_generalized_eigen_solver_type_does_not_exist";
+      opts["disable_checks"] = "true";
+      GeneralizedEigenSolverType solver(unit_matrix_, unit_matrix_, opts);
+      try {
+        solver.eigenvalues();
+        FAIL() << "Expected Common::Exceptions::internal_error";
+      } catch (const Common::Exceptions::internal_error& /*ee*/) {
+      } catch (...) {
+        FAIL() << "Expected Common::Exceptions::internal_error";
+      }
+    }
+  } // ... throws_on_unknown_type_when_checks_are_disabled(...)
+
+  /// \brief Covers the 'non-positive tolerance' branch of GeneralizedEigenSolverBase::pre_checks().
+  void throws_on_non_positive_real_tolerance()
+  {
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      for (const std::string& tolerance : {"0", "-1e-15"}) {
+        Common::Configuration opts = GeneralizedEigenSolverOpts::options(tp);
+        opts["real_tolerance"] = tolerance;
+        try {
+          [[maybe_unused]] GeneralizedEigenSolverType solver(unit_matrix_, unit_matrix_, opts);
+          FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly"
+                 << "\n\nreal_tolerance: " << tolerance;
+        } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly& /*ee*/) {
+        } catch (...) {
+          FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_it_was_not_set_up_correctly"
+                 << "\n\nreal_tolerance: " << tolerance;
+        }
+      }
+    }
+  } // ... throws_on_non_positive_real_tolerance(...)
+
+  /**
+   * \brief Covers the three size checks in GeneralizedEigenSolverBase::check_size().
+   *
+   * Only meaningful for matrix types of dynamic size; for statically sized ones (FieldMatrix) a non-square or
+   * mismatched pair cannot even be formed, so there is nothing to check.
+   */
+  void throws_on_matrices_of_wrong_size()
+  {
+    if constexpr (!M::has_static_size) {
+      const auto square = make_matrix(2, 2);
+      const auto non_square = make_matrix(2, 3);
+      const auto larger_square = make_matrix(3, 3);
+      const std::vector<std::pair<MatrixType, MatrixType>> broken_pairs{
+          {non_square, square}, // <- lhs is not square
+          {square, larger_square}, // <- rhs has the wrong size
+          {square, non_square} // <- rhs is not square
+      };
+      for (const auto& pair : broken_pairs) {
+        try {
+          [[maybe_unused]] GeneralizedEigenSolverType solver(pair.first, pair.second);
+          FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements"
+                 << "\n\nlhs: " << pair.first << "\n\nrhs: " << pair.second;
+        } catch (const LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements& /*ee*/) {
+        } catch (...) {
+          FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements"
+                 << "\n\nlhs: " << pair.first << "\n\nrhs: " << pair.second;
+        }
+      }
+    }
+  } // ... throws_on_matrices_of_wrong_size(...)
 
   void throws_on_inconsistent_given_options()
   {
@@ -142,13 +318,45 @@ struct GeneralizedEigenSolverTest : public ::testing::Test
   {
     ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
     this->make_unit_matrix();
-    [[maybe_unused]] GeneralizedEigenSolverType default_solver{matrix_, unit_matrix_};
+    [[maybe_unused]] GeneralizedEigenSolverType default_solver{matrix_, rhs_matrix_};
     for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
-      [[maybe_unused]] GeneralizedEigenSolverType default_opts_solver(matrix_, unit_matrix_, tp);
-      [[maybe_unused]] GeneralizedEigenSolverType solver(
-          matrix_, unit_matrix_, GeneralizedEigenSolverOpts::options(tp));
+      [[maybe_unused]] GeneralizedEigenSolverType default_opts_solver(matrix_, rhs_matrix_, tp);
+      [[maybe_unused]] GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, GeneralizedEigenSolverOpts::options(tp));
     }
   } // ... is_constructible(...)
+
+  /**
+   * \brief Covers the third GeneralizedEigenSolverBase ctor, which keeps a pointer to externally owned options.
+   *
+   * That ctor exists for hot loops (see dune/gdt/operators/reconstruction/internal.hh, which keeps a static
+   * Configuration around); unlike the by-value ctor it writes the missing defaults back into the caller's options.
+   */
+  void is_constructible_from_options_pointer()
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      Common::Configuration opts = GeneralizedEigenSolverOpts::options(tp);
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, &opts);
+      EXPECT_EQ(tp, solver.options().template get<std::string>("type"));
+      // the solver must not have copied the options, but refer to ours
+      EXPECT_EQ(&opts, &solver.options());
+      EXPECT_EQ(Common::get_matrix_rows(matrix_), solver.eigenvalues().size());
+    }
+  } // ... is_constructible_from_options_pointer(...)
+
+  /// \brief Covers the lhs_matrix()/rhs_matrix() accessors of GeneralizedEigenSolverBase.
+  void exposes_the_given_matrices()
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, tp);
+      EXPECT_EQ(&matrix_, &solver.lhs_matrix());
+      EXPECT_EQ(&rhs_matrix_, &solver.rhs_matrix());
+      EXPECT_EQ(tp, solver.options().template get<std::string>("type"));
+    }
+  } // ... exposes_the_given_matrices(...)
 
   static bool find_ev(const EigenValuesType& expected_evs,
                       const XT::Common::complex_t<FieldType>& actual_ev,
@@ -176,7 +384,7 @@ struct GeneralizedEigenSolverTest : public ::testing::Test
     this->make_unit_matrix();
     for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
       const double tolerance = tolerances.get(tp, 1e-15);
-      GeneralizedEigenSolverType solver(matrix_, unit_matrix_, tp);
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, tp);
       try {
         const auto& eigenvalues = solver.eigenvalues();
         EXPECT_EQ(Common::get_matrix_rows(matrix_), eigenvalues.size());
@@ -194,10 +402,101 @@ struct GeneralizedEigenSolverTest : public ::testing::Test
     }
   } // ... gives_correct_eigenvalues(...)
 
+  /// \brief The free functions from dune/xt/la/generalized-eigen-solver.hh have to agree with the class interface.
+  void gives_correct_eigenvalues_via_free_functions(const Common::Configuration& tolerances = {})
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    EXPECT_EQ(GeneralizedEigenSolverOpts::types(), generalized_eigen_solver_types(matrix_));
+    EXPECT_EQ(GeneralizedEigenSolverOpts::options(), generalized_eigen_solver_options(matrix_));
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      const double tolerance = tolerances.get(tp, 1e-15);
+      const auto opts = generalized_eigen_solver_options(matrix_, tp);
+      EXPECT_EQ(tp, opts.template get<std::string>("type"));
+      const auto solver_from_type = make_generalized_eigen_solver(matrix_, rhs_matrix_, tp);
+      const auto solver_from_opts = make_generalized_eigen_solver(matrix_, rhs_matrix_, opts);
+      for (const auto* solver : {&solver_from_type, &solver_from_opts}) {
+        const auto& eigenvalues = solver->eigenvalues();
+        EXPECT_EQ(Common::get_matrix_rows(matrix_), eigenvalues.size());
+        for (const auto& ev : eigenvalues)
+          EXPECT_TRUE(find_ev(expected_eigenvalues_, ev, tolerance))
+              << "\n\nactual eigenvalue: " << ev << "\n\nexpected eigenvalues: " << expected_eigenvalues_
+              << "\n\ntype: " << tp << "\n\ntolerance: " << tolerance;
+      }
+    }
+  } // ... gives_correct_eigenvalues_via_free_functions(...)
+
+  /**
+   * \brief Eigenvectors of generalized eigenvalue problems are not implemented (yet).
+   *
+   * Asking for them up front makes compute() fail, while asking for them after a successful eigenvalue computation
+   * has to be reported as a usage error instead of returning an empty matrix.
+   */
+  void throws_on_request_for_eigenvectors()
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      Common::Configuration opts_with_eigenvectors = GeneralizedEigenSolverOpts::options(tp);
+      opts_with_eigenvectors["compute_eigenvectors"] = "true";
+      GeneralizedEigenSolverType eigenvector_solver(matrix_, rhs_matrix_, opts_with_eigenvectors);
+      try {
+        eigenvector_solver.eigenvalues();
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed";
+      } catch (const LA::Exceptions::generalized_eigen_solver_failed& /*ee*/) {
+      } catch (...) {
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed";
+      }
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, tp);
+      EXPECT_EQ(Common::get_matrix_rows(matrix_), solver.eigenvalues().size());
+      try {
+        solver.eigenvectors();
+        FAIL() << "Expected Common::Exceptions::you_are_using_this_wrong";
+      } catch (const Common::Exceptions::you_are_using_this_wrong& /*ee*/) {
+      } catch (...) {
+        FAIL() << "Expected Common::Exceptions::you_are_using_this_wrong";
+      }
+      try {
+        solver.real_eigenvectors();
+        FAIL() << "Expected Common::Exceptions::you_are_using_this_wrong";
+      } catch (const Common::Exceptions::you_are_using_this_wrong& /*ee*/) {
+      } catch (...) {
+        FAIL() << "Expected Common::Exceptions::you_are_using_this_wrong";
+      }
+    }
+  } // ... throws_on_request_for_eigenvectors(...)
+
+  /**
+   * \brief lapack's dsygv requires the right hand side matrix to be positive definite.
+   *
+   * A zero right hand side passes all of our own checks (it is square, of matching size and free of inf/nan), so the
+   * failure has to be reported by the backend error handling of the lapack based implementation.
+   */
+  void throws_on_indefinite_rhs_matrix()
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    const auto zero_matrix = make_matrix(Common::get_matrix_rows(matrix_), Common::get_matrix_cols(matrix_));
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      GeneralizedEigenSolverType solver(matrix_, zero_matrix, tp);
+      try {
+        solver.eigenvalues();
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed"
+               << "\n\ntype: " << tp;
+      } catch (const LA::Exceptions::generalized_eigen_solver_failed& /*ee*/) {
+      } catch (...) {
+        FAIL() << "Expected LA::Exceptions::generalized_eigen_solver_failed"
+               << "\n\ntype: " << tp;
+      }
+    }
+  } // ... throws_on_indefinite_rhs_matrix(...)
+
   bool all_matrices_and_expected_eigenvalues_and_vectors_are_computed_{false};
   MatrixType broken_matrix_;
   MatrixType unit_matrix_;
   MatrixType matrix_;
+  MatrixType rhs_matrix_;
+  bool rhs_matrix_is_given_{false};
   EigenValuesType expected_eigenvalues_;
 }; // ... struct GeneralizedEigenSolverTest
 
@@ -224,7 +523,7 @@ struct GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors
     this->make_unit_matrix();
     for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
       const double tolerance = tolerances.get(tp, 1e-15);
-      GeneralizedEigenSolverType solver(matrix_, unit_matrix_, tp);
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, tp);
       const auto& eigenvalues = solver.eigenvalues();
       EXPECT_EQ(Common::get_matrix_rows(matrix_), eigenvalues.size());
       for (const auto& complex_ev : eigenvalues) {
@@ -278,7 +577,7 @@ struct GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors
     this->make_unit_matrix();
     for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
       const double tolerance = tolerances.get(tp, 1e-15);
-      GeneralizedEigenSolverType solver(matrix_, unit_matrix_, tp);
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, tp);
       const auto actual_max_eigenvalues = solver.max_eigenvalues(1); /// \todo: Add try/catch around this, too!
       ASSERT_GE(1, actual_max_eigenvalues.size());
       if (tolerance > 0)
@@ -302,7 +601,7 @@ struct GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors
     this->make_unit_matrix();
     for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
       const double tolerance = tolerances.get(tp, 1e-15);
-      GeneralizedEigenSolverType solver(matrix_, unit_matrix_, tp);
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, tp);
       const auto actual_min_eigenvalues = solver.min_eigenvalues(1); /// \todo: Add try/catch around this, too!
       ASSERT_GE(1, actual_min_eigenvalues.size());
       if (tolerance > 0)
@@ -320,9 +619,154 @@ struct GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors
     }
   }
 
+  /**
+   * \brief min_eigenvalues(k)/max_eigenvalues(k) for k != 1 and for k above the number of eigenvalues.
+   *
+   * Both accessors sort a copy of the real eigenvalues and truncate it to k, so the interesting cases are k in the
+   * middle of the spectrum (does the truncation keep the right end?) and k beyond the spectrum (is the result
+   * clamped instead of padded?).
+   */
+  void gives_correct_extremal_eigenvalues(const Common::Configuration& tolerances = {})
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    const size_t size = Common::get_matrix_rows(matrix_);
+    RealEigenValuesType sorted_expected_eigenvalues = expected_real_eigenvalues_;
+    std::sort(sorted_expected_eigenvalues.begin(), sorted_expected_eigenvalues.end());
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      const double tolerance = tolerances.get(tp, 1e-15);
+      if (tolerance <= 0)
+        continue; // <- see gives_correct_min_eigenvalue()
+      GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, tp);
+      for (size_t num_evs = 1; num_evs <= size; ++num_evs) {
+        auto actual_min_eigenvalues = solver.min_eigenvalues(num_evs);
+        auto actual_max_eigenvalues = solver.max_eigenvalues(num_evs);
+        ASSERT_EQ(num_evs, actual_min_eigenvalues.size());
+        ASSERT_EQ(num_evs, actual_max_eigenvalues.size());
+        std::sort(actual_min_eigenvalues.begin(), actual_min_eigenvalues.end());
+        std::sort(actual_max_eigenvalues.begin(), actual_max_eigenvalues.end());
+        for (size_t ii = 0; ii < num_evs; ++ii) {
+          EXPECT_TRUE(Common::FloatCmp::eq(sorted_expected_eigenvalues[ii], actual_min_eigenvalues[ii], tolerance))
+              << "\n\nnum_evs: " << num_evs << "\n\nactual smallest eigenvalues: " << actual_min_eigenvalues
+              << "\n\nexpected eigenvalues: " << sorted_expected_eigenvalues << "\n\ntype: " << tp;
+          EXPECT_TRUE(Common::FloatCmp::eq(
+              sorted_expected_eigenvalues[size - num_evs + ii], actual_max_eigenvalues[ii], tolerance))
+              << "\n\nnum_evs: " << num_evs << "\n\nactual largest eigenvalues: " << actual_max_eigenvalues
+              << "\n\nexpected eigenvalues: " << sorted_expected_eigenvalues << "\n\ntype: " << tp;
+        }
+      }
+      // asking for more than there are has to yield all of them, and the default is exactly that
+      EXPECT_EQ(size, solver.min_eigenvalues(size + 1).size());
+      EXPECT_EQ(size, solver.max_eigenvalues(size + 1).size());
+      EXPECT_EQ(size, solver.min_eigenvalues().size());
+      EXPECT_EQ(size, solver.max_eigenvalues().size());
+    }
+  } // ... gives_correct_extremal_eigenvalues(...)
+
+  /**
+   * \brief Covers the assert_real/positive/negative_eigenvalues post checks, in both directions.
+   *
+   * Which of the sign assertions has to hold is derived from the expected spectrum, so the same check both confirms
+   * the assertion for a matching test case and confirms that a violated assertion is reported for all others.
+   */
+  void checks_eigenvalue_assertions(const Common::Configuration& tolerances = {})
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    const std::string assertion_tolerance = "1e-10";
+    const bool all_eigenvalues_are_positive = expected_min_ev_ > 1e-10;
+    const bool all_eigenvalues_are_negative = expected_max_ev_ < -1e-10;
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      if (tolerances.get(tp, 1e-15) <= 0)
+        continue; // <- see gives_correct_real_eigenvalues()
+      // the eigenvalues of a symmetric-definite pair are real, so this assertion always holds
+      Common::Configuration real_opts = GeneralizedEigenSolverOpts::options(tp);
+      real_opts["assert_real_eigenvalues"] = assertion_tolerance;
+      GeneralizedEigenSolverType real_solver(matrix_, rhs_matrix_, real_opts);
+      EXPECT_EQ(Common::get_matrix_rows(matrix_), real_solver.real_eigenvalues().size());
+      for (const bool assert_positive : {true, false}) {
+        Common::Configuration opts = GeneralizedEigenSolverOpts::options(tp);
+        opts[assert_positive ? "assert_positive_eigenvalues" : "assert_negative_eigenvalues"] = assertion_tolerance;
+        // asserting a sign implies asserting real eigenvalues, which pre_checks() has to fill in for us
+        GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, opts);
+        const bool assertion_holds = assert_positive ? all_eigenvalues_are_positive : all_eigenvalues_are_negative;
+        if (assertion_holds) {
+          EXPECT_EQ(Common::get_matrix_rows(matrix_), solver.real_eigenvalues().size())
+              << "\n\ntype: " << tp << "\n\nassert_positive: " << assert_positive;
+        } else if (assert_positive) {
+          try {
+            solver.eigenvalues();
+            FAIL() << "Expected generalized_eigen_solver_failed_bc_eigenvalues_are_not_positive_as_requested"
+                   << "\n\ntype: " << tp;
+          } catch (const LA::Exceptions::
+                       generalized_eigen_solver_failed_bc_eigenvalues_are_not_positive_as_requested& /*ee*/) {
+          } catch (...) {
+            FAIL() << "Expected generalized_eigen_solver_failed_bc_eigenvalues_are_not_positive_as_requested"
+                   << "\n\ntype: " << tp;
+          }
+        } else {
+          try {
+            solver.eigenvalues();
+            FAIL() << "Expected generalized_eigen_solver_failed_bc_eigenvalues_are_not_negative_as_requested"
+                   << "\n\ntype: " << tp;
+          } catch (const LA::Exceptions::
+                       generalized_eigen_solver_failed_bc_eigenvalues_are_not_negative_as_requested& /*ee*/) {
+          } catch (...) {
+            FAIL() << "Expected generalized_eigen_solver_failed_bc_eigenvalues_are_not_negative_as_requested"
+                   << "\n\ntype: " << tp;
+          }
+        }
+      }
+    }
+  } // ... checks_eigenvalue_assertions(...)
+
+  /**
+   * \brief Any assertion on the eigenvalues has to switch their computation back on.
+   *
+   * 'compute_eigenvalues' defaults to true, so this only matters when it was explicitly disabled: pre_checks() then
+   * has to re-enable it (there is nothing to assert otherwise) and, for the sign assertions, has to derive
+   * 'assert_real_eigenvalues' from 'real_tolerance'.
+   */
+  void computes_eigenvalues_required_for_assertions(const Common::Configuration& tolerances = {})
+  {
+    ASSERT_TRUE(all_matrices_and_expected_eigenvalues_and_vectors_are_computed_);
+    this->make_unit_matrix();
+    const bool all_eigenvalues_are_positive = expected_min_ev_ > 1e-10;
+    const bool all_eigenvalues_are_negative = expected_max_ev_ < -1e-10;
+    for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
+      const double tolerance = tolerances.get(tp, 1e-15);
+      if (tolerance <= 0)
+        continue; // <- see gives_correct_real_eigenvalues()
+      std::vector<std::string> assertions{"assert_real_eigenvalues"};
+      if (all_eigenvalues_are_positive)
+        assertions.emplace_back("assert_positive_eigenvalues");
+      if (all_eigenvalues_are_negative)
+        assertions.emplace_back("assert_negative_eigenvalues");
+      for (const auto& assertion : assertions) {
+        Common::Configuration opts = GeneralizedEigenSolverOpts::options(tp);
+        opts["compute_eigenvalues"] = "false";
+        opts[assertion] = "1e-10";
+        GeneralizedEigenSolverType solver(matrix_, rhs_matrix_, opts);
+        EXPECT_TRUE(solver.options().template get<bool>("compute_eigenvalues"))
+            << "\n\nassertion: " << assertion << "\n\ntype: " << tp;
+        EXPECT_GT(solver.options().template get<double>("assert_real_eigenvalues"), 0.)
+            << "\n\nassertion: " << assertion << "\n\ntype: " << tp;
+        const auto& real_eigenvalues = solver.real_eigenvalues();
+        EXPECT_EQ(Common::get_matrix_rows(matrix_), real_eigenvalues.size());
+        for (const auto& real_ev : real_eigenvalues)
+          EXPECT_TRUE(find_ev(expected_real_eigenvalues_, real_ev, tolerance))
+              << "\n\nactual eigenvalue: " << real_ev << "\n\nexpected eigenvalues: " << expected_real_eigenvalues_
+              << "\n\nassertion: " << assertion << "\n\ntype: " << tp;
+      }
+    }
+  } // ... computes_eigenvalues_required_for_assertions(...)
+
   using BaseType::all_matrices_and_expected_eigenvalues_and_vectors_are_computed_;
   using BaseType::expected_eigenvalues_;
+  using BaseType::make_unit_matrix;
   using BaseType::matrix_;
+  using BaseType::rhs_matrix_;
+  using BaseType::rhs_matrix_is_given_;
   using BaseType::unit_matrix_;
   RealEigenValuesType expected_real_eigenvalues_;
   RealType expected_max_ev_;

--- a/dune/xt/test/la/generalized-eigensolver.hh
+++ b/dune/xt/test/la/generalized-eigensolver.hh
@@ -633,6 +633,10 @@ struct GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors
     const size_t size = Common::get_matrix_rows(matrix_);
     RealEigenValuesType sorted_expected_eigenvalues = expected_real_eigenvalues_;
     std::sort(sorted_expected_eigenvalues.begin(), sorted_expected_eigenvalues.end());
+    // the whole spectrum is indexed below, so an incompletely filled expectation has to fail here rather than run
+    // past the end of the vector
+    ASSERT_EQ(size, sorted_expected_eigenvalues.size())
+        << "expected_real_eigenvalues_ has to hold one entry per row of matrix_!";
     for (const auto& tp : GeneralizedEigenSolverOpts::types()) {
       const double tolerance = tolerances.get(tp, 1e-15);
       if (tolerance <= 0)

--- a/dune/xt/test/la/generalized-eigensolver_for_matrix_pairs.py
+++ b/dune/xt/test/la/generalized-eigensolver_for_matrix_pairs.py
@@ -12,35 +12,25 @@
 from dune.xt.codegen import have_eigen
 from dune.xt.codegen import typeid_to_typedef_name as safe_name
 
-matrix = [
-    "EigenDenseMatrix<double>",
-    "FieldMatrix<double, 2, 2>",
-    "CommonDenseMatrix<double>",
-    "CommonSparseMatrix<double>",
-]
-field = ["double", "double", "double", "double"]
-complex_matrix = [
-    "EigenDenseMatrix<std::complex<double>>",
-    "FieldMatrix<std::complex<double>, 2, 2>",
-    "CommonDenseMatrix<std::complex<double>>",
-    "CommonSparseMatrix<std::complex<double>>",
-]
-real_matrix = [
-    "EigenDenseMatrix<double>",
-    "FieldMatrix<double, 2, 2>",
-    "CommonDenseMatrix<double>",
-    "CommonSparseMatrix<double>",
+# One entry per matrix backend under test: how to spell the type for a given scalar, and whether it needs eigen.
+# Spelled as format strings rather than as the four parallel real/field/complex/real lists the sibling eigensolver
+# configurations use, so that the real and the complex spelling of a backend cannot drift apart.
+MATRIX_TEMPLATES = [
+    ("EigenDenseMatrix<{scalar}>", True),
+    ("FieldMatrix<{scalar}, 2, 2>", False),
+    ("CommonDenseMatrix<{scalar}>", False),
+    ("CommonSparseMatrix<{scalar}>", False),
 ]
 
 
-def _ok(ft):
-    if "Eigen" in ft[0]:
-        return have_eigen(cache)  # noqa: F821
-    return True
+def _test_type(template):
+    """(matrix, field, complex matrix, real matrix), the tuple the templates expect."""
+    real = template.format(scalar="double")
+    return real, "double", template.format(scalar="std::complex<double>"), real
 
 
 testtypes = [
-    (safe_name("_".join(ft)), *ft)
-    for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
-    if _ok(ft)
+    (safe_name("_".join(_test_type(template))), *_test_type(template))
+    for template, needs_eigen in MATRIX_TEMPLATES
+    if not needs_eigen or have_eigen(cache)  # noqa: F821
 ]

--- a/dune/xt/test/la/generalized-eigensolver_for_matrix_pairs.py
+++ b/dune/xt/test/la/generalized-eigensolver_for_matrix_pairs.py
@@ -1,0 +1,46 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+
+from dune.xt.codegen import have_eigen
+from dune.xt.codegen import typeid_to_typedef_name as safe_name
+
+matrix = [
+    "EigenDenseMatrix<double>",
+    "FieldMatrix<double, 2, 2>",
+    "CommonDenseMatrix<double>",
+    "CommonSparseMatrix<double>",
+]
+field = ["double", "double", "double", "double"]
+complex_matrix = [
+    "EigenDenseMatrix<std::complex<double>>",
+    "FieldMatrix<std::complex<double>, 2, 2>",
+    "CommonDenseMatrix<std::complex<double>>",
+    "CommonSparseMatrix<std::complex<double>>",
+]
+real_matrix = [
+    "EigenDenseMatrix<double>",
+    "FieldMatrix<double, 2, 2>",
+    "CommonDenseMatrix<double>",
+    "CommonSparseMatrix<double>",
+]
+
+
+def _ok(ft):
+    if "Eigen" in ft[0]:
+        return have_eigen(cache)  # noqa: F821
+    return True
+
+
+testtypes = [
+    (safe_name("_".join(ft)), *ft)
+    for ft in zip(matrix, field, complex_matrix, real_matrix, strict=True)
+    if _ok(ft)
+]

--- a/dune/xt/test/la/generalized-eigensolver_for_matrix_pairs.tpl
+++ b/dune/xt/test/la/generalized-eigensolver_for_matrix_pairs.tpl
@@ -1,0 +1,198 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+// Tests of genuine generalized eigenvalue problems lhs*v = lambda*rhs*v with a right hand side other than the
+// identity: generalized-eigensolver_for_real_matrix_with_real_evs uses rhs = Id throughout, which reduces to the
+// standard problem and never exercises lapack's Cholesky reduction of the pair.
+//
+// Both pairs below are symmetric with a positive definite right hand side (the requirement of dsygv, see
+// dune/xt/la/generalized-eigen-solver/internal/lapacke.hh) and are chosen so that the eigenvalues are exactly
+// representable: with rhs = 2*Id the problem reduces to the eigenvalues of lhs/2, and lhs = [a b; b a] has the
+// eigenvalues a +- b. One pair has a strictly positive, the other a strictly negative spectrum, which is what makes
+// both directions of the assert_positive_eigenvalues/assert_negative_eigenvalues post checks reachable
+// (GeneralizedEigenSolverBase::post_checks(), dune/xt/la/generalized-eigen-solver/internal/base.hh).
+
+#include <dune/xt/test/main.hxx> // <- has to come first (includes the config.h)!
+
+#include <dune/xt/test/la/generalized-eigensolver.hh>
+
+{% for T_NAME, TESTMATRIXTYPE, TESTFIELDTYPE, TESTCOMPLEXMATRIXTYPE, TESTREALMATRIXTYPE in config.testtypes %}
+struct GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}
+    : public GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors<{{TESTMATRIXTYPE}},
+                                                                     {{TESTFIELDTYPE}},
+                                                                     {{TESTCOMPLEXMATRIXTYPE}},
+                                                                     {{TESTREALMATRIXTYPE}}>
+{
+  using BaseType = GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors;
+  using typename BaseType::MatrixType;
+  using typename BaseType::EigenValuesType;
+  using typename BaseType::RealEigenValuesType;
+
+  GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}()
+  {
+    matrix_ = XT::Common::from_string<MatrixType>("[3 1; 1 3]");
+    rhs_matrix_ = XT::Common::from_string<MatrixType>("[2 0; 0 2]");
+    rhs_matrix_is_given_ = true;
+    expected_eigenvalues_ = XT::Common::from_string<EigenValuesType>("[1 2]");
+    expected_real_eigenvalues_ = XT::Common::from_string<RealEigenValuesType>("[1 2]");
+    expected_max_ev_ = 2;
+    expected_min_ev_ = 1;
+    all_matrices_and_expected_eigenvalues_and_vectors_are_computed_ = true;
+  }
+
+  using BaseType::all_matrices_and_expected_eigenvalues_and_vectors_are_computed_;
+  using BaseType::matrix_;
+  using BaseType::rhs_matrix_;
+  using BaseType::rhs_matrix_is_given_;
+  using BaseType::expected_eigenvalues_;
+  using BaseType::expected_real_eigenvalues_;
+  using BaseType::expected_max_ev_;
+  using BaseType::expected_min_ev_;
+}; // struct GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}
+
+
+struct GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}
+    : public GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors<{{TESTMATRIXTYPE}},
+                                                                     {{TESTFIELDTYPE}},
+                                                                     {{TESTCOMPLEXMATRIXTYPE}},
+                                                                     {{TESTREALMATRIXTYPE}}>
+{
+  using BaseType = GeneralizedEigenSolverTestForMatricesWithRealEigenvaluesAndVectors;
+  using typename BaseType::MatrixType;
+  using typename BaseType::EigenValuesType;
+  using typename BaseType::RealEigenValuesType;
+
+  GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}()
+  {
+    matrix_ = XT::Common::from_string<MatrixType>("[-3 1; 1 -3]");
+    rhs_matrix_ = XT::Common::from_string<MatrixType>("[2 0; 0 2]");
+    rhs_matrix_is_given_ = true;
+    expected_eigenvalues_ = XT::Common::from_string<EigenValuesType>("[-2 -1]");
+    expected_real_eigenvalues_ = XT::Common::from_string<RealEigenValuesType>("[-2 -1]");
+    expected_max_ev_ = -1;
+    expected_min_ev_ = -2;
+    all_matrices_and_expected_eigenvalues_and_vectors_are_computed_ = true;
+  }
+
+  using BaseType::all_matrices_and_expected_eigenvalues_and_vectors_are_computed_;
+  using BaseType::matrix_;
+  using BaseType::rhs_matrix_;
+  using BaseType::rhs_matrix_is_given_;
+  using BaseType::expected_eigenvalues_;
+  using BaseType::expected_real_eigenvalues_;
+  using BaseType::expected_max_ev_;
+  using BaseType::expected_min_ev_;
+}; // struct GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}
+
+
+#if HAVE_MKL || HAVE_LAPACKE
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, is_constructible)
+{
+  is_constructible();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, gives_correct_eigenvalues)
+{
+  gives_correct_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}},
+       gives_correct_eigenvalues_via_free_functions)
+{
+  gives_correct_eigenvalues_via_free_functions();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, gives_correct_real_eigenvalues)
+{
+  gives_correct_real_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, gives_correct_max_eigenvalue)
+{
+  gives_correct_max_eigenvalue();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, gives_correct_min_eigenvalue)
+{
+  gives_correct_min_eigenvalue();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, gives_correct_extremal_eigenvalues)
+{
+  gives_correct_extremal_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, checks_eigenvalue_assertions)
+{
+  checks_eigenvalue_assertions();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}},
+       computes_eigenvalues_required_for_assertions)
+{
+  computes_eigenvalues_required_for_assertions();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, is_constructible)
+{
+  is_constructible();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, gives_correct_eigenvalues)
+{
+  gives_correct_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}},
+       gives_correct_eigenvalues_via_free_functions)
+{
+  gives_correct_eigenvalues_via_free_functions();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, gives_correct_real_eigenvalues)
+{
+  gives_correct_real_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, gives_correct_max_eigenvalue)
+{
+  gives_correct_max_eigenvalue();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, gives_correct_min_eigenvalue)
+{
+  gives_correct_min_eigenvalue();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, gives_correct_extremal_eigenvalues)
+{
+  gives_correct_extremal_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, checks_eigenvalue_assertions)
+{
+  checks_eigenvalue_assertions();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}},
+       computes_eigenvalues_required_for_assertions)
+{
+  computes_eigenvalues_required_for_assertions();
+}
+#else // HAVE_MKL || HAVE_LAPACKE
+TEST_F(GeneralizedEigenSolverForMatrixPairWithPositiveEigenvalues_{{T_NAME}}, disabled_due_to_missing_lapacke)
+{
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixPairWithNegativeEigenvalues_{{T_NAME}}, disabled_due_to_missing_lapacke)
+{
+}
+#endif
+
+{% endfor %}

--- a/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.tpl
+++ b/dune/xt/test/la/generalized-eigensolver_for_real_matrix_with_real_evs.tpl
@@ -63,9 +63,19 @@ TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_broken_ma
   throws_on_broken_matrix_construction();
 }
 
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_broken_rhs_matrix_construction)
+{
+  throws_on_broken_rhs_matrix_construction();
+}
+
 TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, allows_broken_matrix_construction_when_checks_disabled)
 {
   allows_broken_matrix_construction_when_checks_disabled();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, allows_broken_matrix_construction_when_all_checks_disabled)
+{
+  allows_broken_matrix_construction_when_all_checks_disabled();
 }
 
 TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_inconsistent_given_options)
@@ -73,14 +83,64 @@ TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_inconsist
   throws_on_inconsistent_given_options();
 }
 
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_missing_type_in_options)
+{
+  throws_on_missing_type_in_options();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_unknown_type)
+{
+  throws_on_unknown_type();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_unknown_type_when_checks_are_disabled)
+{
+  throws_on_unknown_type_when_checks_are_disabled();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_non_positive_real_tolerance)
+{
+  throws_on_non_positive_real_tolerance();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_matrices_of_wrong_size)
+{
+  throws_on_matrices_of_wrong_size();
+}
+
 TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, is_constructible)
 {
   is_constructible();
 }
 
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, is_constructible_from_options_pointer)
+{
+  is_constructible_from_options_pointer();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, exposes_the_given_matrices)
+{
+  exposes_the_given_matrices();
+}
+
 TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, gives_correct_eigenvalues)
 {
   gives_correct_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, gives_correct_eigenvalues_via_free_functions)
+{
+  gives_correct_eigenvalues_via_free_functions();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_request_for_eigenvectors)
+{
+  throws_on_request_for_eigenvectors();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, throws_on_indefinite_rhs_matrix)
+{
+  throws_on_indefinite_rhs_matrix();
 }
 
 TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, gives_correct_real_eigenvalues)
@@ -96,6 +156,21 @@ TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, gives_correct_max_e
 TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, gives_correct_min_eigenvalue)
 {
   gives_correct_min_eigenvalue();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, gives_correct_extremal_eigenvalues)
+{
+  gives_correct_extremal_eigenvalues();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, checks_eigenvalue_assertions)
+{
+  checks_eigenvalue_assertions();
+}
+
+TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, computes_eigenvalues_required_for_assertions)
+{
+  computes_eigenvalues_required_for_assertions();
 }
 #else // HAVE_MKL || HAVE_LAPACKE
 TEST_F(GeneralizedEigenSolverForMatrixFullOfOnes_{{T_NAME}}, disabled_due_to_missing_lapacke)

--- a/dune/xt/test/la/generalized-eigensolver_internals.cc
+++ b/dune/xt/test/la/generalized-eigensolver_internals.cc
@@ -117,6 +117,9 @@ void check_backend_failure_is_reported()
  * and made lapack write past its end for every larger problem afterwards. That overwrote unrelated heap memory
  * without changing any of the values checked here, so this is a regression check that bites in a sanitizer build;
  * the growing-then-shrinking sequence is what a single test binary looks like to the shared buffer.
+ *
+ * Run for const and for mutable inputs alike: those select different MatrixDataProvider specializations, hence
+ * different instantiations of the implementation, each with its own function-local buffer.
  */
 template <class MatrixType>
 void check_varying_problem_sizes()
@@ -130,11 +133,16 @@ void check_varying_problem_sizes()
     }
     const auto lhs = make_matrix<MatrixType>(size, size, lhs_entries);
     const auto rhs = make_matrix<MatrixType>(size, size, rhs_entries);
-    const auto eigenvalues = internal::compute_generalized_eigenvalues_using_lapack(lhs, rhs);
-    ASSERT_EQ(size, eigenvalues.size()) << "size: " << size;
-    for (size_t ii = 0; ii < size; ++ii)
-      EXPECT_TRUE(Common::FloatCmp::eq(std::complex<double>(double(ii + 1), 0.), eigenvalues[ii], {1e-14, 1e-14}))
-          << "size: " << size << ", eigenvalue: " << eigenvalues[ii];
+    // dsygv overwrites both of its inputs, so the mutable variant needs matrices of its own
+    auto mutable_lhs = make_matrix<MatrixType>(size, size, lhs_entries);
+    auto mutable_rhs = make_matrix<MatrixType>(size, size, rhs_entries);
+    for (const auto& eigenvalues : {internal::compute_generalized_eigenvalues_using_lapack(lhs, rhs),
+                                    internal::compute_generalized_eigenvalues_using_lapack(mutable_lhs, mutable_rhs)}) {
+      ASSERT_EQ(size, eigenvalues.size()) << "size: " << size;
+      for (size_t ii = 0; ii < size; ++ii)
+        EXPECT_TRUE(Common::FloatCmp::eq(std::complex<double>(double(ii + 1), 0.), eigenvalues[ii], {1e-14, 1e-14}))
+            << "size: " << size << ", eigenvalue: " << eigenvalues[ii];
+    }
   }
 } // ... check_varying_problem_sizes(...)
 

--- a/dune/xt/test/la/generalized-eigensolver_internals.cc
+++ b/dune/xt/test/la/generalized-eigensolver_internals.cc
@@ -1,0 +1,185 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze (2026)
+
+// Tests of the free functions in dune/xt/la/generalized-eigen-solver/internal/lapacke.hh, which
+// GeneralizedEigenSolver only ever reaches through const references to its two matrices. That fixes the
+// MatrixDataProvider specialization to the copying one (a const matrix is never "contiguous and mutable"), so the
+// in-place branch -- and with it the row-major dispatch to LAPACKE -- is only reachable by calling the free functions
+// with mutable matrices, as done below. The same holds for the size checks of the *_impl function, which the solver's
+// own check_size() shields.
+
+#include <dune/xt/test/main.hxx> // <- has to come first (includes the config.h)!
+
+#include <complex>
+#include <vector>
+
+#include <dune/xt/common/matrix.hh>
+#include <dune/xt/la/container/common/matrix/dense.hh>
+#include <dune/xt/la/container/common/matrix/sparse.hh>
+#include <dune/xt/la/container/eigen.hh>
+#include <dune/xt/la/exceptions.hh>
+#include <dune/xt/la/generalized-eigen-solver.hh>
+#include <dune/xt/la/generalized-eigen-solver/internal/lapacke.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+
+#if HAVE_MKL || HAVE_LAPACKE
+
+
+/// \brief Creates a rows x cols matrix from a row-wise list of entries.
+template <class MatrixType>
+MatrixType make_matrix(const size_t rows, const size_t cols, const std::vector<double>& entries)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  EXPECT_EQ(rows * cols, entries.size());
+  auto matrix = M::create(rows, cols, 0.);
+  for (size_t ii = 0; ii < rows; ++ii)
+    for (size_t jj = 0; jj < cols; ++jj)
+      M::set_entry(matrix, ii, jj, entries[ii * cols + jj]);
+  return matrix;
+}
+
+
+/**
+ * \brief lhs = [3 1; 1 3], rhs = [2 0; 0 2] has the exactly representable eigenvalues 1 and 2.
+ *
+ * Called once with mutable matrices (which lets the implementation hand lapack the matrix memory directly, in
+ * whatever storage layout the matrix type uses) and once with const ones (which makes it serialize into a
+ * column-major buffer first). Both have to agree; note that the mutable variant is destructive, as dsygv overwrites
+ * both of its inputs.
+ */
+template <class MatrixType>
+void check_both_data_provider_paths()
+{
+  const std::vector<std::complex<double>> expected{{1., 0.}, {2., 0.}};
+  {
+    auto lhs = make_matrix<MatrixType>(2, 2, {3., 1., 1., 3.});
+    auto rhs = make_matrix<MatrixType>(2, 2, {2., 0., 0., 2.});
+    const auto eigenvalues = internal::compute_generalized_eigenvalues_using_lapack(lhs, rhs);
+    ASSERT_EQ(expected.size(), eigenvalues.size());
+    for (size_t ii = 0; ii < expected.size(); ++ii)
+      EXPECT_TRUE(Common::FloatCmp::eq(expected[ii], eigenvalues[ii], {1e-14, 1e-14})) << eigenvalues[ii];
+  }
+  {
+    const auto lhs = make_matrix<MatrixType>(2, 2, {3., 1., 1., 3.});
+    const auto rhs = make_matrix<MatrixType>(2, 2, {2., 0., 0., 2.});
+    const auto eigenvalues = internal::compute_generalized_eigenvalues_using_lapack(lhs, rhs);
+    ASSERT_EQ(expected.size(), eigenvalues.size());
+    for (size_t ii = 0; ii < expected.size(); ++ii)
+      EXPECT_TRUE(Common::FloatCmp::eq(expected[ii], eigenvalues[ii], {1e-14, 1e-14})) << eigenvalues[ii];
+  }
+} // ... check_both_data_provider_paths(...)
+
+
+/// \brief Each of the three size requirements of the implementation has to be reported separately.
+template <class MatrixType>
+void check_size_requirements()
+{
+  const auto square = make_matrix<MatrixType>(2, 2, {1., 0., 0., 1.});
+  const auto non_square = make_matrix<MatrixType>(2, 3, {1., 0., 0., 0., 1., 0.});
+  const auto larger_square = make_matrix<MatrixType>(3, 3, {1., 0., 0., 0., 1., 0., 0., 0., 1.});
+  EXPECT_THROW(internal::compute_generalized_eigenvalues_using_lapack(non_square, square),
+               Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements);
+  EXPECT_THROW(internal::compute_generalized_eigenvalues_using_lapack(square, larger_square),
+               Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements);
+  EXPECT_THROW(internal::compute_generalized_eigenvalues_using_lapack(square, non_square),
+               Exceptions::generalized_eigen_solver_failed_bc_data_did_not_fulfill_requirements);
+} // ... check_size_requirements(...)
+
+
+/// \brief dsygv needs a positive definite right hand side and reports anything else through its info return value.
+template <class MatrixType>
+void check_backend_failure_is_reported()
+{
+  const auto lhs = make_matrix<MatrixType>(2, 2, {1., 1., 1., 1.});
+  const auto zero = make_matrix<MatrixType>(2, 2, {0., 0., 0., 0.});
+  const auto indefinite = make_matrix<MatrixType>(2, 2, {1., 0., 0., -1.});
+  EXPECT_THROW(internal::compute_generalized_eigenvalues_using_lapack(lhs, zero),
+               Exceptions::generalized_eigen_solver_failed);
+  EXPECT_THROW(internal::compute_generalized_eigenvalues_using_lapack(lhs, indefinite),
+               Exceptions::generalized_eigen_solver_failed);
+} // ... check_backend_failure_is_reported(...)
+
+
+/**
+ * \brief Solving problems of growing size in one thread has to keep working.
+ *
+ * The implementation keeps the eigenvalue buffer in a thread_local, which used to be sized on the first call only
+ * and made lapack write past its end for every larger problem afterwards. That overwrote unrelated heap memory
+ * without changing any of the values checked here, so this is a regression check that bites in a sanitizer build;
+ * the growing-then-shrinking sequence is what a single test binary looks like to the shared buffer.
+ */
+template <class MatrixType>
+void check_varying_problem_sizes()
+{
+  for (const size_t size : {1, 2, 3, 4, 5, 6, 2, 1}) {
+    std::vector<double> lhs_entries(size * size, 0.);
+    std::vector<double> rhs_entries(size * size, 0.);
+    for (size_t ii = 0; ii < size; ++ii) {
+      lhs_entries[ii * size + ii] = double(ii + 1);
+      rhs_entries[ii * size + ii] = 1.;
+    }
+    const auto lhs = make_matrix<MatrixType>(size, size, lhs_entries);
+    const auto rhs = make_matrix<MatrixType>(size, size, rhs_entries);
+    const auto eigenvalues = internal::compute_generalized_eigenvalues_using_lapack(lhs, rhs);
+    ASSERT_EQ(size, eigenvalues.size()) << "size: " << size;
+    for (size_t ii = 0; ii < size; ++ii)
+      EXPECT_TRUE(Common::FloatCmp::eq(std::complex<double>(double(ii + 1), 0.), eigenvalues[ii], {1e-14, 1e-14}))
+          << "size: " << size << ", eigenvalue: " << eigenvalues[ii];
+  }
+} // ... check_varying_problem_sizes(...)
+
+
+GTEST_TEST(GeneralizedEigenSolverInternals, common_dense_matrix)
+{
+  using MatrixType = CommonDenseMatrix<double>; // <- row-major and contiguous
+  check_both_data_provider_paths<MatrixType>();
+  check_size_requirements<MatrixType>();
+  check_backend_failure_is_reported<MatrixType>();
+  check_varying_problem_sizes<MatrixType>();
+}
+
+GTEST_TEST(GeneralizedEigenSolverInternals, common_sparse_matrix)
+{
+  using MatrixType = CommonSparseMatrix<double>; // <- never contiguous, always serialized
+  check_both_data_provider_paths<MatrixType>();
+  check_size_requirements<MatrixType>();
+  check_backend_failure_is_reported<MatrixType>();
+  check_varying_problem_sizes<MatrixType>();
+}
+
+GTEST_TEST(GeneralizedEigenSolverInternals, field_matrix)
+{
+  using MatrixType = FieldMatrix<double, 2, 2>; // <- row-major, contiguous and of static size
+  check_both_data_provider_paths<MatrixType>();
+  check_backend_failure_is_reported<MatrixType>();
+}
+
+#  if HAVE_EIGEN
+GTEST_TEST(GeneralizedEigenSolverInternals, eigen_dense_matrix)
+{
+  using MatrixType = EigenDenseMatrix<double>; // <- column-major and contiguous
+  check_both_data_provider_paths<MatrixType>();
+  check_size_requirements<MatrixType>();
+  check_backend_failure_is_reported<MatrixType>();
+  check_varying_problem_sizes<MatrixType>();
+}
+#  endif // HAVE_EIGEN
+
+
+#else // HAVE_MKL || HAVE_LAPACKE
+
+
+GTEST_TEST(GeneralizedEigenSolverInternals, disabled_due_to_missing_lapacke) {}
+
+
+#endif // HAVE_MKL || HAVE_LAPACKE

--- a/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
+++ b/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
@@ -284,7 +284,8 @@ class TestGeneralizedEigenSolverBindings:
             (solver.lhs_matrix, self.LHS),
             (solver.rhs_matrix, self.RHS),
         ):
-            assert (prop.rows, prop.cols) == expected.shape
+            assert prop.rows == expected.shape[0]
+            assert prop.cols == expected.shape[1]
             for ii in range(expected.shape[0]):
                 for jj in range(expected.shape[1]):
                     assert prop.get_entry(ii, jj) == pytest.approx(expected[ii, jj])
@@ -344,14 +345,19 @@ class TestGeneralizedEigenSolverBindings:
     def test_violated_sign_assertions_are_reported(self, cls):
         from dune.xt.common import DuneError
 
+        # Constructed outside the raises block on purpose: the assertion is a post check, so
+        # construction has to succeed and only the eigenvalue access may fail.
+        negative_on_positive_spectrum = solver_with_asserts(
+            cls, self.LHS, self.RHS, assert_negative_eigenvalues="1e-10"
+        )
         with pytest.raises(DuneError):
-            solver_with_asserts(
-                cls, self.LHS, self.RHS, assert_negative_eigenvalues="1e-10"
-            ).eigenvalues()
+            negative_on_positive_spectrum.eigenvalues()
+
+        positive_on_negative_spectrum = solver_with_asserts(
+            cls, -self.LHS, self.RHS, assert_positive_eigenvalues="1e-10"
+        )
         with pytest.raises(DuneError):
-            solver_with_asserts(
-                cls, -self.LHS, self.RHS, assert_positive_eigenvalues="1e-10"
-            ).eigenvalues()
+            positive_on_negative_spectrum.eigenvalues()
 
     def test_indefinite_rhs_is_reported(self, cls):
         # lapack's dsygv requires a positive definite rhs; a zero one passes all of our own checks

--- a/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
+++ b/python/xt/test/test_hypothesis_la_generalized_eigensolver.py
@@ -33,6 +33,11 @@ GeneralizedEigenSolverBase::post_checks() branches in internal/base.hh -- the la
 "assert_real_eigenvalues" are both satisfiable for SPD pairs (real, strictly positive
 eigenvalues), so the branch bodies (and the compute_real_eigenvalues() assert-tolerance path
 they trigger) run without tripping.
+
+TestGeneralizedEigenSolverBindings at the end of this module complements the property tests with
+deterministic checks of the remainder of bind_GeneralizedEigenSolver()'s surface (the free
+factory overloads, the matrix/option properties, the eigenvector accessors) and of the failure
+paths -- rejected options, mismatched sizes, a right hand side lapack cannot factorize.
 """
 
 import numpy as np
@@ -235,6 +240,162 @@ class TestGeneralizedEigenSolverAgainstScipy:
         actual = np.sort(np.array([ev.real for ev in solver.eigenvalues()]))
         expected = np.sort(scipy_linalg.eigh(lhs_arr, rhs_arr, eigvals_only=True))
         assert actual == pytest.approx(expected, rel=1e-6, abs=1e-8)
+
+
+@pytest.mark.skipif(
+    not MATRIX_CLASSES,
+    reason="no generalized eigen-solver with lapack backend available",
+)
+@pytest.mark.parametrize("cls", MATRIX_CLASSES, ids=lambda c: c.__name__)
+class TestGeneralizedEigenSolverBindings:
+    """Deterministic coverage of the parts of bind_GeneralizedEigenSolver() the property tests miss.
+
+    The class above drives the eigenvalue accessors only; everything bound alongside them in
+    python/xt/dune/xt/la/generalized_eigen_solver.hh -- the two free `make_generalized_eigen_solver`
+    factory overloads, the `used_options`/`lhs_matrix`/`rhs_matrix` properties and the
+    `eigenvectors()`/`real_eigenvectors()` accessors -- has no test at all. These are fixed small
+    problems rather than hypothesis-generated ones: none of them is about numerics.
+
+    The pair used throughout is lhs = [3 1; 1 3], rhs = [2 0; 0 2], whose generalized eigenvalues are
+    exactly 1 and 2 (with rhs = 2*Id the problem reduces to the eigenvalues of lhs/2, and [a b; b a]
+    has the eigenvalues a +- b).
+    """
+
+    LHS = np.array([[3.0, 1.0], [1.0, 3.0]])
+    RHS = np.array([[2.0, 0.0], [0.0, 2.0]])
+    EIGENVALUES = [1.0, 2.0]
+
+    def test_types_and_options(self, cls):
+        solver_cls = generalized_solver_for(cls)
+        types = list(solver_cls.types())
+        assert "lapack" in types
+        # options() without an argument has to default to the first available type
+        assert dict(solver_cls.options())["type"] == types[0]
+        for tp in types:
+            assert dict(solver_cls.options(tp))["type"] == tp
+
+    def test_matrices_and_used_options_are_exposed(self, cls):
+        solver = generalized_solver_for(cls)(
+            make_matrix(cls, self.LHS), make_matrix(cls, self.RHS)
+        )
+
+        assert dict(solver.used_options)["type"] == "lapack"
+        for prop, expected in (
+            (solver.lhs_matrix, self.LHS),
+            (solver.rhs_matrix, self.RHS),
+        ):
+            assert (prop.rows, prop.cols) == expected.shape
+            for ii in range(expected.shape[0]):
+                for jj in range(expected.shape[1]):
+                    assert prop.get_entry(ii, jj) == pytest.approx(expected[ii, jj])
+
+    def test_factory_matches_constructor(self, cls):
+        import dune.xt.la as la
+
+        opts = dict(generalized_solver_for(cls).options("lapack"))
+        solvers = [
+            generalized_solver_for(cls)(
+                make_matrix(cls, self.LHS), make_matrix(cls, self.RHS)
+            ),
+            la.make_generalized_eigen_solver(
+                make_matrix(cls, self.LHS), make_matrix(cls, self.RHS), "lapack"
+            ),
+            la.make_generalized_eigen_solver(
+                make_matrix(cls, self.LHS), make_matrix(cls, self.RHS), opts
+            ),
+        ]
+        for solver in solvers:
+            actual = np.sort(np.array([ev.real for ev in solver.eigenvalues()]))
+            assert actual == pytest.approx(self.EIGENVALUES)
+
+    def test_eigenvectors_are_not_available(self, cls):
+        # Eigenvectors of a generalized problem are not implemented (see
+        # dune/xt/la/generalized-eigen-solver/default.hh): requesting them up front makes compute()
+        # fail, and asking for them afterwards is reported as a usage error rather than silently
+        # returning an empty matrix.
+        from dune.xt.common import DuneError
+
+        solver_cls = generalized_solver_for(cls)
+        solver = solver_cls(make_matrix(cls, self.LHS), make_matrix(cls, self.RHS))
+        with pytest.raises(DuneError):
+            solver.eigenvectors()
+        with pytest.raises(DuneError):
+            solver.real_eigenvectors()
+
+        opts = dict(solver_cls.options("lapack"))
+        opts["compute_eigenvectors"] = "true"
+        eigenvector_solver = solver_cls(
+            make_matrix(cls, self.LHS), make_matrix(cls, self.RHS), opts
+        )
+        with pytest.raises(DuneError):
+            eigenvector_solver.eigenvalues()
+
+    def test_negative_definite_pair(self, cls):
+        # The mirror image of test_assert_positive_eigenvalues_option above: a negative definite lhs
+        # with a positive definite rhs has a strictly negative spectrum, which is the only way to
+        # satisfy "assert_negative_eigenvalues" (and hence to reach the non-throwing side of that
+        # post check in GeneralizedEigenSolverBase::post_checks()).
+        solver = solver_with_asserts(
+            cls, -self.LHS, self.RHS, assert_negative_eigenvalues="1e-10"
+        )
+        actual = np.sort(np.array(solver.real_eigenvalues()))
+        assert actual == pytest.approx([-2.0, -1.0])
+
+    def test_violated_sign_assertions_are_reported(self, cls):
+        from dune.xt.common import DuneError
+
+        with pytest.raises(DuneError):
+            solver_with_asserts(
+                cls, self.LHS, self.RHS, assert_negative_eigenvalues="1e-10"
+            ).eigenvalues()
+        with pytest.raises(DuneError):
+            solver_with_asserts(
+                cls, -self.LHS, self.RHS, assert_positive_eigenvalues="1e-10"
+            ).eigenvalues()
+
+    def test_indefinite_rhs_is_reported(self, cls):
+        # lapack's dsygv requires a positive definite rhs; a zero one passes all of our own checks
+        # (square, of matching size, free of inf/nan), so the failure can only come from the backend.
+        from dune.xt.common import DuneError
+
+        solver = generalized_solver_for(cls)(
+            make_matrix(cls, self.LHS), make_matrix(cls, np.zeros((2, 2)))
+        )
+        with pytest.raises(DuneError):
+            solver.eigenvalues()
+
+    @pytest.mark.parametrize(
+        "broken_option",
+        [
+            {"type": "this_generalized_eigen_solver_type_does_not_exist"},
+            {"real_tolerance": "0"},
+            {
+                "assert_positive_eigenvalues": "1e-10",
+                "assert_negative_eigenvalues": "1e-10",
+            },
+        ],
+        ids=["unknown-type", "non-positive-tolerance", "contradicting-assertions"],
+    )
+    def test_inconsistent_options_are_rejected(self, cls, broken_option):
+        from dune.xt.common import DuneError
+
+        with pytest.raises(DuneError):
+            solver_with_asserts(cls, self.LHS, self.RHS, **broken_option)
+
+    def test_matrices_of_wrong_size_are_rejected(self, cls):
+        from dune.xt.common import DuneError
+
+        square = make_matrix(cls, self.RHS)
+        non_square = make_matrix(cls, np.ones((2, 3)))
+        larger_square = make_matrix(cls, np.eye(3))
+        solver_cls = generalized_solver_for(cls)
+        for lhs, rhs in (
+            (non_square, square),
+            (square, larger_square),
+            (square, non_square),
+        ):
+            with pytest.raises(DuneError):
+                solver_cls(lhs, rhs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The generalized eigen-solver stack (dune/xt/la/generalized-eigen-solver.hh,
generalized-eigen-solver/default.hh and its internal base.hh/lapacke.hh) was
only driven along its happy path: one 2x2 matrix with rhs = Id, plus the SPD
property tests from Python. Every error path, every option branch and the
in-place lapack dispatch were untested.

C++ test fixture (dune/xt/test/la/generalized-eigensolver.hh)
 - let deriving tests provide a right hand side other than the identity, so a
   genuine generalized problem is solved rather than a standard one
 - new checks for the options pointer ctor, the lhs/rhs accessors, the free
   functions of generalized-eigen-solver.hh, a broken rhs matrix, missing and
   unknown solver types (including via compute() with the checks disabled), a
   non-positive tolerance, matrices of the wrong size, requesting eigenvectors,
   an rhs lapack cannot factorize, min/max_eigenvalues(k) for arbitrary k, and
   both directions of the assert_{real,positive,negative}_eigenvalues post
   checks

New tests
 - generalized-eigensolver_for_matrix_pairs.{tpl,py}: a positive and a negative
   definite pair with rhs = 2*Id, whose eigenvalues are exactly representable;
   the negative one is what makes the assert_negative_eigenvalues branch
   satisfiable
 - generalized-eigensolver_internals.cc: the free functions of
   internal/lapacke.hh, which the solver only ever reaches through const
   matrices -- calling them with mutable ones covers the in-place data provider
   and the row-major dispatch, and calling them directly reaches their own size
   checks and the backend error handling

Fix: the thread_local eigenvalue buffer in
compute_generalized_eigenvalues_of_real_matrices_using_lapack_impl() was sized
by its initializer, i.e. only on the first call per thread, so dsygv wrote past
its end for every larger problem afterwards (reproduced under AddressSanitizer
with the existing Python property test's 1..6 sizes). It is now resized on every
call, as the non-generalized backend already does.

Python (python/xt/test/test_hypothesis_la_generalized_eigensolver.py)
 - deterministic tests for the rest of bind_GeneralizedEigenSolver(): the two
   make_generalized_eigen_solver overloads, used_options/lhs_matrix/rhs_matrix,
   the eigenvector accessors, and the rejected-input paths

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YJDDMzm4RGrbFGf1ARABxT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for repeated generalized eigenvalue computations when switching matrix sizes by ensuring per-thread eigenvalue buffers are correctly resized each call.
  * Correctly uses explicitly provided right-hand-side matrices (lhs/v = λ*rhs/v) instead of defaulting to an identity RHS.

* **Tests**
  * Added extensive new coverage for generalized eigen-solvers, including dedicated matrix-pair templates (positive/negative spectra), explicit RHS handling scenarios, and additional internal LAPACKE-backed regression tests.
  * Added new Python deterministic tests for constructor/binding behavior, option exposure, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->