### PR TITLE
test(la): cover the uncovered paths of dune/xt/la/algorithms

### DIFF
--- a/dune/xt/la/algorithms/cholesky.hh
+++ b/dune/xt/la/algorithms/cholesky.hh
@@ -56,6 +56,11 @@ solve_tridiag_ldlt(const FirstVectorType& diag, const SecondVectorType& subdiag,
   size_t size = vec.size();
   thread_local auto L =
       eye_matrix<CommonSparseMatrix<ScalarType>>(size, diagonal_pattern(size, size) + diagonal_pattern(size, size, -1));
+  // the thread local matrix above is only created once per thread, so it has to be recreated whenever this thread
+  // solves a system of a different size
+  if (L.rows() != size)
+    L = eye_matrix<CommonSparseMatrix<ScalarType>>(size,
+                                                   diagonal_pattern(size, size) + diagonal_pattern(size, size, -1));
   for (size_t ii = 0; ii < size - 1; ++ii)
     L.set_entry(ii + 1, ii, V2::get_entry(subdiag, ii));
   // solve LDL^T x = rhs;

--- a/dune/xt/la/algorithms/triangular_solves.hh
+++ b/dune/xt/la/algorithms/triangular_solves.hh
@@ -321,9 +321,8 @@ class TriangularSolver<CommonSparseOrDenseMatrix<DenseMatrixType, SparseMatrixTy
                        Common::StorageLayout::other>
 {
   using MatrixType = CommonSparseOrDenseMatrix<DenseMatrixType, SparseMatrixType>;
-  using M = Common::VectorAbstraction<MatrixType>;
-  using V = Common::VectorAbstraction<VectorType>;
 
+public:
   static void solve(const MatrixType& A, VectorType& x)
   {
     A.sparse() ? TriangularSolver<SparseMatrixType, VectorType, triangular_type, transpose>::solve(A.sparse_matrix(), x)

--- a/dune/xt/test/la/algorithms_cholesky_extra.cc
+++ b/dune/xt/test/la/algorithms_cholesky_extra.cc
@@ -1,0 +1,341 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze    (2026)
+
+// This file complements algorithms_cholesky.tpl: while the latter checks the factorization of a single small
+// tridiagonal matrix for all container types, the tests here cover the code paths of dune/xt/la/algorithms/cholesky.hh
+// which are not reached by that test, i.e.
+// * the LAPACK backed factorization (which is only used for dense matrices larger than min_lapack_factor_size),
+// * the storage layout specific implementations (row-wise, column-wise, csr and csc),
+// * solving with a given Cholesky factor,
+// * the LDL^T implementations which are not backed by LAPACK, and
+// * all error conditions.
+
+#include <dune/xt/test/main.hxx> // <- This one has to come first, includes config.h!
+
+#include <cmath>
+#include <vector>
+
+#include <dune/common/dynmatrix.hh>
+#include <dune/common/dynvector.hh>
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/common/float_cmp.hh>
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/matrix.hh>
+#include <dune/xt/common/vector.hh>
+
+#include <dune/xt/la/algorithms/cholesky.hh>
+#include <dune/xt/la/container.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+namespace {
+
+
+// Anything larger than internal::min_lapack_factor_size is factorized by LAPACK (if available), anything smaller by our
+// own implementations. We test both regimes with each of the dimensions below.
+constexpr size_t small_dim = 5;
+constexpr size_t large_dim = 12;
+
+// A symmetric and strictly diagonally dominant (and thus positive definite) matrix without zero entries.
+template <class MatrixType>
+MatrixType spd_matrix(const size_t dim)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  auto ret = M::create(dim, dim, 0.);
+  for (size_t ii = 0; ii < dim; ++ii)
+    for (size_t jj = 0; jj < dim; ++jj)
+      M::set_entry(ret, ii, jj, 1. / (1. + std::abs(int(ii) - int(jj))));
+  for (size_t ii = 0; ii < dim; ++ii)
+    M::add_to_entry(ret, ii, ii, double(dim));
+  return ret;
+}
+
+// The same matrix with a negative entry on the last diagonal element, i.e. not positive definite anymore.
+template <class MatrixType>
+MatrixType indefinite_matrix(const size_t dim)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  auto ret = spd_matrix<MatrixType>(dim);
+  M::set_entry(ret, dim - 1, dim - 1, -1.);
+  return ret;
+}
+
+// Checks that the lower triangular part of L is the Cholesky factor of A, i.e. that (L L^T)_ij == A_ij for j <= i. The
+// strictly upper triangular part of L is not checked, as it is left untouched by all implementations.
+template <class MatrixType>
+void expect_is_cholesky_factor_of(const MatrixType& L, const MatrixType& A, const size_t dim)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  for (size_t ii = 0; ii < dim; ++ii) {
+    for (size_t jj = 0; jj <= ii; ++jj) {
+      typename M::ScalarType L_LT_ij(0.);
+      for (size_t kk = 0; kk <= jj; ++kk)
+        L_LT_ij += M::get_entry(L, ii, kk) * M::get_entry(L, jj, kk);
+      EXPECT_TRUE(Common::FloatCmp::eq(L_LT_ij, M::get_entry(A, ii, jj), 1e-13, 1e-13))
+          << "ii = " << ii << ", jj = " << jj << ", (L L^T)_ij = " << L_LT_ij << ", A_ij = " << M::get_entry(A, ii, jj);
+    }
+    EXPECT_GT(M::get_entry(L, ii, ii), 0.);
+  }
+} // ... expect_is_cholesky_factor_of(...)
+
+template <class MatrixType>
+void factorizes_correctly(const size_t dim)
+{
+  const auto matrix = spd_matrix<MatrixType>(dim);
+  auto L = matrix;
+  cholesky(L);
+  expect_is_cholesky_factor_of(L, matrix, dim);
+}
+
+// The solution of A x = b for the matrix returned by spd_matrix is not available in closed form, so we prescribe x and
+// compute the corresponding right hand side instead.
+template <class MatrixType, class VectorType>
+void solves_correctly(const size_t dim)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  using V = Common::VectorAbstraction<VectorType>;
+  const auto matrix = spd_matrix<MatrixType>(dim);
+  auto expected_solution = V::create(dim, 0.);
+  for (size_t ii = 0; ii < dim; ++ii)
+    V::set_entry(expected_solution, ii, (ii % 2 == 0 ? 1. : -1.) * (1. + double(ii)));
+  auto rhs = V::create(dim, 0.);
+  for (size_t ii = 0; ii < dim; ++ii) {
+    typename V::ScalarType rhs_ii(0.);
+    for (size_t jj = 0; jj < dim; ++jj)
+      rhs_ii += M::get_entry(matrix, ii, jj) * V::get_entry(expected_solution, jj);
+    V::set_entry(rhs, ii, rhs_ii);
+  }
+  auto L = matrix;
+  cholesky(L);
+  solve_cholesky_factorized(L, rhs);
+  for (size_t ii = 0; ii < dim; ++ii)
+    EXPECT_TRUE(Common::FloatCmp::eq(V::get_entry(rhs, ii), V::get_entry(expected_solution, ii), 1e-12, 1e-12))
+        << "ii = " << ii << ", x_ii = " << V::get_entry(rhs, ii) << ", expected "
+        << V::get_entry(expected_solution, ii);
+} // ... solves_correctly(...)
+
+// The expected LDL^T factorization of the tridiagonal matrix with 2 on the diagonal and -1 on the sub- and
+// superdiagonal, see e.g. algorithms_cholesky.tpl for the five dimensional case.
+std::vector<double> expected_ldlt_diag(const size_t dim)
+{
+  std::vector<double> ret(dim);
+  for (size_t ii = 0; ii < dim; ++ii)
+    ret[ii] = double(ii + 2) / double(ii + 1);
+  return ret;
+}
+
+std::vector<double> expected_ldlt_subdiag(const size_t dim)
+{
+  std::vector<double> ret(dim - 1);
+  for (size_t ii = 0; ii < dim - 1; ++ii)
+    ret[ii] = -double(ii + 1) / double(ii + 2);
+  return ret;
+}
+
+// The solution of A x = (1, ..., 1)^T for the same matrix.
+std::vector<double> expected_tridiag_solution(const size_t dim)
+{
+  std::vector<double> ret(dim);
+  for (size_t ii = 0; ii < dim; ++ii)
+    ret[ii] = 0.5 * double(ii + 1) * double(dim - ii);
+  return ret;
+}
+
+
+} // namespace
+
+
+GTEST_TEST(CholeskyExtraTest, factorizes_dense_matrices)
+{
+  factorizes_correctly<CommonDenseMatrix<double>>(small_dim);
+  factorizes_correctly<CommonDenseMatrix<double>>(large_dim);
+  factorizes_correctly<DynamicMatrix<double>>(small_dim);
+  factorizes_correctly<DynamicMatrix<double>>(large_dim);
+  factorizes_correctly<FieldMatrix<double, small_dim, small_dim>>(small_dim);
+  factorizes_correctly<FieldMatrix<double, large_dim, large_dim>>(large_dim);
+  factorizes_correctly<Common::FieldMatrix<double, large_dim, large_dim>>(large_dim);
+}
+
+GTEST_TEST(CholeskyExtraTest, factorizes_sparse_matrices)
+{
+  factorizes_correctly<CommonSparseMatrixCsr<double>>(small_dim);
+  factorizes_correctly<CommonSparseMatrixCsr<double>>(large_dim);
+  factorizes_correctly<CommonSparseMatrixCsc<double>>(small_dim);
+  factorizes_correctly<CommonSparseMatrixCsc<double>>(large_dim);
+#if HAVE_DUNE_ISTL
+  factorizes_correctly<IstlRowMajorSparseMatrix<double>>(small_dim);
+  factorizes_correctly<IstlRowMajorSparseMatrix<double>>(large_dim);
+#endif
+}
+
+GTEST_TEST(CholeskyExtraTest, storage_layout_specific_implementations_agree)
+{
+  const auto matrix = spd_matrix<CommonDenseMatrix<double>>(small_dim);
+  auto rowwise = matrix;
+  internal::cholesky_rowwise<false>(rowwise);
+  expect_is_cholesky_factor_of(rowwise, matrix, small_dim);
+  auto rowwise_sparse = matrix;
+  internal::cholesky_rowwise<true>(rowwise_sparse);
+  expect_is_cholesky_factor_of(rowwise_sparse, matrix, small_dim);
+  auto colwise = matrix;
+  internal::cholesky_colwise<false>(colwise);
+  expect_is_cholesky_factor_of(colwise, matrix, small_dim);
+  auto colwise_sparse = matrix;
+  internal::cholesky_colwise<true>(colwise_sparse);
+  expect_is_cholesky_factor_of(colwise_sparse, matrix, small_dim);
+  for (size_t ii = 0; ii < small_dim; ++ii)
+    for (size_t jj = 0; jj <= ii; ++jj) {
+      EXPECT_DOUBLE_EQ(rowwise.get_entry(ii, jj), colwise.get_entry(ii, jj));
+      EXPECT_DOUBLE_EQ(rowwise.get_entry(ii, jj), rowwise_sparse.get_entry(ii, jj));
+      EXPECT_DOUBLE_EQ(rowwise.get_entry(ii, jj), colwise_sparse.get_entry(ii, jj));
+    }
+}
+
+GTEST_TEST(CholeskyExtraTest, solves_with_given_cholesky_factor)
+{
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(small_dim);
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(large_dim);
+  solves_correctly<CommonDenseMatrix<double>, DynamicVector<double>>(large_dim);
+  solves_correctly<DynamicMatrix<double>, DynamicVector<double>>(small_dim);
+  solves_correctly<DynamicMatrix<double>, DynamicVector<double>>(large_dim);
+  // the two dimensional case is special cased in the triangular solves
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(2);
+}
+
+GTEST_TEST(CholeskyExtraTest, throws_on_non_square_matrix)
+{
+  auto matrix = Common::MatrixAbstraction<CommonDenseMatrix<double>>::create(3, 4, 1.);
+  EXPECT_THROW(cholesky(matrix), Dune::InvalidStateException);
+}
+
+GTEST_TEST(CholeskyExtraTest, throws_on_matrix_which_is_not_positive_definite)
+{
+  auto small_dense = indefinite_matrix<CommonDenseMatrix<double>>(small_dim);
+  EXPECT_THROW(cholesky(small_dense), Dune::MathError);
+  auto large_dense = indefinite_matrix<CommonDenseMatrix<double>>(large_dim);
+  EXPECT_THROW(cholesky(large_dense), Dune::MathError);
+  auto dynamic_matrix = indefinite_matrix<DynamicMatrix<double>>(large_dim);
+  EXPECT_THROW(cholesky(dynamic_matrix), Dune::MathError);
+  auto csr = indefinite_matrix<CommonSparseMatrixCsr<double>>(small_dim);
+  EXPECT_THROW(cholesky(csr), Dune::MathError);
+  auto csc = indefinite_matrix<CommonSparseMatrixCsc<double>>(small_dim);
+  EXPECT_THROW(cholesky(csc), Dune::MathError);
+#if HAVE_DUNE_ISTL
+  auto istl = indefinite_matrix<IstlRowMajorSparseMatrix<double>>(small_dim);
+  EXPECT_THROW(cholesky(istl), Dune::MathError);
+#endif
+}
+
+GTEST_TEST(CholeskyExtraTest, csr_and_csc_factorizations_throw_for_other_storage_layouts)
+{
+  auto dense = spd_matrix<CommonDenseMatrix<double>>(small_dim);
+  EXPECT_THROW(internal::cholesky_csr(dense), Dune::InvalidStateException);
+  EXPECT_THROW(internal::cholesky_csc(dense), Dune::InvalidStateException);
+  auto csr = spd_matrix<CommonSparseMatrixCsr<double>>(small_dim);
+  EXPECT_THROW(internal::cholesky_csc(csr), Dune::InvalidStateException);
+  auto csc = spd_matrix<CommonSparseMatrixCsc<double>>(small_dim);
+  EXPECT_THROW(internal::cholesky_csr(csc), Dune::InvalidStateException);
+}
+
+GTEST_TEST(CholeskyExtraTest, tridiagonal_ldlt_factorizes_correctly)
+{
+  for (const size_t dim : {small_dim, large_dim}) {
+    std::vector<double> diag(dim, 2.);
+    std::vector<double> subdiag(dim - 1, -1.);
+    tridiagonal_ldlt(diag, subdiag);
+    const auto expected_diag = expected_ldlt_diag(dim);
+    const auto expected_subdiag = expected_ldlt_subdiag(dim);
+    for (size_t ii = 0; ii < dim; ++ii)
+      EXPECT_TRUE(Common::FloatCmp::eq(diag[ii], expected_diag[ii])) << "dim = " << dim << ", ii = " << ii;
+    for (size_t ii = 0; ii < dim - 1; ++ii)
+      EXPECT_TRUE(Common::FloatCmp::eq(subdiag[ii], expected_subdiag[ii])) << "dim = " << dim << ", ii = " << ii;
+  }
+}
+
+// internal::tridiagonal_ldlt is only used if neither MKL nor LAPACKE are available, so we call it directly to have it
+// covered in any case.
+GTEST_TEST(CholeskyExtraTest, internal_tridiagonal_ldlt_factorizes_correctly)
+{
+  const size_t dim = small_dim;
+  std::vector<double> diag(dim, 2.);
+  std::vector<double> subdiag(dim - 1, -1.);
+  internal::tridiagonal_ldlt(diag, subdiag);
+  const auto expected_diag = expected_ldlt_diag(dim);
+  const auto expected_subdiag = expected_ldlt_subdiag(dim);
+  for (size_t ii = 0; ii < dim; ++ii)
+    EXPECT_TRUE(Common::FloatCmp::eq(diag[ii], expected_diag[ii])) << "ii = " << ii;
+  for (size_t ii = 0; ii < dim - 1; ++ii)
+    EXPECT_TRUE(Common::FloatCmp::eq(subdiag[ii], expected_subdiag[ii])) << "ii = " << ii;
+}
+
+GTEST_TEST(CholeskyExtraTest, internal_tridiagonal_ldlt_throws_if_not_positive_definite)
+{
+  std::vector<double> diag{1., -1., 1.};
+  std::vector<double> subdiag{2., 0.};
+  EXPECT_THROW(internal::tridiagonal_ldlt(diag, subdiag), Dune::MathError);
+}
+
+GTEST_TEST(CholeskyExtraTest, tridiagonal_ldlt_throws_for_mismatching_sizes)
+{
+  std::vector<double> diag(small_dim, 2.);
+  std::vector<double> too_long_subdiag(small_dim, -1.);
+  EXPECT_THROW(tridiagonal_ldlt(diag, too_long_subdiag), Dune::InvalidStateException);
+  std::vector<double> too_short_subdiag(small_dim - 2, -1.);
+  EXPECT_THROW(tridiagonal_ldlt(diag, too_short_subdiag), Dune::InvalidStateException);
+}
+
+// internal::solve_tridiag_ldlt is only used for right hand sides which are not stored contiguously, so we call it
+// directly to have it covered for all configurations. Note that both dimensions are solved within the same test to
+// ensure that the (thread local) helper matrix is adapted to the size of the system.
+GTEST_TEST(CholeskyExtraTest, internal_solve_tridiag_ldlt_solves_correctly)
+{
+  for (const size_t dim : {small_dim, large_dim}) {
+    std::vector<double> diag(dim, 2.);
+    std::vector<double> subdiag(dim - 1, -1.);
+    internal::tridiagonal_ldlt(diag, subdiag);
+    DynamicVector<double> vector_rhs(dim, 1.);
+    internal::solve_tridiag_ldlt(diag, subdiag, vector_rhs);
+    const auto expected_solution = expected_tridiag_solution(dim);
+    for (size_t ii = 0; ii < dim; ++ii)
+      EXPECT_TRUE(Common::FloatCmp::eq(vector_rhs[ii], expected_solution[ii])) << "dim = " << dim << ", ii = " << ii;
+    DynamicMatrix<double> matrix_rhs(dim, dim, 1.);
+    internal::solve_tridiag_ldlt(diag, subdiag, matrix_rhs);
+    for (size_t jj = 0; jj < dim; ++jj)
+      for (size_t ii = 0; ii < dim; ++ii)
+        EXPECT_TRUE(Common::FloatCmp::eq(matrix_rhs[ii][jj], expected_solution[ii]))
+            << "dim = " << dim << ", ii = " << ii << ", jj = " << jj;
+  }
+}
+
+GTEST_TEST(CholeskyExtraTest, solve_tridiagonal_ldlt_factorized_handles_matrix_right_hand_sides)
+{
+  const size_t dim = large_dim;
+  std::vector<double> diag(dim, 2.);
+  std::vector<double> subdiag(dim - 1, -1.);
+  tridiagonal_ldlt(diag, subdiag);
+  const auto expected_solution = expected_tridiag_solution(dim);
+  // a dense row major right hand side (handled by LAPACK, if available)
+  auto dense_rhs = Common::MatrixAbstraction<CommonDenseMatrix<double>>::create(dim, dim, 1.);
+  solve_tridiagonal_ldlt_factorized(diag, subdiag, dense_rhs);
+  // a right hand side which is not stored contiguously
+  DynamicMatrix<double> dynamic_rhs(dim, dim, 1.);
+  solve_tridiagonal_ldlt_factorized(diag, subdiag, dynamic_rhs);
+  for (size_t jj = 0; jj < dim; ++jj)
+    for (size_t ii = 0; ii < dim; ++ii) {
+      EXPECT_TRUE(Common::FloatCmp::eq(dense_rhs.get_entry(ii, jj), expected_solution[ii]))
+          << "ii = " << ii << ", jj = " << jj;
+      EXPECT_TRUE(Common::FloatCmp::eq(dynamic_rhs[ii][jj], expected_solution[ii])) << "ii = " << ii << ", jj = " << jj;
+    }
+}

--- a/dune/xt/test/la/algorithms_qr_extra.cc
+++ b/dune/xt/test/la/algorithms_qr_extra.cc
@@ -114,13 +114,12 @@ void expect_is_qr_factorization_of(const MatrixType& QR,
   for (size_t ii = 0; ii < dim; ++ii)
     for (size_t jj = 0; jj < dim; ++jj) {
       ScalarType QT_Q_ij(0.);
-      ScalarType Q_R_ij(0.);
-      for (size_t kk = 0; kk < dim; ++kk) {
+      for (size_t kk = 0; kk < dim; ++kk)
         QT_Q_ij += Common::conj(MQ::get_entry(Q, kk, ii)) * MQ::get_entry(Q, kk, jj);
-        // R is the upper triangular part of QR
-        if (kk <= jj)
-          Q_R_ij += MQ::get_entry(Q, ii, kk) * M::get_entry(QR, kk, jj);
-      }
+      // R is the upper triangular part of QR, so only its first jj + 1 rows contribute to (Q R)_ij
+      ScalarType Q_R_ij(0.);
+      for (size_t kk = 0; kk <= jj; ++kk)
+        Q_R_ij += MQ::get_entry(Q, ii, kk) * M::get_entry(QR, kk, jj);
       EXPECT_LT(std::abs(QT_Q_ij - ScalarType(ii == jj ? 1. : 0.)), tolerance) << "ii = " << ii << ", jj = " << jj;
       EXPECT_LT(std::abs(Q_R_ij - M::get_entry(A, ii, size_t(permutations[jj]))), tolerance)
           << "ii = " << ii << ", jj = " << jj;

--- a/dune/xt/test/la/algorithms_qr_extra.cc
+++ b/dune/xt/test/la/algorithms_qr_extra.cc
@@ -1,0 +1,289 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze    (2026)
+
+// This file complements algorithms_qr_5x5.tpl, algorithms_qr_5x3.tpl and algorithms_qr_block_2x3x3.tpl, all of which
+// factorize matrices which are too small to be handed to LAPACK. The tests here cover the code paths of
+// dune/xt/la/algorithms/qr.hh which are not reached by those tests, i.e.
+// * the LAPACK backed factorization, reconstruction of Q and multiplication by Q,
+// * the complex valued Householder reflections,
+// * rank deficient matrices (for which the reduction of a column is skipped),
+// * the solvers built on top of the factorization (for vector, matrix and blocked matrix right hand sides), and
+// * all error conditions.
+
+#include <dune/xt/test/main.hxx> // <- This one has to come first, includes config.h!
+
+#include <cmath>
+#include <complex>
+#include <vector>
+
+#include <dune/common/dynmatrix.hh>
+#include <dune/common/dynvector.hh>
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/common/float_cmp.hh>
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/math.hh>
+#include <dune/xt/common/matrix.hh>
+#include <dune/xt/common/vector.hh>
+
+#include <dune/xt/la/algorithms/qr.hh>
+#include <dune/xt/la/container.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+namespace {
+
+
+// Anything larger than internal::min_lapack_factor_size is factorized by LAPACK (if available), anything smaller by our
+// own implementation.
+constexpr size_t small_dim = 5;
+constexpr size_t large_dim = 12;
+
+template <class ScalarType>
+ScalarType test_matrix_entry(const size_t ii, const size_t jj, const size_t dim)
+{
+  const auto real_part = 1. / (1. + std::abs(int(ii) - int(jj))) + 0.1 * double(int(ii) - int(jj)) / double(dim)
+                         + (ii == jj ? double(dim) : 0.);
+  if constexpr (Common::is_complex<ScalarType>::value)
+    return ScalarType(real_part, 0.25 * double(int(ii) - int(jj)) / double(dim));
+  else
+    return ScalarType(real_part);
+}
+
+// A non-symmetric, strictly diagonally dominant (and thus invertible) matrix.
+template <class MatrixType>
+MatrixType test_matrix(const size_t dim)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  auto ret = M::create(dim, dim, 0.);
+  for (size_t ii = 0; ii < dim; ++ii)
+    for (size_t jj = 0; jj < dim; ++jj)
+      M::set_entry(ret, ii, jj, test_matrix_entry<typename M::ScalarType>(ii, jj, dim));
+  return ret;
+}
+
+template <class VectorType>
+VectorType prescribed_solution(const size_t dim)
+{
+  using V = Common::VectorAbstraction<VectorType>;
+  auto ret = V::create(dim, 0.);
+  for (size_t ii = 0; ii < dim; ++ii)
+    V::set_entry(ret, ii, typename V::ScalarType((ii % 2 == 0 ? 1. : -1.) * (1. + double(ii))));
+  return ret;
+}
+
+template <class MatrixType, class VectorType>
+VectorType multiply(const MatrixType& A, const VectorType& x)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  using V = Common::VectorAbstraction<VectorType>;
+  auto ret = V::create(M::rows(A), 0.);
+  for (size_t ii = 0; ii < M::rows(A); ++ii) {
+    typename V::ScalarType ret_ii(0.);
+    for (size_t jj = 0; jj < M::cols(A); ++jj)
+      ret_ii += M::get_entry(A, ii, jj) * V::get_entry(x, jj);
+    V::set_entry(ret, ii, ret_ii);
+  }
+  return ret;
+}
+
+// Checks that Q is orthogonal (unitary in the complex case) and that Q R equals the column permutation of A given by
+// permutations, i.e. that A P = Q R.
+template <class MatrixType, class QMatrixType, class IndexVectorType>
+void expect_is_qr_factorization_of(const MatrixType& QR,
+                                   const QMatrixType& Q,
+                                   const IndexVectorType& permutations,
+                                   const MatrixType& A,
+                                   const size_t dim,
+                                   const double tolerance = 1e-13)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  using MQ = Common::MatrixAbstraction<QMatrixType>;
+  using ScalarType = typename M::ScalarType;
+  for (size_t ii = 0; ii < dim; ++ii)
+    for (size_t jj = 0; jj < dim; ++jj) {
+      ScalarType QT_Q_ij(0.);
+      ScalarType Q_R_ij(0.);
+      for (size_t kk = 0; kk < dim; ++kk) {
+        QT_Q_ij += Common::conj(MQ::get_entry(Q, kk, ii)) * MQ::get_entry(Q, kk, jj);
+        // R is the upper triangular part of QR
+        if (kk <= jj)
+          Q_R_ij += MQ::get_entry(Q, ii, kk) * M::get_entry(QR, kk, jj);
+      }
+      EXPECT_LT(std::abs(QT_Q_ij - ScalarType(ii == jj ? 1. : 0.)), tolerance) << "ii = " << ii << ", jj = " << jj;
+      EXPECT_LT(std::abs(Q_R_ij - M::get_entry(A, ii, size_t(permutations[jj]))), tolerance)
+          << "ii = " << ii << ", jj = " << jj;
+    }
+} // ... expect_is_qr_factorization_of(...)
+
+template <class MatrixType, class VectorType>
+void factorizes_correctly(const size_t dim, const double tolerance = 1e-13)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  using V = Common::VectorAbstraction<VectorType>;
+  using ScalarType = typename M::ScalarType;
+  const auto matrix = test_matrix<MatrixType>(dim);
+  auto QR = matrix;
+  auto tau = V::create(dim, ScalarType(0.));
+  std::vector<int> permutations(dim);
+  qr(QR, tau, permutations);
+  const auto Q = calculate_q_from_qr(QR, tau);
+  expect_is_qr_factorization_of(QR, Q, permutations, matrix, dim, tolerance);
+
+  // y = Q x and y = Q^T x have to coincide with the respective matrix vector products
+  const auto x = prescribed_solution<VectorType>(dim);
+  auto y = V::create(dim, ScalarType(0.));
+  apply_q_from_qr<Common::Transpose::no>(QR, tau, x, y);
+  const auto expected_y = multiply(Q, x);
+  for (size_t ii = 0; ii < dim; ++ii)
+    EXPECT_LT(std::abs(V::get_entry(y, ii) - V::get_entry(expected_y, ii)), tolerance) << "ii = " << ii;
+  auto transposed_y = V::create(dim, ScalarType(0.));
+  apply_q_from_qr<Common::Transpose::yes>(QR, tau, x, transposed_y);
+  for (size_t ii = 0; ii < dim; ++ii) {
+    ScalarType expected_ii(0.);
+    for (size_t kk = 0; kk < dim; ++kk)
+      expected_ii += Common::conj(Common::MatrixAbstraction<std::decay_t<decltype(Q)>>::get_entry(Q, kk, ii))
+                     * V::get_entry(x, kk);
+    EXPECT_LT(std::abs(V::get_entry(transposed_y, ii) - expected_ii), tolerance) << "ii = " << ii;
+  }
+} // ... factorizes_correctly(...)
+
+template <class MatrixType, class VectorType>
+void solves_correctly(const size_t dim, const double tolerance = 1e-12)
+{
+  using V = Common::VectorAbstraction<VectorType>;
+  const auto matrix = test_matrix<MatrixType>(dim);
+  const auto expected_solution = prescribed_solution<VectorType>(dim);
+  const auto rhs = multiply(matrix, expected_solution);
+  auto solution = V::create(dim, 0.);
+  auto A = matrix;
+  solve_by_qr_decomposition(A, solution, rhs);
+  for (size_t ii = 0; ii < dim; ++ii)
+    EXPECT_LT(std::abs(V::get_entry(solution, ii) - V::get_entry(expected_solution, ii)), tolerance)
+        << "ii = " << ii << ", solution = " << V::get_entry(solution, ii);
+} // ... solves_correctly(...)
+
+
+} // namespace
+
+
+GTEST_TEST(QrExtraTest, factorizes_dense_matrices)
+{
+  factorizes_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(small_dim);
+  factorizes_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(large_dim);
+  factorizes_correctly<CommonDenseMatrix<double>, DynamicVector<double>>(large_dim);
+  factorizes_correctly<DynamicMatrix<double>, DynamicVector<double>>(large_dim);
+  factorizes_correctly<FieldMatrix<double, large_dim, large_dim>, FieldVector<double, large_dim>>(large_dim);
+}
+
+GTEST_TEST(QrExtraTest, factorizes_complex_matrices)
+{
+  factorizes_correctly<CommonDenseMatrix<std::complex<double>>, CommonDenseVector<std::complex<double>>>(small_dim);
+  factorizes_correctly<CommonDenseMatrix<std::complex<double>>, CommonDenseVector<std::complex<double>>>(large_dim);
+}
+
+GTEST_TEST(QrExtraTest, factorizes_rank_deficient_matrices)
+{
+  // the reduction by a Householder matrix is skipped for columns which are zero below the diagonal
+  const size_t dim = 4;
+  using MatrixType = CommonDenseMatrix<double>;
+  auto matrix = Common::MatrixAbstraction<MatrixType>::create(dim, dim, 0.);
+  matrix.set_entry(0, 0, 2.);
+  matrix.set_entry(1, 1, 1.);
+  const auto expected_matrix = matrix;
+  auto QR = matrix;
+  std::vector<double> tau(dim, 0.);
+  std::vector<int> permutations(dim);
+  qr(QR, tau, permutations);
+  const auto Q = calculate_q_from_qr(QR, tau);
+  expect_is_qr_factorization_of(QR, Q, permutations, expected_matrix, dim);
+}
+
+GTEST_TEST(QrExtraTest, solves_with_qr_decomposition)
+{
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(small_dim);
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(large_dim);
+  solves_correctly<DynamicMatrix<double>, DynamicVector<double>>(large_dim);
+  solves_correctly<FieldMatrix<double, large_dim, large_dim>, FieldVector<double, large_dim>>(large_dim);
+  solves_correctly<CommonSparseMatrixCsr<double>, CommonDenseVector<double>>(small_dim);
+  solves_correctly<CommonSparseMatrixCsc<double>, CommonDenseVector<double>>(small_dim);
+}
+
+GTEST_TEST(QrExtraTest, solves_with_matrix_valued_right_hand_side)
+{
+  using MatrixType = CommonDenseMatrix<double>;
+  using M = Common::MatrixAbstraction<MatrixType>;
+  const size_t num_rhs = 3;
+  const auto matrix = test_matrix<MatrixType>(large_dim);
+  auto expected_solution = M::create(large_dim, num_rhs, 0.);
+  for (size_t ii = 0; ii < large_dim; ++ii)
+    for (size_t jj = 0; jj < num_rhs; ++jj)
+      M::set_entry(expected_solution, ii, jj, (ii % 2 == 0 ? 1. : -1.) * (1. + double(ii + jj)));
+  auto rhs = M::create(large_dim, num_rhs, 0.);
+  for (size_t ii = 0; ii < large_dim; ++ii)
+    for (size_t jj = 0; jj < num_rhs; ++jj) {
+      double rhs_ij = 0.;
+      for (size_t kk = 0; kk < large_dim; ++kk)
+        rhs_ij += M::get_entry(matrix, ii, kk) * M::get_entry(expected_solution, kk, jj);
+      M::set_entry(rhs, ii, jj, rhs_ij);
+    }
+  auto A = matrix;
+  auto solution = M::create(large_dim, num_rhs, 0.);
+  solve_by_qr_decomposition(A, solution, rhs);
+  for (size_t ii = 0; ii < large_dim; ++ii)
+    for (size_t jj = 0; jj < num_rhs; ++jj)
+      EXPECT_LT(std::abs(M::get_entry(solution, ii, jj) - M::get_entry(expected_solution, ii, jj)), 1e-12)
+          << "ii = " << ii << ", jj = " << jj;
+}
+
+GTEST_TEST(QrExtraTest, solves_blocked_systems)
+{
+  static constexpr size_t num_blocks = 2;
+  static constexpr size_t block_dim = 3;
+  using MatrixType = Common::BlockedFieldMatrix<double, num_blocks, block_dim, block_dim>;
+  MatrixType matrix(0.);
+  MatrixType expected_solution(0.);
+  for (size_t bb = 0; bb < num_blocks; ++bb)
+    for (size_t ii = 0; ii < block_dim; ++ii) {
+      for (size_t jj = 0; jj < block_dim; ++jj)
+        matrix.block(bb)[ii][jj] = test_matrix_entry<double>(ii, jj, block_dim) + double(bb);
+      expected_solution.block(bb)[ii][0] = (ii % 2 == 0 ? 1. : -1.) * (1. + double(ii + bb));
+    }
+  MatrixType rhs(0.);
+  for (size_t bb = 0; bb < num_blocks; ++bb)
+    for (size_t ii = 0; ii < block_dim; ++ii)
+      for (size_t kk = 0; kk < block_dim; ++kk)
+        rhs.block(bb)[ii][0] += matrix.block(bb)[ii][kk] * expected_solution.block(bb)[kk][0];
+  auto A = matrix;
+  MatrixType solution(0.);
+  solve_by_qr_decomposition(A, solution, rhs);
+  for (size_t bb = 0; bb < num_blocks; ++bb)
+    for (size_t ii = 0; ii < block_dim; ++ii)
+      EXPECT_LT(std::abs(solution.block(bb)[ii][0] - expected_solution.block(bb)[ii][0]), 1e-13)
+          << "bb = " << bb << ", ii = " << ii;
+}
+
+GTEST_TEST(QrExtraTest, throws_for_more_columns_than_rows)
+{
+  using MatrixType = CommonDenseMatrix<double>;
+  const size_t num_rows = 3;
+  const size_t num_cols = 5;
+  auto matrix = Common::MatrixAbstraction<MatrixType>::create(num_rows, num_cols, 1.);
+  std::vector<double> tau(num_cols, 0.);
+  std::vector<int> permutations(num_cols);
+  EXPECT_THROW(calculate_q_from_qr(matrix, tau), Dune::NotImplemented);
+  auto rhs = Common::VectorAbstraction<CommonDenseVector<double>>::create(num_rows, 1.);
+  auto solution = Common::VectorAbstraction<CommonDenseVector<double>>::create(num_cols, 0.);
+  EXPECT_THROW(solve_qr_factorized(matrix, tau, permutations, solution, rhs), Dune::NotImplemented);
+}

--- a/dune/xt/test/la/algorithms_solve_sym_tridiag_posdef_extra.cc
+++ b/dune/xt/test/la/algorithms_solve_sym_tridiag_posdef_extra.cc
@@ -1,0 +1,105 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze    (2026)
+
+// This file complements algorithms_solve_sym_tridiag_posdef.tpl, which only solves a single five dimensional system
+// given as a full matrix. The tests here additionally cover the overload which takes the diagonal and the subdiagonal
+// of the matrix, as well as systems of other dimensions.
+
+#include <dune/xt/test/main.hxx> // <- This one has to come first, includes config.h!
+
+#include <vector>
+
+#include <dune/common/dynmatrix.hh>
+#include <dune/common/dynvector.hh>
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/common/float_cmp.hh>
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/matrix.hh>
+#include <dune/xt/common/vector.hh>
+
+#include <dune/xt/la/algorithms/solve_sym_tridiag_posdef.hh>
+#include <dune/xt/la/container.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+namespace {
+
+
+// The solution of A x = (1, ..., 1)^T, where A is the tridiagonal matrix with 2 on the diagonal and -1 on the sub- and
+// superdiagonal.
+std::vector<double> expected_solution(const size_t size)
+{
+  std::vector<double> ret(size);
+  for (size_t ii = 0; ii < size; ++ii)
+    ret[ii] = 0.5 * double(ii + 1) * double(size - ii);
+  return ret;
+}
+
+template <class MatrixType>
+MatrixType tridiagonal_matrix(const size_t size)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  auto ret = M::create(size, size, 0., tridiagonal_pattern(size, size));
+  for (size_t ii = 0; ii < size; ++ii) {
+    M::set_entry(ret, ii, ii, 2.);
+    if (ii > 0) {
+      M::set_entry(ret, ii, ii - 1, -1.);
+      M::set_entry(ret, ii - 1, ii, -1.);
+    }
+  }
+  return ret;
+}
+
+template <class MatrixType, class VectorType>
+void solves_correctly(const size_t size)
+{
+  using V = Common::VectorAbstraction<VectorType>;
+  const auto matrix = tridiagonal_matrix<MatrixType>(size);
+  const auto rhs = V::create(size, 1.);
+  auto solution = V::create(size, 0.);
+  solve_sym_tridiag_posdef(matrix, solution, rhs);
+  const auto expected = expected_solution(size);
+  for (size_t ii = 0; ii < size; ++ii)
+    EXPECT_TRUE(Common::FloatCmp::eq(V::get_entry(solution, ii), expected[ii])) << "size = " << size << ", ii = " << ii;
+}
+
+
+} // namespace
+
+
+GTEST_TEST(SolveSymTridiagPosdefExtraTest, solves_systems_given_by_a_matrix)
+{
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(3);
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(12);
+  solves_correctly<DynamicMatrix<double>, DynamicVector<double>>(12);
+  solves_correctly<FieldMatrix<double, 12, 12>, FieldVector<double, 12>>(12);
+  solves_correctly<CommonSparseMatrixCsr<double>, CommonDenseVector<double>>(12);
+#if HAVE_DUNE_ISTL
+  solves_correctly<IstlRowMajorSparseMatrix<double>, IstlDenseVector<double>>(12);
+#endif
+}
+
+GTEST_TEST(SolveSymTridiagPosdefExtraTest, solves_systems_given_by_diagonal_and_subdiagonal)
+{
+  for (const size_t size : {size_t(3), size_t(12)}) {
+    std::vector<double> diag(size, 2.);
+    std::vector<double> subdiag(size - 1, -1.);
+    DynamicVector<double> rhs(size, 1.);
+    solve_sym_tridiag_posdef(diag, subdiag, rhs);
+    const auto expected = expected_solution(size);
+    for (size_t ii = 0; ii < size; ++ii)
+      EXPECT_TRUE(Common::FloatCmp::eq(rhs[ii], expected[ii])) << "size = " << size << ", ii = " << ii;
+  }
+}

--- a/dune/xt/test/la/algorithms_triangular_solves_extra.cc
+++ b/dune/xt/test/la/algorithms_triangular_solves_extra.cc
@@ -1,0 +1,226 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   René Fritze    (2026)
+
+// This file complements algorithms_triangular_solves_2x2.tpl and algorithms_triangular_solves_3x3.tpl, which only check
+// the solutions of two very small systems. The tests here cover the code paths of
+// dune/xt/la/algorithms/triangular_solves.hh which are not reached by those tests, i.e.
+// * systems which are large enough to be of interest for the BLAS backend,
+// * the CommonSparseOrDenseMatrix specialization of the solver, and
+// * all error conditions (singular matrices, non-square matrices and calling the compressed sparse implementations for
+//   matrices which are not stored in a compressed sparse format).
+
+#include <dune/xt/test/main.hxx> // <- This one has to come first, includes config.h!
+
+#include <cmath>
+#include <vector>
+
+#include <dune/common/dynmatrix.hh>
+#include <dune/common/dynvector.hh>
+#include <dune/common/fmatrix.hh>
+#include <dune/common/fvector.hh>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/common/float_cmp.hh>
+#include <dune/xt/common/fmatrix.hh>
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/matrix.hh>
+#include <dune/xt/common/vector.hh>
+
+#include <dune/xt/la/algorithms/triangular_solves.hh>
+#include <dune/xt/la/container.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::LA;
+
+namespace {
+
+
+constexpr size_t dim = 12;
+
+// A triangular matrix with a strictly positive diagonal and without zeros in the triangular part.
+template <class MatrixType>
+MatrixType triangular_matrix(const size_t size, const Common::MatrixPattern pattern_type)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  const bool lower = (pattern_type == Common::MatrixPattern::lower_triangular);
+  auto ret = M::create(size, size, 0., triangular_pattern(size, size, pattern_type));
+  for (size_t ii = 0; ii < size; ++ii)
+    for (size_t jj = 0; jj < size; ++jj)
+      if ((lower && jj <= ii) || (!lower && jj >= ii))
+        M::set_entry(ret, ii, jj, ii == jj ? 2. + double(ii) : 1. / (1. + std::abs(int(ii) - int(jj))));
+  return ret;
+}
+
+template <class VectorType>
+VectorType prescribed_solution(const size_t size)
+{
+  using V = Common::VectorAbstraction<VectorType>;
+  auto ret = V::create(size, 0.);
+  for (size_t ii = 0; ii < size; ++ii)
+    V::set_entry(ret, ii, (ii % 2 == 0 ? 1. : -1.) * (1. + double(ii)));
+  return ret;
+}
+
+// Computes A x or A^T x, entry by entry, to obtain a right hand side for a prescribed solution.
+template <class MatrixType, class VectorType>
+VectorType multiply(const MatrixType& A, const VectorType& x, const bool transposed)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  using V = Common::VectorAbstraction<VectorType>;
+  const size_t size = M::rows(A);
+  auto ret = V::create(size, 0.);
+  for (size_t ii = 0; ii < size; ++ii) {
+    typename V::ScalarType ret_ii(0.);
+    for (size_t jj = 0; jj < size; ++jj)
+      ret_ii += M::get_entry(A, transposed ? jj : ii, transposed ? ii : jj) * V::get_entry(x, jj);
+    V::set_entry(ret, ii, ret_ii);
+  }
+  return ret;
+}
+
+template <class VectorType>
+void expect_solution_eq(const VectorType& actual, const VectorType& expected, const size_t size)
+{
+  using V = Common::VectorAbstraction<VectorType>;
+  for (size_t ii = 0; ii < size; ++ii)
+    EXPECT_TRUE(Common::FloatCmp::eq(V::get_entry(actual, ii), V::get_entry(expected, ii), 1e-12, 1e-12))
+        << "ii = " << ii << ", actual = " << V::get_entry(actual, ii) << ", expected = " << V::get_entry(expected, ii);
+}
+
+// Checks all four triangular solves for the given matrix and vector type.
+template <class MatrixType, class VectorType>
+void solves_correctly(const size_t size)
+{
+  using V = Common::VectorAbstraction<VectorType>;
+  const auto lower = triangular_matrix<MatrixType>(size, Common::MatrixPattern::lower_triangular);
+  const auto upper = triangular_matrix<MatrixType>(size, Common::MatrixPattern::upper_triangular);
+  const auto expected_solution = prescribed_solution<VectorType>(size);
+  auto solution = V::create(size, 0.);
+
+  solve_lower_triangular(lower, solution, multiply(lower, expected_solution, false));
+  expect_solution_eq(solution, expected_solution, size);
+  solve_lower_triangular_transposed(lower, solution, multiply(lower, expected_solution, true));
+  expect_solution_eq(solution, expected_solution, size);
+  solve_upper_triangular(upper, solution, multiply(upper, expected_solution, false));
+  expect_solution_eq(solution, expected_solution, size);
+  solve_upper_triangular_transposed(upper, solution, multiply(upper, expected_solution, true));
+  expect_solution_eq(solution, expected_solution, size);
+} // ... solves_correctly(...)
+
+// Checks that all four triangular solves report a matrix with a zero on the diagonal as singular.
+template <class MatrixType, class VectorType>
+void throws_for_singular_matrices(const size_t size)
+{
+  using M = Common::MatrixAbstraction<MatrixType>;
+  using V = Common::VectorAbstraction<VectorType>;
+  auto lower = triangular_matrix<MatrixType>(size, Common::MatrixPattern::lower_triangular);
+  auto upper = triangular_matrix<MatrixType>(size, Common::MatrixPattern::upper_triangular);
+  // the zero has to be in the interior, as the first and last row are not necessarily visited before the
+  // implementations divide by the respective other diagonal entry
+  M::set_entry(lower, size / 2, size / 2, 0.);
+  M::set_entry(upper, size / 2, size / 2, 0.);
+  const auto rhs = V::create(size, 1.);
+  auto solution = V::create(size, 0.);
+  EXPECT_THROW(solve_lower_triangular(lower, solution, rhs), Dune::MathError);
+  EXPECT_THROW(solve_lower_triangular_transposed(lower, solution, rhs), Dune::MathError);
+  EXPECT_THROW(solve_upper_triangular(upper, solution, rhs), Dune::MathError);
+  EXPECT_THROW(solve_upper_triangular_transposed(upper, solution, rhs), Dune::MathError);
+} // ... throws_for_singular_matrices(...)
+
+
+} // namespace
+
+
+// Systems of dimension two are special cased in the solver, all other dimensions share the same code paths.
+GTEST_TEST(TriangularSolvesExtraTest, solves_two_dimensional_systems)
+{
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(2);
+  solves_correctly<DynamicMatrix<double>, DynamicVector<double>>(2);
+  solves_correctly<FieldMatrix<double, 2, 2>, FieldVector<double, 2>>(2);
+  solves_correctly<CommonSparseMatrixCsr<double>, CommonDenseVector<double>>(2);
+  solves_correctly<CommonSparseMatrixCsc<double>, CommonDenseVector<double>>(2);
+}
+
+GTEST_TEST(TriangularSolvesExtraTest, solves_dense_systems)
+{
+  solves_correctly<CommonDenseMatrix<double>, CommonDenseVector<double>>(dim);
+  solves_correctly<CommonDenseMatrix<double>, DynamicVector<double>>(dim);
+  solves_correctly<DynamicMatrix<double>, DynamicVector<double>>(dim);
+  solves_correctly<FieldMatrix<double, dim, dim>, FieldVector<double, dim>>(dim);
+  solves_correctly<Common::FieldMatrix<double, dim, dim>, Common::FieldVector<double, dim>>(dim);
+}
+
+GTEST_TEST(TriangularSolvesExtraTest, solves_sparse_systems)
+{
+  solves_correctly<CommonSparseMatrixCsr<double>, CommonDenseVector<double>>(dim);
+  solves_correctly<CommonSparseMatrixCsc<double>, CommonDenseVector<double>>(dim);
+  solves_correctly<CommonSparseMatrixCsr<double>, CommonSparseVector<double>>(dim);
+  solves_correctly<CommonSparseMatrixCsc<double>, CommonSparseVector<double>>(dim);
+#if HAVE_DUNE_ISTL
+  solves_correctly<IstlRowMajorSparseMatrix<double>, IstlDenseVector<double>>(dim);
+#endif
+}
+
+// CommonSparseOrDenseMatrix decides on construction whether to store the matrix in a sparse or in a dense format, both
+// of which are handled by a dedicated specialization of the triangular solver.
+GTEST_TEST(TriangularSolvesExtraTest, solves_sparse_or_dense_systems)
+{
+  // a triangular pattern is dense enough for the dense storage to be chosen
+  solves_correctly<CommonSparseOrDenseMatrixCsr<double>, CommonDenseVector<double>>(dim);
+  solves_correctly<CommonSparseOrDenseMatrixCsc<double>, CommonDenseVector<double>>(dim);
+  // ... while a bidiagonal pattern of a large enough matrix is sparse enough for the sparse storage
+  using SparseOrDenseType = CommonSparseOrDenseMatrixCsr<double>;
+  const size_t large_dim = 64;
+  SparseOrDenseType lower(
+      large_dim, large_dim, diagonal_pattern(large_dim, large_dim) + diagonal_pattern(large_dim, large_dim, -1));
+  for (size_t ii = 0; ii < large_dim; ++ii) {
+    lower.set_entry(ii, ii, 2. + double(ii));
+    if (ii > 0)
+      lower.set_entry(ii, ii - 1, -1.);
+  }
+  EXPECT_TRUE(lower.sparse());
+  const auto expected_solution = prescribed_solution<CommonDenseVector<double>>(large_dim);
+  auto solution = Common::VectorAbstraction<CommonDenseVector<double>>::create(large_dim, 0.);
+  solve_lower_triangular(lower, solution, multiply(lower, expected_solution, false));
+  expect_solution_eq(solution, expected_solution, large_dim);
+}
+
+GTEST_TEST(TriangularSolvesExtraTest, throws_for_singular_matrices)
+{
+  throws_for_singular_matrices<CommonDenseMatrix<double>, CommonDenseVector<double>>(dim);
+  throws_for_singular_matrices<DynamicMatrix<double>, DynamicVector<double>>(dim);
+  throws_for_singular_matrices<CommonSparseMatrixCsr<double>, CommonDenseVector<double>>(dim);
+  throws_for_singular_matrices<CommonSparseMatrixCsc<double>, CommonDenseVector<double>>(dim);
+#if HAVE_DUNE_ISTL
+  throws_for_singular_matrices<IstlRowMajorSparseMatrix<double>, IstlDenseVector<double>>(dim);
+#endif
+}
+
+GTEST_TEST(TriangularSolvesExtraTest, throws_for_non_square_matrices)
+{
+  auto matrix = Common::MatrixAbstraction<CommonDenseMatrix<double>>::create(3, 4, 1.);
+  auto rhs = Common::VectorAbstraction<CommonDenseVector<double>>::create(3, 1.);
+  auto solution = Common::VectorAbstraction<CommonDenseVector<double>>::create(3, 0.);
+  EXPECT_THROW(solve_lower_triangular(matrix, solution, rhs), Dune::InvalidStateException);
+  EXPECT_THROW(solve_lower_triangular_transposed(matrix, solution, rhs), Dune::InvalidStateException);
+  EXPECT_THROW(solve_upper_triangular(matrix, solution, rhs), Dune::InvalidStateException);
+  EXPECT_THROW(solve_upper_triangular_transposed(matrix, solution, rhs), Dune::InvalidStateException);
+}
+
+GTEST_TEST(TriangularSolvesExtraTest, compressed_sparse_solves_throw_for_other_storage_layouts)
+{
+  const auto matrix = triangular_matrix<CommonDenseMatrix<double>>(dim, Common::MatrixPattern::lower_triangular);
+  std::vector<double> x(dim, 0.);
+  std::vector<double> rhs(dim, 1.);
+  EXPECT_THROW(internal::forward_solve_csr(matrix, x, rhs), Dune::InvalidStateException);
+  EXPECT_THROW(internal::forward_solve_csc(matrix, x, rhs), Dune::InvalidStateException);
+  EXPECT_THROW(internal::backward_solve_csr(matrix, x, rhs), Dune::InvalidStateException);
+  EXPECT_THROW(internal::backward_solve_csc(matrix, x, rhs), Dune::InvalidStateException);
+}


### PR DESCRIPTION
Raises coverage for everything under `dune/xt/la/algorithms` (Codecov: `triangular_solves.hh` 32.8%, `cholesky.hh` 61.9%, `qr.hh` 89.8%, `solve_sym_tridiag_posdef.hh` not reported at all).

## What was missing

I pulled the per-line report from the Codecov API for the three reported files and used the missed-line list as the work list. Almost all of it is error handling and storage-layout dispatch that the existing `algorithms_*.tpl` tests never reach — they factorize one small, well-behaved matrix per container type, so nothing throws and nothing is large enough (`> internal::min_lapack_factor_size`) to go through LAPACK.

## What was added

Four plain gtest sources in `dune/xt/test/la/` (picked up by `add_subdir_tests(la)` like the existing `pattern.cc`/`vector_view.cc`), each one a companion to the corresponding `.tpl`:

- **`algorithms_cholesky_extra.cc`** — LAPACK backed factorization (dimension 12 alongside dimension 5), the row-wise/column-wise/csr/csc implementations and their agreement, `solve_cholesky_factorized`, the non-LAPACK `internal::tridiagonal_ldlt`/`internal::solve_tridiag_ldlt` routines, matrix-valued right hand sides, and every error condition (non-square, not positive definite for each layout, csr/csc factorization called for another layout, mismatching diagonal sizes).
- **`algorithms_triangular_solves_extra.cc`** — all four solves for dense, csr, csc, ISTL and `CommonSparseOrDenseMatrix` (both its sparse and its dense storage), for the special-cased dimension two as well as the general case; singular matrices for each implementation, non-square matrices, and the compressed-sparse implementations called for other storage layouts.
- **`algorithms_qr_extra.cc`** — LAPACK backed factorization, explicit reconstruction of `Q` and multiplication by `Q`/`Q^T`, complex valued Householder reflections (`get_s` for `std::complex`), rank deficient matrices (the skipped column reduction), `solve_by_qr_decomposition` for vector, matrix and blocked right hand sides, the csr/csc branch of `solve_qr_factorized`, and the two `NotImplemented` conditions.
- **`algorithms_solve_sym_tridiag_posdef_extra.cc`** — both overloads for several container types and dimensions; the header currently has no coverage record at all.

Every currently-missed statement in the three reported files is now executed, except the CBLAS branch in `TriangularSolver::solve` — `Common::Cblas::available()` is only true with MKL, so that branch is unreachable in this build.

## Two fixes the new tests forced

- `internal::solve_tridiag_ldlt` kept its `thread_local` helper matrix at the size of the first system a thread solved; a second system of a different size then threw `index_out_of_range`. It is recreated when the size changes.
- The `TriangularSolver` specialization for `CommonSparseOrDenseMatrix` declared `solve()` in the private section of a `class`, so any use of it was a compile error — the specialization was dead code. It is public now, and the two unused (and incorrect: `VectorAbstraction<MatrixType>`) member aliases are gone.

## Verification

The dune toolchain is not available in this environment, so I built the four new sources plus all seven existing `algorithms_*.tpl` tests against the pinned `dune-common`/`dune-istl` and ran them, in both a `HAVE_LAPACKE=0` and a `HAVE_LAPACKE=1` configuration. All pass in both; the existing tests still pass with the two source fixes. Line coverage was measured with gcov to confirm the intended lines are hit.

## Noted, not fixed

`internal::qr_decomposition` reads `A(jj, jj)` for `jj` up to `num_cols - 2`, so calling `qr()` on a matrix with more columns than rows reads out of bounds when LAPACK is unavailable (it is fine via `dgeqp3`). The test only exercises the `NotImplemented` guards downstream of it; fixing the loop bound felt out of scope for a coverage change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoiQWuQq4QoSuwgerPQn4f)_