### PR TITLE
test(xt): cover the function interfaces' default implementations

### DIFF
--- a/dune/xt/test/functions/element_flux_function_interface.cc
+++ b/dune/xt/test/functions/element_flux_function_interface.cc
@@ -1,0 +1,475 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-xt developers
+
+/// \file
+/// \brief Tests the default implementations provided by the flux function interfaces.
+///
+/// Covers ElementFluxFunctionSetInterface, ElementFluxFunctionInterface (which is a set of size one) and the small
+/// FluxFunctionInterface on top of them. As for the plain element functions, concrete implementations override the
+/// "should be implemented" virtuals, so the convenience layers the interfaces provide -- the single-component
+/// accessors, the dynamic-container overloads, the argument checks and the NotImplemented defaults -- are only
+/// reachable from subclasses that deliberately leave them alone, which is what the minimal classes below do.
+///
+/// \note Everything here uses a state dimension equal to the domain dimension. The interfaces size their jacobian
+///       types from the state dimension (JacobianRangeSelector is a DerivativeRangeTypeSelector<s, ...>) but iterate
+///       over the domain dimension d in the matrix-valued branches of the single-component accessors, so the two have
+///       to agree for those code paths to be well defined.
+
+#ifndef DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS
+#  define DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS 1
+#endif
+
+#include <dune/xt/test/main.hxx> // <- has to come first, includes the config.h!
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/xt/functions/exceptions.hh>
+#include <dune/xt/functions/interfaces/element-flux-functions.hh>
+#include <dune/xt/functions/interfaces/flux-function.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::Functions;
+
+namespace {
+
+
+using GridType = CUBEGRID_2D;
+using ElementType = XT::Grid::extract_entity_t<GridType>;
+constexpr size_t dim_domain = GridType::dimension;
+constexpr size_t dim_state = dim_domain;
+
+// the reference element of a YaspGrid cube is [0, 1]^d
+const FieldVector<double, dim_domain> inside_point(0.25);
+const FieldVector<double, dim_domain> outside_point(1.5);
+const FieldVector<double, dim_state> state(0.5);
+
+
+/// \brief Deterministic, pairwise distinct values, so every accessed component can be identified in an assertion.
+double expected_value(const size_t function_index, const size_t row, const size_t col)
+{
+  return 100. * function_index + 10. * row + col + 1.;
+}
+
+double expected_jacobian(const size_t function_index, const size_t row, const size_t col, const size_t ss)
+{
+  return 1000. * function_index + 100. * row + 10. * col + ss + 1.;
+}
+
+
+/// \brief Implements only the three pure virtuals, so every "should be implemented" method still throws.
+template <size_t r, size_t rC>
+class ThrowingSet : public ElementFluxFunctionSetInterface<ElementType, dim_state, r, rC>
+{
+public:
+  size_t size(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 1;
+  }
+
+  size_t max_size(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 1;
+  }
+
+  int order(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 0;
+  }
+};
+
+
+/// \brief Implements only order(), so evaluate()/jacobian() still throw.
+template <size_t r, size_t rC>
+class ThrowingLocalFunction : public ElementFluxFunctionInterface<ElementType, dim_state, r, rC>
+{
+public:
+  int order(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 0;
+  }
+};
+
+
+/// \brief Implements the two single-valued methods only; everything else is served by the interfaces.
+template <size_t r, size_t rC>
+class FixedLocalFunction : public ElementFluxFunctionInterface<ElementType, dim_state, r, rC>
+{
+  using BaseType = ElementFluxFunctionInterface<ElementType, dim_state, r, rC>;
+
+public:
+  using BaseType::s;
+  using typename BaseType::DomainType;
+  using typename BaseType::JacobianRangeReturnType;
+  using typename BaseType::RangeReturnType;
+  using typename BaseType::StateType;
+
+  // overriding one overload hides the others, and those are exactly what is under test here
+  using BaseType::evaluate;
+  using BaseType::jacobian;
+
+  int order(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 0;
+  }
+
+  RangeReturnType evaluate(const DomainType& point_in_reference_element,
+                           const StateType& /*u*/,
+                           const Common::Parameter& /*param*/ = {}) const override
+  {
+    this->assert_inside_reference_element(point_in_reference_element);
+    RangeReturnType result;
+    for (size_t row = 0; row < r; ++row) {
+      if constexpr (rC == 1)
+        result[row] = expected_value(0, row, 0);
+      else
+        for (size_t col = 0; col < rC; ++col)
+          result[row][col] = expected_value(0, row, col);
+    }
+    return result;
+  } // ... evaluate(...)
+
+  JacobianRangeReturnType jacobian(const DomainType& point_in_reference_element,
+                                   const StateType& /*u*/,
+                                   const Common::Parameter& /*param*/ = {}) const override
+  {
+    this->assert_inside_reference_element(point_in_reference_element);
+    JacobianRangeReturnType result;
+    for (size_t row = 0; row < r; ++row) {
+      if constexpr (rC == 1) {
+        for (size_t ss = 0; ss < s; ++ss)
+          result[row][ss] = expected_jacobian(0, row, 0, ss);
+      } else {
+        for (size_t col = 0; col < rC; ++col)
+          for (size_t ss = 0; ss < s; ++ss)
+            result[row][col][ss] = expected_jacobian(0, row, col, ss);
+      }
+    }
+    return result;
+  } // ... jacobian(...)
+};
+
+
+/// \brief Implements only local_function(), so x_dependent() and name() fall back to the interface defaults.
+template <size_t r, size_t rC>
+class MinimalFluxFunction : public FluxFunctionInterface<ElementType, dim_state, r, rC>
+{
+  using BaseType = FluxFunctionInterface<ElementType, dim_state, r, rC>;
+
+public:
+  using typename BaseType::LocalFunctionType;
+
+  std::unique_ptr<LocalFunctionType> local_function() const override
+  {
+    return std::make_unique<FixedLocalFunction<r, rC>>();
+  }
+};
+
+
+struct FluxFunctionInterfaceTest : public ::testing::Test
+{
+  using GridProviderType = XT::Grid::GridProvider<GridType>;
+
+  FluxFunctionInterfaceTest()
+    : grid_(XT::Grid::make_cube_grid<GridType>(0., 1., 2))
+    , leaf_view_(grid_.leaf_view())
+    // which element we bind to is irrelevant: everything under test here is element independent, it merely requires
+    // the object to be bound at all
+    , element_(*elements(leaf_view_).begin())
+  {
+  }
+
+  const GridProviderType grid_;
+  const typename GridProviderType::LeafGridViewType leaf_view_;
+  const ElementType element_;
+}; // struct FluxFunctionInterfaceTest
+
+
+// ======================================================================== ElementFluxFunctionSetInterface
+
+
+template <size_t r, size_t rC>
+void check_set_defaults_throw(const ElementType& element)
+{
+  ThrowingSet<r, rC> set;
+  set.bind(element);
+
+  std::vector<typename ThrowingSet<r, rC>::RangeType> values;
+  std::vector<typename ThrowingSet<r, rC>::JacobianRangeType> jacobians;
+
+  EXPECT_THROW(set.evaluate(inside_point, state, values), Dune::NotImplemented);
+  EXPECT_THROW(set.jacobian(inside_point, state, jacobians), Dune::NotImplemented);
+  // the convenience wrappers forward to the same defaults
+  EXPECT_THROW(set.evaluate_set(inside_point, state), Dune::NotImplemented);
+  EXPECT_THROW(set.jacobian_of_set(inside_point, state), Dune::NotImplemented);
+} // ... check_set_defaults_throw(...)
+
+
+template <size_t r, size_t rC>
+void check_of_set_wrappers(const ElementType& element)
+{
+  FixedLocalFunction<r, rC> func;
+  func.bind(element);
+
+  // an ElementFluxFunctionInterface is an ElementFluxFunctionSetInterface of size one
+  EXPECT_EQ(1u, func.size());
+  EXPECT_EQ(1u, func.max_size());
+
+  const auto values = func.evaluate_set(inside_point, state);
+  ASSERT_EQ(1u, values.size());
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[0][row]);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0][row][col]);
+  }
+
+  const auto jacobians = func.jacobian_of_set(inside_point, state);
+  ASSERT_EQ(1u, jacobians.size());
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t ss = 0; ss < dim_state; ++ss)
+        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, 0, ss), jacobians[0][row][ss]);
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t ss = 0; ss < dim_state; ++ss)
+          EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobians[0][row][col][ss]);
+    }
+  }
+} // ... check_of_set_wrappers(...)
+
+
+template <size_t r, size_t rC>
+void check_set_single_component_accessors(const ElementType& element)
+{
+  FixedLocalFunction<r, rC> func;
+  func.bind(element);
+  using SingleJacobianRangeType = typename FixedLocalFunction<r, rC>::SingleJacobianRangeType;
+
+  for (size_t row = 0; row < r; ++row)
+    for (size_t col = 0; col < rC; ++col) {
+      // both results are deliberately left empty, to also cover the interface's resize path
+      std::vector<double> values;
+      func.evaluate(inside_point, state, values, row, col);
+      ASSERT_EQ(1u, values.size());
+      EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0]);
+
+      std::vector<SingleJacobianRangeType> jacobians;
+      func.jacobian(inside_point, state, jacobians, row, col);
+      ASSERT_EQ(1u, jacobians.size());
+      for (size_t ss = 0; ss < dim_state; ++ss)
+        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobians[0][ss]);
+    }
+} // ... check_set_single_component_accessors(...)
+
+
+template <size_t r, size_t rC>
+void check_set_dynamic_overloads(const ElementType& element)
+{
+  FixedLocalFunction<r, rC> func;
+  func.bind(element);
+  using DynamicRangeType = typename FixedLocalFunction<r, rC>::DynamicRangeType;
+  using DynamicJacobianRangeType = typename FixedLocalFunction<r, rC>::DynamicJacobianRangeType;
+
+  // both results are deliberately left empty, so the interface has to resize and ensure_size the entries
+  std::vector<DynamicRangeType> values;
+  func.evaluate(inside_point, state, values);
+  ASSERT_EQ(1u, values.size());
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[0][row]);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0].get_entry(row, col));
+  }
+
+  std::vector<DynamicJacobianRangeType> jacobians;
+  func.jacobian(inside_point, state, jacobians);
+  ASSERT_EQ(1u, jacobians.size());
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t ss = 0; ss < dim_state; ++ss)
+        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, 0, ss), jacobians[0].get_entry(row, ss));
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t ss = 0; ss < dim_state; ++ss)
+          EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobians[0][row].get_entry(col, ss));
+    }
+  }
+} // ... check_set_dynamic_overloads(...)
+
+
+template <size_t r, size_t rC>
+void check_set_argument_checks(const ElementType& element)
+{
+  FixedLocalFunction<r, rC> func;
+  func.bind(element);
+  using SingleJacobianRangeType = typename FixedLocalFunction<r, rC>::SingleJacobianRangeType;
+
+  std::vector<double> values;
+  std::vector<SingleJacobianRangeType> jacobians;
+
+  EXPECT_THROW(func.evaluate(inside_point, state, values, /*row=*/r, /*col=*/0),
+               Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(func.jacobian(inside_point, state, jacobians, /*row=*/0, /*col=*/rC),
+               Common::Exceptions::shapes_do_not_match);
+
+  // assert_inside_reference_element() is what FixedLocalFunction calls at the top of evaluate()/jacobian()
+  EXPECT_THROW(func.evaluate(outside_point, state), Functions::Exceptions::wrong_input_given);
+} // ... check_set_argument_checks(...)
+
+
+TEST_F(FluxFunctionInterfaceTest, set_defaults_throw)
+{
+  check_set_defaults_throw<2, 1>(element_);
+  check_set_defaults_throw<2, 3>(element_);
+}
+
+TEST_F(FluxFunctionInterfaceTest, of_set_wrappers)
+{
+  check_of_set_wrappers<2, 1>(element_);
+  check_of_set_wrappers<2, 3>(element_);
+}
+
+TEST_F(FluxFunctionInterfaceTest, set_single_component_accessors)
+{
+  check_set_single_component_accessors<2, 1>(element_);
+  check_set_single_component_accessors<2, 3>(element_);
+}
+
+TEST_F(FluxFunctionInterfaceTest, set_dynamic_overloads)
+{
+  check_set_dynamic_overloads<2, 1>(element_);
+  check_set_dynamic_overloads<2, 3>(element_);
+}
+
+TEST_F(FluxFunctionInterfaceTest, set_argument_checks)
+{
+  check_set_argument_checks<2, 1>(element_);
+  check_set_argument_checks<2, 3>(element_);
+}
+
+
+// =========================================================================== ElementFluxFunctionInterface
+
+
+template <size_t r, size_t rC>
+void check_local_function_defaults_throw(const ElementType& element)
+{
+  ThrowingLocalFunction<r, rC> func;
+  func.bind(element);
+
+  EXPECT_THROW(func.evaluate(inside_point, state), Dune::NotImplemented);
+  EXPECT_THROW(func.jacobian(inside_point, state), Dune::NotImplemented);
+} // ... check_local_function_defaults_throw(...)
+
+
+template <size_t r, size_t rC>
+void check_local_function_single_component_accessors(const ElementType& element)
+{
+  FixedLocalFunction<r, rC> func;
+  func.bind(element);
+
+  for (size_t row = 0; row < r; ++row)
+    for (size_t col = 0; col < rC; ++col) {
+      EXPECT_DOUBLE_EQ(expected_value(0, row, col), func.evaluate(inside_point, state, row, col));
+
+      const auto jacobian = func.jacobian(inside_point, state, row, col);
+      for (size_t ss = 0; ss < dim_state; ++ss)
+        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobian[ss]);
+    }
+} // ... check_local_function_single_component_accessors(...)
+
+
+template <size_t r, size_t rC>
+void check_local_function_dynamic_overloads(const ElementType& element)
+{
+  using FunctionType = FixedLocalFunction<r, rC>;
+  FunctionType func;
+  func.bind(element);
+
+  // both results are default constructed, so the interface has to ensure_size them
+  typename FunctionType::DynamicRangeType values;
+  func.evaluate(inside_point, state, values);
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[row]);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values.get_entry(row, col));
+  }
+
+  typename FunctionType::DynamicJacobianRangeType jacobian;
+  func.jacobian(inside_point, state, jacobian);
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t ss = 0; ss < dim_state; ++ss)
+        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, 0, ss), jacobian.get_entry(row, ss));
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t ss = 0; ss < dim_state; ++ss)
+          EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobian[row].get_entry(col, ss));
+    }
+  }
+} // ... check_local_function_dynamic_overloads(...)
+
+
+TEST_F(FluxFunctionInterfaceTest, local_function_defaults_throw)
+{
+  check_local_function_defaults_throw<2, 1>(element_);
+  check_local_function_defaults_throw<2, 3>(element_);
+}
+
+TEST_F(FluxFunctionInterfaceTest, local_function_single_component_accessors)
+{
+  check_local_function_single_component_accessors<2, 1>(element_);
+  check_local_function_single_component_accessors<2, 3>(element_);
+}
+
+TEST_F(FluxFunctionInterfaceTest, local_function_dynamic_overloads)
+{
+  check_local_function_dynamic_overloads<2, 1>(element_);
+  check_local_function_dynamic_overloads<2, 3>(element_);
+}
+
+
+// ==================================================================================== FluxFunctionInterface
+
+
+template <size_t r, size_t rC>
+void check_flux_function_defaults(const ElementType& element)
+{
+  const MinimalFluxFunction<r, rC> flux;
+
+  // both are interface defaults a concrete flux function is expected to override
+  EXPECT_TRUE(flux.x_dependent());
+  EXPECT_EQ(std::string("dune.xt.functions.fluxfunction"), flux.name());
+
+  auto local_function = flux.local_function();
+  ASSERT_NE(local_function, nullptr);
+  local_function->bind(element);
+  EXPECT_DOUBLE_EQ(expected_value(0, 0, 0), local_function->evaluate(inside_point, state, 0, 0));
+} // ... check_flux_function_defaults(...)
+
+
+TEST_F(FluxFunctionInterfaceTest, flux_function_defaults)
+{
+  check_flux_function_defaults<2, 1>(element_);
+  check_flux_function_defaults<2, 3>(element_);
+}
+
+
+} // namespace

--- a/dune/xt/test/functions/element_flux_function_interface.cc
+++ b/dune/xt/test/functions/element_flux_function_interface.cc
@@ -31,9 +31,7 @@
 #include <string>
 #include <vector>
 
-#include <dune/xt/grid/grids.hh>
-#include <dune/xt/grid/gridprovider/cube.hh>
-#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/test/functions/interface_fixture.hh>
 
 #include <dune/xt/functions/exceptions.hh>
 #include <dune/xt/functions/interfaces/element-flux-functions.hh>
@@ -42,31 +40,16 @@
 using namespace Dune;
 using namespace Dune::XT;
 using namespace Dune::XT::Functions;
+using namespace Dune::XT::Test;
 
 namespace {
 
 
-using GridType = CUBEGRID_2D;
-using ElementType = XT::Grid::extract_entity_t<GridType>;
-constexpr size_t dim_domain = GridType::dimension;
+using ElementType = FunctionInterfaceTestBase::ElementType;
+constexpr size_t dim_domain = FunctionInterfaceTestBase::dim_domain;
 constexpr size_t dim_state = dim_domain;
 
-// the reference element of a YaspGrid cube is [0, 1]^d
-const FieldVector<double, dim_domain> inside_point(0.25);
-const FieldVector<double, dim_domain> outside_point(1.5);
 const FieldVector<double, dim_state> state(0.5);
-
-
-/// \brief Deterministic, pairwise distinct values, so every accessed component can be identified in an assertion.
-double expected_value(const size_t function_index, const size_t row, const size_t col)
-{
-  return 100. * function_index + 10. * row + col + 1.;
-}
-
-double expected_jacobian(const size_t function_index, const size_t row, const size_t col, const size_t ss)
-{
-  return 1000. * function_index + 100. * row + 10. * col + ss + 1.;
-}
 
 
 /// \brief Implements only the three pure virtuals, so every "should be implemented" method still throws.
@@ -130,35 +113,16 @@ public:
                            const Common::Parameter& /*param*/ = {}) const override
   {
     this->assert_inside_reference_element(point_in_reference_element);
-    RangeReturnType result;
-    for (size_t row = 0; row < r; ++row) {
-      if constexpr (rC == 1)
-        result[row] = expected_value(0, row, 0);
-      else
-        for (size_t col = 0; col < rC; ++col)
-          result[row][col] = expected_value(0, row, col);
-    }
-    return result;
-  } // ... evaluate(...)
+    return filled_range<r, rC, RangeReturnType>(0);
+  }
 
   JacobianRangeReturnType jacobian(const DomainType& point_in_reference_element,
                                    const StateType& /*u*/,
                                    const Common::Parameter& /*param*/ = {}) const override
   {
     this->assert_inside_reference_element(point_in_reference_element);
-    JacobianRangeReturnType result;
-    for (size_t row = 0; row < r; ++row) {
-      if constexpr (rC == 1) {
-        for (size_t ss = 0; ss < s; ++ss)
-          result[row][ss] = expected_jacobian(0, row, 0, ss);
-      } else {
-        for (size_t col = 0; col < rC; ++col)
-          for (size_t ss = 0; ss < s; ++ss)
-            result[row][col][ss] = expected_jacobian(0, row, col, ss);
-      }
-    }
-    return result;
-  } // ... jacobian(...)
+    return filled_derivative<r, rC, s, JacobianRangeReturnType>(0);
+  }
 };
 
 
@@ -178,23 +142,8 @@ public:
 };
 
 
-struct FluxFunctionInterfaceTest : public ::testing::Test
-{
-  using GridProviderType = XT::Grid::GridProvider<GridType>;
-
-  FluxFunctionInterfaceTest()
-    : grid_(XT::Grid::make_cube_grid<GridType>(0., 1., 2))
-    , leaf_view_(grid_.leaf_view())
-    // which element we bind to is irrelevant: everything under test here is element independent, it merely requires
-    // the object to be bound at all
-    , element_(*elements(leaf_view_).begin())
-  {
-  }
-
-  const GridProviderType grid_;
-  const typename GridProviderType::LeafGridViewType leaf_view_;
-  const ElementType element_;
-}; // struct FluxFunctionInterfaceTest
+struct FluxFunctionInterfaceTest : public FunctionInterfaceTestBase
+{};
 
 
 // ======================================================================== ElementFluxFunctionSetInterface
@@ -209,11 +158,11 @@ void check_set_defaults_throw(const ElementType& element)
   std::vector<typename ThrowingSet<r, rC>::RangeType> values;
   std::vector<typename ThrowingSet<r, rC>::JacobianRangeType> jacobians;
 
-  EXPECT_THROW(set.evaluate(inside_point, state, values), Dune::NotImplemented);
-  EXPECT_THROW(set.jacobian(inside_point, state, jacobians), Dune::NotImplemented);
+  EXPECT_THROW(set.evaluate(inside_point(), state, values), Dune::NotImplemented);
+  EXPECT_THROW(set.jacobian(inside_point(), state, jacobians), Dune::NotImplemented);
   // the convenience wrappers forward to the same defaults
-  EXPECT_THROW(set.evaluate_set(inside_point, state), Dune::NotImplemented);
-  EXPECT_THROW(set.jacobian_of_set(inside_point, state), Dune::NotImplemented);
+  EXPECT_THROW(set.evaluate_set(inside_point(), state), Dune::NotImplemented);
+  EXPECT_THROW(set.jacobian_of_set(inside_point(), state), Dune::NotImplemented);
 } // ... check_set_defaults_throw(...)
 
 
@@ -227,28 +176,13 @@ void check_of_set_wrappers(const ElementType& element)
   EXPECT_EQ(1u, func.size());
   EXPECT_EQ(1u, func.max_size());
 
-  const auto values = func.evaluate_set(inside_point, state);
+  const auto values = func.evaluate_set(inside_point(), state);
   ASSERT_EQ(1u, values.size());
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1)
-      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[0][row]);
-    else
-      for (size_t col = 0; col < rC; ++col)
-        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0][row][col]);
-  }
+  expect_range_eq<r, rC>(values[0], 0);
 
-  const auto jacobians = func.jacobian_of_set(inside_point, state);
+  const auto jacobians = func.jacobian_of_set(inside_point(), state);
   ASSERT_EQ(1u, jacobians.size());
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1) {
-      for (size_t ss = 0; ss < dim_state; ++ss)
-        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, 0, ss), jacobians[0][row][ss]);
-    } else {
-      for (size_t col = 0; col < rC; ++col)
-        for (size_t ss = 0; ss < dim_state; ++ss)
-          EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobians[0][row][col][ss]);
-    }
-  }
+  expect_derivative_eq<r, rC, dim_state>(jacobians[0], 0);
 } // ... check_of_set_wrappers(...)
 
 
@@ -263,15 +197,15 @@ void check_set_single_component_accessors(const ElementType& element)
     for (size_t col = 0; col < rC; ++col) {
       // both results are deliberately left empty, to also cover the interface's resize path
       std::vector<double> values;
-      func.evaluate(inside_point, state, values, row, col);
+      func.evaluate(inside_point(), state, values, row, col);
       ASSERT_EQ(1u, values.size());
       EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0]);
 
       std::vector<SingleJacobianRangeType> jacobians;
-      func.jacobian(inside_point, state, jacobians, row, col);
+      func.jacobian(inside_point(), state, jacobians, row, col);
       ASSERT_EQ(1u, jacobians.size());
       for (size_t ss = 0; ss < dim_state; ++ss)
-        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobians[0][ss]);
+        EXPECT_DOUBLE_EQ(expected_derivative(0, row, col, ss), jacobians[0][ss]);
     }
 } // ... check_set_single_component_accessors(...)
 
@@ -286,29 +220,14 @@ void check_set_dynamic_overloads(const ElementType& element)
 
   // both results are deliberately left empty, so the interface has to resize and ensure_size the entries
   std::vector<DynamicRangeType> values;
-  func.evaluate(inside_point, state, values);
+  func.evaluate(inside_point(), state, values);
   ASSERT_EQ(1u, values.size());
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1)
-      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[0][row]);
-    else
-      for (size_t col = 0; col < rC; ++col)
-        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0].get_entry(row, col));
-  }
+  expect_dynamic_range_eq<r, rC>(values[0], 0);
 
   std::vector<DynamicJacobianRangeType> jacobians;
-  func.jacobian(inside_point, state, jacobians);
+  func.jacobian(inside_point(), state, jacobians);
   ASSERT_EQ(1u, jacobians.size());
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1) {
-      for (size_t ss = 0; ss < dim_state; ++ss)
-        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, 0, ss), jacobians[0].get_entry(row, ss));
-    } else {
-      for (size_t col = 0; col < rC; ++col)
-        for (size_t ss = 0; ss < dim_state; ++ss)
-          EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobians[0][row].get_entry(col, ss));
-    }
-  }
+  expect_dynamic_derivative_eq<r, rC, dim_state>(jacobians[0], 0);
 } // ... check_set_dynamic_overloads(...)
 
 
@@ -322,13 +241,13 @@ void check_set_argument_checks(const ElementType& element)
   std::vector<double> values;
   std::vector<SingleJacobianRangeType> jacobians;
 
-  EXPECT_THROW(func.evaluate(inside_point, state, values, /*row=*/r, /*col=*/0),
+  EXPECT_THROW(func.evaluate(inside_point(), state, values, /*row=*/r, /*col=*/0),
                Common::Exceptions::shapes_do_not_match);
-  EXPECT_THROW(func.jacobian(inside_point, state, jacobians, /*row=*/0, /*col=*/rC),
+  EXPECT_THROW(func.jacobian(inside_point(), state, jacobians, /*row=*/0, /*col=*/rC),
                Common::Exceptions::shapes_do_not_match);
 
   // assert_inside_reference_element() is what FixedLocalFunction calls at the top of evaluate()/jacobian()
-  EXPECT_THROW(func.evaluate(outside_point, state), Functions::Exceptions::wrong_input_given);
+  EXPECT_THROW(func.evaluate(outside_point(), state), Functions::Exceptions::wrong_input_given);
 } // ... check_set_argument_checks(...)
 
 
@@ -372,8 +291,8 @@ void check_local_function_defaults_throw(const ElementType& element)
   ThrowingLocalFunction<r, rC> func;
   func.bind(element);
 
-  EXPECT_THROW(func.evaluate(inside_point, state), Dune::NotImplemented);
-  EXPECT_THROW(func.jacobian(inside_point, state), Dune::NotImplemented);
+  EXPECT_THROW(func.evaluate(inside_point(), state), Dune::NotImplemented);
+  EXPECT_THROW(func.jacobian(inside_point(), state), Dune::NotImplemented);
 } // ... check_local_function_defaults_throw(...)
 
 
@@ -385,11 +304,11 @@ void check_local_function_single_component_accessors(const ElementType& element)
 
   for (size_t row = 0; row < r; ++row)
     for (size_t col = 0; col < rC; ++col) {
-      EXPECT_DOUBLE_EQ(expected_value(0, row, col), func.evaluate(inside_point, state, row, col));
+      EXPECT_DOUBLE_EQ(expected_value(0, row, col), func.evaluate(inside_point(), state, row, col));
 
-      const auto jacobian = func.jacobian(inside_point, state, row, col);
+      const auto jacobian = func.jacobian(inside_point(), state, row, col);
       for (size_t ss = 0; ss < dim_state; ++ss)
-        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobian[ss]);
+        EXPECT_DOUBLE_EQ(expected_derivative(0, row, col, ss), jacobian[ss]);
     }
 } // ... check_local_function_single_component_accessors(...)
 
@@ -403,27 +322,12 @@ void check_local_function_dynamic_overloads(const ElementType& element)
 
   // both results are default constructed, so the interface has to ensure_size them
   typename FunctionType::DynamicRangeType values;
-  func.evaluate(inside_point, state, values);
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1)
-      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[row]);
-    else
-      for (size_t col = 0; col < rC; ++col)
-        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values.get_entry(row, col));
-  }
+  func.evaluate(inside_point(), state, values);
+  expect_dynamic_range_eq<r, rC>(values, 0);
 
   typename FunctionType::DynamicJacobianRangeType jacobian;
-  func.jacobian(inside_point, state, jacobian);
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1) {
-      for (size_t ss = 0; ss < dim_state; ++ss)
-        EXPECT_DOUBLE_EQ(expected_jacobian(0, row, 0, ss), jacobian.get_entry(row, ss));
-    } else {
-      for (size_t col = 0; col < rC; ++col)
-        for (size_t ss = 0; ss < dim_state; ++ss)
-          EXPECT_DOUBLE_EQ(expected_jacobian(0, row, col, ss), jacobian[row].get_entry(col, ss));
-    }
-  }
+  func.jacobian(inside_point(), state, jacobian);
+  expect_dynamic_derivative_eq<r, rC, dim_state>(jacobian, 0);
 } // ... check_local_function_dynamic_overloads(...)
 
 
@@ -461,7 +365,7 @@ void check_flux_function_defaults(const ElementType& element)
   auto local_function = flux.local_function();
   ASSERT_NE(local_function, nullptr);
   local_function->bind(element);
-  EXPECT_DOUBLE_EQ(expected_value(0, 0, 0), local_function->evaluate(inside_point, state, 0, 0));
+  EXPECT_DOUBLE_EQ(expected_value(0, 0, 0), local_function->evaluate(inside_point(), state, 0, 0));
 } // ... check_flux_function_defaults(...)
 
 

--- a/dune/xt/test/functions/element_function_interface.cc
+++ b/dune/xt/test/functions/element_function_interface.cc
@@ -227,21 +227,24 @@ void check_set_of_set_wrappers(const ElementType& element)
 {
   FixedSet<r, rC> set;
   set.bind(element);
+  // hoisted into a local: passing FixedSet<r, rC>::set_size straight to ASSERT_EQ would let the preprocessor
+  // split the macro arguments at the comma inside the template argument list
+  constexpr size_t set_size = FixedSet<r, rC>::set_size;
 
   const auto values = set.evaluate_set(inside_point());
-  ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
+  ASSERT_EQ(set_size, values.size());
   for (size_t ii = 0; ii < values.size(); ++ii)
     expect_range_eq<r, rC>(values[ii], ii);
 
   const auto jacobians = set.jacobians_of_set(inside_point());
-  ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
+  ASSERT_EQ(set_size, jacobians.size());
   for (size_t ii = 0; ii < jacobians.size(); ++ii)
     expect_derivative_eq<r, rC, dim_domain>(jacobians[ii], ii);
 
   // derivatives_of_set() sizes the result from size() and forwards to derivatives(), whose default forwards the
   // all-ones multi-index to jacobians() -- so this has to reproduce the jacobian values
   const auto derivatives = set.derivatives_of_set(first_derivative_multiindex(), inside_point());
-  ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
+  ASSERT_EQ(set_size, derivatives.size());
   for (size_t ii = 0; ii < derivatives.size(); ++ii)
     expect_derivative_eq<r, rC, dim_domain>(derivatives[ii], ii);
 } // ... check_set_of_set_wrappers(...)
@@ -252,6 +255,9 @@ void check_set_single_component_accessors(const ElementType& element)
 {
   FixedSet<r, rC> set;
   set.bind(element);
+  // hoisted into a local: passing FixedSet<r, rC>::set_size straight to ASSERT_EQ would let the preprocessor
+  // split the macro arguments at the comma inside the template argument list
+  constexpr size_t set_size = FixedSet<r, rC>::set_size;
   using SingleDerivativeRangeType = typename FixedSet<r, rC>::SingleDerivativeRangeType;
 
   for (size_t row = 0; row < r; ++row)
@@ -259,17 +265,17 @@ void check_set_single_component_accessors(const ElementType& element)
       // all three results are deliberately left empty, to also cover the interface's resize path
       std::vector<double> values;
       set.evaluate(inside_point(), values, row, col);
-      ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
+      ASSERT_EQ(set_size, values.size());
       for (size_t ii = 0; ii < values.size(); ++ii)
         EXPECT_DOUBLE_EQ(expected_value(ii, row, col), values[ii]);
 
       std::vector<SingleDerivativeRangeType> jacobians;
       set.jacobians(inside_point(), jacobians, row, col);
-      ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
+      ASSERT_EQ(set_size, jacobians.size());
 
       std::vector<SingleDerivativeRangeType> derivatives;
       set.derivatives(first_derivative_multiindex(), inside_point(), derivatives, row, col);
-      ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
+      ASSERT_EQ(set_size, derivatives.size());
 
       for (size_t ii = 0; ii < jacobians.size(); ++ii)
         for (size_t dd = 0; dd < dim_domain; ++dd) {
@@ -285,25 +291,28 @@ void check_set_dynamic_overloads(const ElementType& element)
 {
   FixedSet<r, rC> set;
   set.bind(element);
+  // hoisted into a local: passing FixedSet<r, rC>::set_size straight to ASSERT_EQ would let the preprocessor
+  // split the macro arguments at the comma inside the template argument list
+  constexpr size_t set_size = FixedSet<r, rC>::set_size;
   using DynamicRangeType = typename FixedSet<r, rC>::DynamicRangeType;
   using DynamicDerivativeRangeType = typename FixedSet<r, rC>::DynamicDerivativeRangeType;
 
   // all results are deliberately left empty, so the interface has to resize and ensure_size the entries
   std::vector<DynamicRangeType> values;
   set.evaluate(inside_point(), values);
-  ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
+  ASSERT_EQ(set_size, values.size());
   for (size_t ii = 0; ii < values.size(); ++ii)
     expect_dynamic_range_eq<r, rC>(values[ii], ii);
 
   std::vector<DynamicDerivativeRangeType> jacobians;
   set.jacobians(inside_point(), jacobians);
-  ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
+  ASSERT_EQ(set_size, jacobians.size());
   for (size_t ii = 0; ii < jacobians.size(); ++ii)
     expect_dynamic_derivative_eq<r, rC, dim_domain>(jacobians[ii], ii);
 
   std::vector<DynamicDerivativeRangeType> derivatives;
   set.derivatives(first_derivative_multiindex(), inside_point(), derivatives);
-  ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
+  ASSERT_EQ(set_size, derivatives.size());
   for (size_t ii = 0; ii < derivatives.size(); ++ii)
     expect_dynamic_derivative_eq<r, rC, dim_domain>(derivatives[ii], ii);
 } // ... check_set_dynamic_overloads(...)

--- a/dune/xt/test/functions/element_function_interface.cc
+++ b/dune/xt/test/functions/element_function_interface.cc
@@ -25,9 +25,7 @@
 #include <array>
 #include <vector>
 
-#include <dune/xt/grid/grids.hh>
-#include <dune/xt/grid/gridprovider/cube.hh>
-#include <dune/xt/grid/type_traits.hh>
+#include <dune/xt/test/functions/interface_fixture.hh>
 
 #include <dune/xt/functions/exceptions.hh>
 #include <dune/xt/functions/interfaces/element-functions.hh>
@@ -35,42 +33,24 @@
 using namespace Dune;
 using namespace Dune::XT;
 using namespace Dune::XT::Functions;
+using namespace Dune::XT::Test;
 
 namespace {
 
 
-using GridType = CUBEGRID_2D;
-using ElementType = XT::Grid::extract_entity_t<GridType>;
-constexpr size_t dim_domain = GridType::dimension;
+using ElementType = FunctionInterfaceTestBase::ElementType;
+constexpr size_t dim_domain = FunctionInterfaceTestBase::dim_domain;
 
-// the reference element of a YaspGrid cube is [0, 1]^d
-const FieldVector<double, dim_domain> inside_point(0.25);
-const FieldVector<double, dim_domain> outside_point(1.5);
-
-
-/// \brief Deterministic, pairwise distinct values, so every accessed component can be identified in an assertion.
-double expected_value(const size_t function_index, const size_t row, const size_t col)
-{
-  return 100. * function_index + 10. * row + col + 1.;
-}
-
-double expected_derivative(const size_t function_index, const size_t row, const size_t col, const size_t dd)
-{
-  return 1000. * function_index + 100. * row + 10. * col + dd + 1.;
-}
-
+/// \brief The all-ones multi-index, which the interface defaults forward to jacobian(s)().
 std::array<size_t, dim_domain> first_derivative_multiindex()
 {
-  std::array<size_t, dim_domain> alpha;
-  alpha.fill(1);
-  return alpha;
+  return multiindex(1);
 }
 
+/// \brief Any other multi-index, which the interface defaults reject.
 std::array<size_t, dim_domain> higher_derivative_multiindex()
 {
-  std::array<size_t, dim_domain> alpha;
-  alpha.fill(2);
-  return alpha;
+  return multiindex(2);
 }
 
 
@@ -136,15 +116,10 @@ public:
     this->assert_inside_reference_element(point_in_reference_element);
     if (result.size() < set_size)
       result.resize(set_size);
+    // the set's ii-th function reports the values of function_index ii
     for (size_t ii = 0; ii < set_size; ++ii)
-      for (size_t row = 0; row < r; ++row) {
-        if constexpr (rC == 1)
-          result[ii][row] = expected_value(ii, row, 0);
-        else
-          for (size_t col = 0; col < rC; ++col)
-            result[ii][row][col] = expected_value(ii, row, col);
-      }
-  } // ... evaluate(...)
+      result[ii] = filled_range<r, rC, RangeType>(ii);
+  }
 
   void jacobians(const DomainType& point_in_reference_element,
                  std::vector<DerivativeRangeType>& result,
@@ -154,17 +129,8 @@ public:
     if (result.size() < set_size)
       result.resize(set_size);
     for (size_t ii = 0; ii < set_size; ++ii)
-      for (size_t row = 0; row < r; ++row) {
-        if constexpr (rC == 1) {
-          for (size_t dd = 0; dd < d; ++dd)
-            result[ii][row][dd] = expected_derivative(ii, row, 0, dd);
-        } else {
-          for (size_t col = 0; col < rC; ++col)
-            for (size_t dd = 0; dd < d; ++dd)
-              result[ii][row][col][dd] = expected_derivative(ii, row, col, dd);
-        }
-      }
-  } // ... jacobians(...)
+      result[ii] = filled_derivative<r, rC, d, DerivativeRangeType>(ii);
+  }
 };
 
 
@@ -211,22 +177,14 @@ public:
                            const Common::Parameter& /*param*/ = {}) const override
   {
     this->assert_inside_reference_element(point_in_reference_element);
-    RangeReturnType result;
-    for (size_t row = 0; row < r; ++row) {
-      if constexpr (rC == 1)
-        result[row] = expected_value(0, row, 0);
-      else
-        for (size_t col = 0; col < rC; ++col)
-          result[row][col] = expected_value(0, row, col);
-    }
-    return result;
-  } // ... evaluate(...)
+    return filled_range<r, rC, RangeReturnType>(0);
+  }
 
   DerivativeRangeReturnType jacobian(const DomainType& point_in_reference_element,
                                      const Common::Parameter& /*param*/ = {}) const override
   {
     this->assert_inside_reference_element(point_in_reference_element);
-    return filled_derivative(jacobian_index);
+    return filled_derivative<r, rC, d, DerivativeRangeReturnType>(jacobian_index);
   }
 
   DerivativeRangeReturnType derivative(const std::array<size_t, d>& /*alpha*/,
@@ -234,61 +192,13 @@ public:
                                        const Common::Parameter& /*param*/ = {}) const override
   {
     this->assert_inside_reference_element(point_in_reference_element);
-    return filled_derivative(derivative_index);
+    return filled_derivative<r, rC, d, DerivativeRangeReturnType>(derivative_index);
   }
-
-  static DerivativeRangeReturnType filled_derivative(const size_t function_index)
-  {
-    DerivativeRangeReturnType result;
-    for (size_t row = 0; row < r; ++row) {
-      if constexpr (rC == 1) {
-        for (size_t dd = 0; dd < d; ++dd)
-          result[row][dd] = expected_derivative(function_index, row, 0, dd);
-      } else {
-        for (size_t col = 0; col < rC; ++col)
-          for (size_t dd = 0; dd < d; ++dd)
-            result[row][col][dd] = expected_derivative(function_index, row, col, dd);
-      }
-    }
-    return result;
-  } // ... filled_derivative(...)
 };
 
 
-/// \brief Component-wise check of a (set of) DerivativeRangeType against expected_derivative().
-template <size_t r, size_t rC, class DerivativeType>
-void expect_derivative_eq(const DerivativeType& actual, const size_t function_index)
-{
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1) {
-      for (size_t dd = 0; dd < dim_domain; ++dd)
-        EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, 0, dd), actual[row][dd]);
-    } else {
-      for (size_t col = 0; col < rC; ++col)
-        for (size_t dd = 0; dd < dim_domain; ++dd)
-          EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, col, dd), actual[row][col][dd]);
-    }
-  }
-} // ... expect_derivative_eq(...)
-
-
-struct ElementFunctionInterfaceTest : public ::testing::Test
-{
-  using GridProviderType = XT::Grid::GridProvider<GridType>;
-
-  ElementFunctionInterfaceTest()
-    : grid_(XT::Grid::make_cube_grid<GridType>(0., 1., 2))
-    , leaf_view_(grid_.leaf_view())
-    // which element we bind to is irrelevant: everything under test here is element independent, it merely requires
-    // the object to be bound at all
-    , element_(*elements(leaf_view_).begin())
-  {
-  }
-
-  const GridProviderType grid_;
-  const typename GridProviderType::LeafGridViewType leaf_view_;
-  const ElementType element_;
-}; // struct ElementFunctionInterfaceTest
+struct ElementFunctionInterfaceTest : public FunctionInterfaceTestBase
+{};
 
 
 // ============================================================================ ElementFunctionSetInterface
@@ -303,12 +213,12 @@ void check_set_defaults_throw(const ElementType& element)
   std::vector<typename ThrowingSet<r, rC>::RangeType> values;
   std::vector<typename ThrowingSet<r, rC>::DerivativeRangeType> derivatives;
 
-  EXPECT_THROW(set.evaluate(inside_point, values), Dune::NotImplemented);
-  EXPECT_THROW(set.jacobians(inside_point, derivatives), Dune::NotImplemented);
+  EXPECT_THROW(set.evaluate(inside_point(), values), Dune::NotImplemented);
+  EXPECT_THROW(set.jacobians(inside_point(), derivatives), Dune::NotImplemented);
   // the default derivatives() forwards the all-ones multi-index to jacobians(), which throws in turn ...
-  EXPECT_THROW(set.derivatives(first_derivative_multiindex(), inside_point, derivatives), Dune::NotImplemented);
+  EXPECT_THROW(set.derivatives(first_derivative_multiindex(), inside_point(), derivatives), Dune::NotImplemented);
   // ... and rejects any other multi-index itself
-  EXPECT_THROW(set.derivatives(higher_derivative_multiindex(), inside_point, derivatives), Dune::NotImplemented);
+  EXPECT_THROW(set.derivatives(higher_derivative_multiindex(), inside_point(), derivatives), Dune::NotImplemented);
 } // ... check_set_defaults_throw(...)
 
 
@@ -318,28 +228,22 @@ void check_set_of_set_wrappers(const ElementType& element)
   FixedSet<r, rC> set;
   set.bind(element);
 
-  const auto values = set.evaluate_set(inside_point);
+  const auto values = set.evaluate_set(inside_point());
   ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
   for (size_t ii = 0; ii < values.size(); ++ii)
-    for (size_t row = 0; row < r; ++row) {
-      if constexpr (rC == 1)
-        EXPECT_DOUBLE_EQ(expected_value(ii, row, 0), values[ii][row]);
-      else
-        for (size_t col = 0; col < rC; ++col)
-          EXPECT_DOUBLE_EQ(expected_value(ii, row, col), values[ii][row][col]);
-    }
+    expect_range_eq<r, rC>(values[ii], ii);
 
-  const auto jacobians = set.jacobians_of_set(inside_point);
+  const auto jacobians = set.jacobians_of_set(inside_point());
   ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
   for (size_t ii = 0; ii < jacobians.size(); ++ii)
-    expect_derivative_eq<r, rC>(jacobians[ii], ii);
+    expect_derivative_eq<r, rC, dim_domain>(jacobians[ii], ii);
 
   // derivatives_of_set() sizes the result from size() and forwards to derivatives(), whose default forwards the
   // all-ones multi-index to jacobians() -- so this has to reproduce the jacobian values
-  const auto derivatives = set.derivatives_of_set(first_derivative_multiindex(), inside_point);
+  const auto derivatives = set.derivatives_of_set(first_derivative_multiindex(), inside_point());
   ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
   for (size_t ii = 0; ii < derivatives.size(); ++ii)
-    expect_derivative_eq<r, rC>(derivatives[ii], ii);
+    expect_derivative_eq<r, rC, dim_domain>(derivatives[ii], ii);
 } // ... check_set_of_set_wrappers(...)
 
 
@@ -354,24 +258,24 @@ void check_set_single_component_accessors(const ElementType& element)
     for (size_t col = 0; col < rC; ++col) {
       // all three results are deliberately left empty, to also cover the interface's resize path
       std::vector<double> values;
-      set.evaluate(inside_point, values, row, col);
+      set.evaluate(inside_point(), values, row, col);
       ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
       for (size_t ii = 0; ii < values.size(); ++ii)
         EXPECT_DOUBLE_EQ(expected_value(ii, row, col), values[ii]);
 
       std::vector<SingleDerivativeRangeType> jacobians;
-      set.jacobians(inside_point, jacobians, row, col);
+      set.jacobians(inside_point(), jacobians, row, col);
       ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
-      for (size_t ii = 0; ii < jacobians.size(); ++ii)
-        for (size_t dd = 0; dd < dim_domain; ++dd)
-          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), jacobians[ii][dd]);
 
       std::vector<SingleDerivativeRangeType> derivatives;
-      set.derivatives(first_derivative_multiindex(), inside_point, derivatives, row, col);
+      set.derivatives(first_derivative_multiindex(), inside_point(), derivatives, row, col);
       ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
-      for (size_t ii = 0; ii < derivatives.size(); ++ii)
-        for (size_t dd = 0; dd < dim_domain; ++dd)
+
+      for (size_t ii = 0; ii < jacobians.size(); ++ii)
+        for (size_t dd = 0; dd < dim_domain; ++dd) {
+          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), jacobians[ii][dd]);
           EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), derivatives[ii][dd]);
+        }
     }
 } // ... check_set_single_component_accessors(...)
 
@@ -386,40 +290,22 @@ void check_set_dynamic_overloads(const ElementType& element)
 
   // all results are deliberately left empty, so the interface has to resize and ensure_size the entries
   std::vector<DynamicRangeType> values;
-  set.evaluate(inside_point, values);
+  set.evaluate(inside_point(), values);
   ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
   for (size_t ii = 0; ii < values.size(); ++ii)
-    for (size_t row = 0; row < r; ++row) {
-      if constexpr (rC == 1)
-        EXPECT_DOUBLE_EQ(expected_value(ii, row, 0), values[ii][row]);
-      else
-        for (size_t col = 0; col < rC; ++col)
-          EXPECT_DOUBLE_EQ(expected_value(ii, row, col), values[ii].get_entry(row, col));
-    }
+    expect_dynamic_range_eq<r, rC>(values[ii], ii);
 
   std::vector<DynamicDerivativeRangeType> jacobians;
-  set.jacobians(inside_point, jacobians);
+  set.jacobians(inside_point(), jacobians);
   ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
+  for (size_t ii = 0; ii < jacobians.size(); ++ii)
+    expect_dynamic_derivative_eq<r, rC, dim_domain>(jacobians[ii], ii);
 
   std::vector<DynamicDerivativeRangeType> derivatives;
-  set.derivatives(first_derivative_multiindex(), inside_point, derivatives);
+  set.derivatives(first_derivative_multiindex(), inside_point(), derivatives);
   ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
-
-  for (size_t ii = 0; ii < jacobians.size(); ++ii)
-    for (size_t row = 0; row < r; ++row) {
-      if constexpr (rC == 1) {
-        for (size_t dd = 0; dd < dim_domain; ++dd) {
-          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, 0, dd), jacobians[ii].get_entry(row, dd));
-          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, 0, dd), derivatives[ii].get_entry(row, dd));
-        }
-      } else {
-        for (size_t col = 0; col < rC; ++col)
-          for (size_t dd = 0; dd < dim_domain; ++dd) {
-            EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), jacobians[ii][row].get_entry(col, dd));
-            EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), derivatives[ii][row].get_entry(col, dd));
-          }
-      }
-    }
+  for (size_t ii = 0; ii < derivatives.size(); ++ii)
+    expect_dynamic_derivative_eq<r, rC, dim_domain>(derivatives[ii], ii);
 } // ... check_set_dynamic_overloads(...)
 
 
@@ -433,15 +319,15 @@ void check_set_argument_checks(const ElementType& element)
   std::vector<double> values;
   std::vector<SingleDerivativeRangeType> derivatives;
 
-  EXPECT_THROW(set.evaluate(inside_point, values, /*row=*/r, /*col=*/0), Common::Exceptions::shapes_do_not_match);
-  EXPECT_THROW(set.jacobians(inside_point, derivatives, /*row=*/0, /*col=*/rC),
+  EXPECT_THROW(set.evaluate(inside_point(), values, /*row=*/r, /*col=*/0), Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(set.jacobians(inside_point(), derivatives, /*row=*/0, /*col=*/rC),
                Common::Exceptions::shapes_do_not_match);
-  EXPECT_THROW(set.derivatives(first_derivative_multiindex(), inside_point, derivatives, /*row=*/r, /*col=*/0),
+  EXPECT_THROW(set.derivatives(first_derivative_multiindex(), inside_point(), derivatives, /*row=*/r, /*col=*/0),
                Common::Exceptions::shapes_do_not_match);
 
   // assert_inside_reference_element() is what FixedSet calls at the top of evaluate()/jacobians()
   std::vector<typename FixedSet<r, rC>::RangeType> range_values;
-  EXPECT_THROW(set.evaluate(outside_point, range_values), Functions::Exceptions::wrong_input_given);
+  EXPECT_THROW(set.evaluate(outside_point(), range_values), Functions::Exceptions::wrong_input_given);
 } // ... check_set_argument_checks(...)
 
 
@@ -485,9 +371,9 @@ void check_function_defaults_throw(const ElementType& element)
   ThrowingFunction<r, rC> func;
   func.bind(element);
 
-  EXPECT_THROW(func.evaluate(inside_point), Dune::NotImplemented);
-  EXPECT_THROW(func.jacobian(inside_point), Dune::NotImplemented);
-  EXPECT_THROW(func.derivative(first_derivative_multiindex(), inside_point), Dune::NotImplemented);
+  EXPECT_THROW(func.evaluate(inside_point()), Dune::NotImplemented);
+  EXPECT_THROW(func.jacobian(inside_point()), Dune::NotImplemented);
+  EXPECT_THROW(func.derivative(first_derivative_multiindex(), inside_point()), Dune::NotImplemented);
 } // ... check_function_defaults_throw(...)
 
 
@@ -504,26 +390,20 @@ void check_function_set_bridge(const ElementType& element)
 
   // the set-flavoured methods have to forward to the single-valued ones; all results are deliberately left empty
   std::vector<typename FunctionType::RangeType> values;
-  func.evaluate(inside_point, values);
+  func.evaluate(inside_point(), values);
   ASSERT_EQ(1u, values.size());
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1)
-      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[0][row]);
-    else
-      for (size_t col = 0; col < rC; ++col)
-        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0][row][col]);
-  }
+  expect_range_eq<r, rC>(values[0], 0);
 
   std::vector<typename FunctionType::DerivativeRangeType> jacobians;
-  func.jacobians(inside_point, jacobians);
+  func.jacobians(inside_point(), jacobians);
   ASSERT_EQ(1u, jacobians.size());
-  expect_derivative_eq<r, rC>(jacobians[0], FunctionType::jacobian_index);
+  expect_derivative_eq<r, rC, dim_domain>(jacobians[0], FunctionType::jacobian_index);
 
   std::vector<typename FunctionType::DerivativeRangeType> derivatives;
-  func.derivatives(first_derivative_multiindex(), inside_point, derivatives);
+  func.derivatives(first_derivative_multiindex(), inside_point(), derivatives);
   ASSERT_EQ(1u, derivatives.size());
   // derivative() reports different values than jacobian(), so this confirms which one was dispatched to
-  expect_derivative_eq<r, rC>(derivatives[0], FunctionType::derivative_index);
+  expect_derivative_eq<r, rC, dim_domain>(derivatives[0], FunctionType::derivative_index);
 } // ... check_function_set_bridge(...)
 
 
@@ -536,15 +416,14 @@ void check_function_single_component_accessors(const ElementType& element)
 
   for (size_t row = 0; row < r; ++row)
     for (size_t col = 0; col < rC; ++col) {
-      EXPECT_DOUBLE_EQ(expected_value(0, row, col), func.evaluate(inside_point, row, col));
+      EXPECT_DOUBLE_EQ(expected_value(0, row, col), func.evaluate(inside_point(), row, col));
 
-      const auto jacobian = func.jacobian(inside_point, row, col);
-      for (size_t dd = 0; dd < dim_domain; ++dd)
+      const auto jacobian = func.jacobian(inside_point(), row, col);
+      const auto derivative = func.derivative(first_derivative_multiindex(), inside_point(), row, col);
+      for (size_t dd = 0; dd < dim_domain; ++dd) {
         EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::jacobian_index, row, col, dd), jacobian[dd]);
-
-      const auto derivative = func.derivative(first_derivative_multiindex(), inside_point, row, col);
-      for (size_t dd = 0; dd < dim_domain; ++dd)
         EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::derivative_index, row, col, dd), derivative[dd]);
+      }
     }
 } // ... check_function_single_component_accessors(...)
 
@@ -558,36 +437,16 @@ void check_function_dynamic_overloads(const ElementType& element)
 
   // all results are default constructed, so the interface has to ensure_size them
   typename FunctionType::DynamicRangeType values;
-  func.evaluate(inside_point, values);
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1)
-      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[row]);
-    else
-      for (size_t col = 0; col < rC; ++col)
-        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values.get_entry(row, col));
-  }
+  func.evaluate(inside_point(), values);
+  expect_dynamic_range_eq<r, rC>(values, 0);
 
   typename FunctionType::DynamicDerivativeRangeType jacobian;
-  func.jacobian(inside_point, jacobian);
+  func.jacobian(inside_point(), jacobian);
+  expect_dynamic_derivative_eq<r, rC, dim_domain>(jacobian, FunctionType::jacobian_index);
+
   typename FunctionType::DynamicDerivativeRangeType derivative;
-  func.derivative(first_derivative_multiindex(), inside_point, derivative);
-  for (size_t row = 0; row < r; ++row) {
-    if constexpr (rC == 1) {
-      for (size_t dd = 0; dd < dim_domain; ++dd) {
-        EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::jacobian_index, row, 0, dd), jacobian.get_entry(row, dd));
-        EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::derivative_index, row, 0, dd),
-                         derivative.get_entry(row, dd));
-      }
-    } else {
-      for (size_t col = 0; col < rC; ++col)
-        for (size_t dd = 0; dd < dim_domain; ++dd) {
-          EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::jacobian_index, row, col, dd),
-                           jacobian[row].get_entry(col, dd));
-          EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::derivative_index, row, col, dd),
-                           derivative[row].get_entry(col, dd));
-        }
-    }
-  }
+  func.derivative(first_derivative_multiindex(), inside_point(), derivative);
+  expect_dynamic_derivative_eq<r, rC, dim_domain>(derivative, FunctionType::derivative_index);
 } // ... check_function_dynamic_overloads(...)
 
 
@@ -597,12 +456,12 @@ void check_function_argument_checks(const ElementType& element)
   FixedFunction<r, rC> func;
   func.bind(element);
 
-  EXPECT_THROW(func.evaluate(inside_point, /*row=*/r, /*col=*/0), Common::Exceptions::shapes_do_not_match);
-  EXPECT_THROW(func.jacobian(inside_point, /*row=*/0, /*col=*/rC), Common::Exceptions::shapes_do_not_match);
-  EXPECT_THROW(func.derivative(first_derivative_multiindex(), inside_point, /*row=*/r, /*col=*/0),
+  EXPECT_THROW(func.evaluate(inside_point(), /*row=*/r, /*col=*/0), Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(func.jacobian(inside_point(), /*row=*/0, /*col=*/rC), Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(func.derivative(first_derivative_multiindex(), inside_point(), /*row=*/r, /*col=*/0),
                Common::Exceptions::shapes_do_not_match);
 
-  EXPECT_THROW(func.evaluate(outside_point), Functions::Exceptions::wrong_input_given);
+  EXPECT_THROW(func.evaluate(outside_point()), Functions::Exceptions::wrong_input_given);
 } // ... check_function_argument_checks(...)
 
 

--- a/dune/xt/test/functions/element_function_interface.cc
+++ b/dune/xt/test/functions/element_function_interface.cc
@@ -1,0 +1,640 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-xt developers
+
+/// \file
+/// \brief Tests the default implementations provided by ElementFunctionSetInterface and ElementFunctionInterface.
+///
+/// The concrete implementations in dune/xt/functions override the "should be implemented" virtuals, which means the
+/// convenience layers the interfaces provide on top of them (the single-component accessors, the dynamic-container
+/// overloads, the argument checks and the NotImplemented defaults) are never exercised by a test of a concrete
+/// function. The minimal subclasses below override exactly as much as each test needs and leave the rest to the
+/// interface, so those layers are reached.
+
+#ifndef DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS
+#  define DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS 1
+#endif
+
+#include <dune/xt/test/main.hxx> // <- has to come first, includes the config.h!
+
+#include <array>
+#include <vector>
+
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <dune/xt/functions/exceptions.hh>
+#include <dune/xt/functions/interfaces/element-functions.hh>
+
+using namespace Dune;
+using namespace Dune::XT;
+using namespace Dune::XT::Functions;
+
+namespace {
+
+
+using GridType = CUBEGRID_2D;
+using ElementType = XT::Grid::extract_entity_t<GridType>;
+constexpr size_t dim_domain = GridType::dimension;
+
+// the reference element of a YaspGrid cube is [0, 1]^d
+const FieldVector<double, dim_domain> inside_point(0.25);
+const FieldVector<double, dim_domain> outside_point(1.5);
+
+
+/// \brief Deterministic, pairwise distinct values, so every accessed component can be identified in an assertion.
+double expected_value(const size_t function_index, const size_t row, const size_t col)
+{
+  return 100. * function_index + 10. * row + col + 1.;
+}
+
+double expected_derivative(const size_t function_index, const size_t row, const size_t col, const size_t dd)
+{
+  return 1000. * function_index + 100. * row + 10. * col + dd + 1.;
+}
+
+std::array<size_t, dim_domain> first_derivative_multiindex()
+{
+  std::array<size_t, dim_domain> alpha;
+  alpha.fill(1);
+  return alpha;
+}
+
+std::array<size_t, dim_domain> higher_derivative_multiindex()
+{
+  std::array<size_t, dim_domain> alpha;
+  alpha.fill(2);
+  return alpha;
+}
+
+
+/// \brief Implements only the three pure virtuals, so every "should be implemented" method still throws.
+template <size_t r, size_t rC>
+class ThrowingSet : public ElementFunctionSetInterface<ElementType, r, rC>
+{
+public:
+  size_t size(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 1;
+  }
+
+  size_t max_size(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 1;
+  }
+
+  int order(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 0;
+  }
+};
+
+
+/// \brief Implements evaluate() and jacobians() only; everything else is served by the interface.
+template <size_t r, size_t rC>
+class FixedSet : public ElementFunctionSetInterface<ElementType, r, rC>
+{
+  using BaseType = ElementFunctionSetInterface<ElementType, r, rC>;
+
+public:
+  using BaseType::d;
+  using typename BaseType::DerivativeRangeType;
+  using typename BaseType::DomainType;
+  using typename BaseType::RangeType;
+
+  // overriding one overload hides the others, and those are exactly what is under test here
+  using BaseType::evaluate;
+  using BaseType::jacobians;
+
+  static constexpr size_t set_size = 2;
+
+  size_t size(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return set_size;
+  }
+
+  size_t max_size(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return set_size;
+  }
+
+  int order(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 0;
+  }
+
+  void evaluate(const DomainType& point_in_reference_element,
+                std::vector<RangeType>& result,
+                const Common::Parameter& /*param*/ = {}) const override
+  {
+    this->assert_inside_reference_element(point_in_reference_element);
+    if (result.size() < set_size)
+      result.resize(set_size);
+    for (size_t ii = 0; ii < set_size; ++ii)
+      for (size_t row = 0; row < r; ++row) {
+        if constexpr (rC == 1)
+          result[ii][row] = expected_value(ii, row, 0);
+        else
+          for (size_t col = 0; col < rC; ++col)
+            result[ii][row][col] = expected_value(ii, row, col);
+      }
+  } // ... evaluate(...)
+
+  void jacobians(const DomainType& point_in_reference_element,
+                 std::vector<DerivativeRangeType>& result,
+                 const Common::Parameter& /*param*/ = {}) const override
+  {
+    this->assert_inside_reference_element(point_in_reference_element);
+    if (result.size() < set_size)
+      result.resize(set_size);
+    for (size_t ii = 0; ii < set_size; ++ii)
+      for (size_t row = 0; row < r; ++row) {
+        if constexpr (rC == 1) {
+          for (size_t dd = 0; dd < d; ++dd)
+            result[ii][row][dd] = expected_derivative(ii, row, 0, dd);
+        } else {
+          for (size_t col = 0; col < rC; ++col)
+            for (size_t dd = 0; dd < d; ++dd)
+              result[ii][row][col][dd] = expected_derivative(ii, row, col, dd);
+        }
+      }
+  } // ... jacobians(...)
+};
+
+
+/// \brief Implements only order(), so evaluate()/jacobian()/derivative() still throw.
+template <size_t r, size_t rC>
+class ThrowingFunction : public ElementFunctionInterface<ElementType, r, rC>
+{
+public:
+  int order(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 0;
+  }
+};
+
+
+/// \brief Implements the three single-valued methods only; everything else is served by the interface.
+template <size_t r, size_t rC>
+class FixedFunction : public ElementFunctionInterface<ElementType, r, rC>
+{
+  using BaseType = ElementFunctionInterface<ElementType, r, rC>;
+
+public:
+  using BaseType::d;
+  using typename BaseType::DerivativeRangeReturnType;
+  using typename BaseType::DomainType;
+  using typename BaseType::RangeReturnType;
+
+  // overriding one overload hides the others, and those are exactly what is under test here
+  using BaseType::derivative;
+  using BaseType::evaluate;
+  using BaseType::jacobian;
+
+  /// \note jacobian() reports the values of function_index 0, derivative() those of 1, so the tests below can tell
+  ///       which of the two an interface method dispatched to.
+  static constexpr size_t jacobian_index = 0;
+  static constexpr size_t derivative_index = 1;
+
+  int order(const Common::Parameter& /*param*/ = {}) const override
+  {
+    return 0;
+  }
+
+  RangeReturnType evaluate(const DomainType& point_in_reference_element,
+                           const Common::Parameter& /*param*/ = {}) const override
+  {
+    this->assert_inside_reference_element(point_in_reference_element);
+    RangeReturnType result;
+    for (size_t row = 0; row < r; ++row) {
+      if constexpr (rC == 1)
+        result[row] = expected_value(0, row, 0);
+      else
+        for (size_t col = 0; col < rC; ++col)
+          result[row][col] = expected_value(0, row, col);
+    }
+    return result;
+  } // ... evaluate(...)
+
+  DerivativeRangeReturnType jacobian(const DomainType& point_in_reference_element,
+                                     const Common::Parameter& /*param*/ = {}) const override
+  {
+    this->assert_inside_reference_element(point_in_reference_element);
+    return filled_derivative(jacobian_index);
+  }
+
+  DerivativeRangeReturnType derivative(const std::array<size_t, d>& /*alpha*/,
+                                       const DomainType& point_in_reference_element,
+                                       const Common::Parameter& /*param*/ = {}) const override
+  {
+    this->assert_inside_reference_element(point_in_reference_element);
+    return filled_derivative(derivative_index);
+  }
+
+  static DerivativeRangeReturnType filled_derivative(const size_t function_index)
+  {
+    DerivativeRangeReturnType result;
+    for (size_t row = 0; row < r; ++row) {
+      if constexpr (rC == 1) {
+        for (size_t dd = 0; dd < d; ++dd)
+          result[row][dd] = expected_derivative(function_index, row, 0, dd);
+      } else {
+        for (size_t col = 0; col < rC; ++col)
+          for (size_t dd = 0; dd < d; ++dd)
+            result[row][col][dd] = expected_derivative(function_index, row, col, dd);
+      }
+    }
+    return result;
+  } // ... filled_derivative(...)
+};
+
+
+/// \brief Component-wise check of a (set of) DerivativeRangeType against expected_derivative().
+template <size_t r, size_t rC, class DerivativeType>
+void expect_derivative_eq(const DerivativeType& actual, const size_t function_index)
+{
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t dd = 0; dd < dim_domain; ++dd)
+        EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, 0, dd), actual[row][dd]);
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t dd = 0; dd < dim_domain; ++dd)
+          EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, col, dd), actual[row][col][dd]);
+    }
+  }
+} // ... expect_derivative_eq(...)
+
+
+struct ElementFunctionInterfaceTest : public ::testing::Test
+{
+  using GridProviderType = XT::Grid::GridProvider<GridType>;
+
+  ElementFunctionInterfaceTest()
+    : grid_(XT::Grid::make_cube_grid<GridType>(0., 1., 2))
+    , leaf_view_(grid_.leaf_view())
+    // which element we bind to is irrelevant: everything under test here is element independent, it merely requires
+    // the object to be bound at all
+    , element_(*elements(leaf_view_).begin())
+  {
+  }
+
+  const GridProviderType grid_;
+  const typename GridProviderType::LeafGridViewType leaf_view_;
+  const ElementType element_;
+}; // struct ElementFunctionInterfaceTest
+
+
+// ============================================================================ ElementFunctionSetInterface
+
+
+template <size_t r, size_t rC>
+void check_set_defaults_throw(const ElementType& element)
+{
+  ThrowingSet<r, rC> set;
+  set.bind(element);
+
+  std::vector<typename ThrowingSet<r, rC>::RangeType> values;
+  std::vector<typename ThrowingSet<r, rC>::DerivativeRangeType> derivatives;
+
+  EXPECT_THROW(set.evaluate(inside_point, values), Dune::NotImplemented);
+  EXPECT_THROW(set.jacobians(inside_point, derivatives), Dune::NotImplemented);
+  // the default derivatives() forwards the all-ones multi-index to jacobians(), which throws in turn ...
+  EXPECT_THROW(set.derivatives(first_derivative_multiindex(), inside_point, derivatives), Dune::NotImplemented);
+  // ... and rejects any other multi-index itself
+  EXPECT_THROW(set.derivatives(higher_derivative_multiindex(), inside_point, derivatives), Dune::NotImplemented);
+} // ... check_set_defaults_throw(...)
+
+
+template <size_t r, size_t rC>
+void check_set_of_set_wrappers(const ElementType& element)
+{
+  FixedSet<r, rC> set;
+  set.bind(element);
+
+  const auto values = set.evaluate_set(inside_point);
+  ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
+  for (size_t ii = 0; ii < values.size(); ++ii)
+    for (size_t row = 0; row < r; ++row) {
+      if constexpr (rC == 1)
+        EXPECT_DOUBLE_EQ(expected_value(ii, row, 0), values[ii][row]);
+      else
+        for (size_t col = 0; col < rC; ++col)
+          EXPECT_DOUBLE_EQ(expected_value(ii, row, col), values[ii][row][col]);
+    }
+
+  const auto jacobians = set.jacobians_of_set(inside_point);
+  ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
+  for (size_t ii = 0; ii < jacobians.size(); ++ii)
+    expect_derivative_eq<r, rC>(jacobians[ii], ii);
+
+  // derivatives_of_set() sizes the result from size() and forwards to derivatives(), whose default forwards the
+  // all-ones multi-index to jacobians() -- so this has to reproduce the jacobian values
+  const auto derivatives = set.derivatives_of_set(first_derivative_multiindex(), inside_point);
+  ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
+  for (size_t ii = 0; ii < derivatives.size(); ++ii)
+    expect_derivative_eq<r, rC>(derivatives[ii], ii);
+} // ... check_set_of_set_wrappers(...)
+
+
+template <size_t r, size_t rC>
+void check_set_single_component_accessors(const ElementType& element)
+{
+  FixedSet<r, rC> set;
+  set.bind(element);
+  using SingleDerivativeRangeType = typename FixedSet<r, rC>::SingleDerivativeRangeType;
+
+  for (size_t row = 0; row < r; ++row)
+    for (size_t col = 0; col < rC; ++col) {
+      // all three results are deliberately left empty, to also cover the interface's resize path
+      std::vector<double> values;
+      set.evaluate(inside_point, values, row, col);
+      ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
+      for (size_t ii = 0; ii < values.size(); ++ii)
+        EXPECT_DOUBLE_EQ(expected_value(ii, row, col), values[ii]);
+
+      std::vector<SingleDerivativeRangeType> jacobians;
+      set.jacobians(inside_point, jacobians, row, col);
+      ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
+      for (size_t ii = 0; ii < jacobians.size(); ++ii)
+        for (size_t dd = 0; dd < dim_domain; ++dd)
+          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), jacobians[ii][dd]);
+
+      std::vector<SingleDerivativeRangeType> derivatives;
+      set.derivatives(first_derivative_multiindex(), inside_point, derivatives, row, col);
+      ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
+      for (size_t ii = 0; ii < derivatives.size(); ++ii)
+        for (size_t dd = 0; dd < dim_domain; ++dd)
+          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), derivatives[ii][dd]);
+    }
+} // ... check_set_single_component_accessors(...)
+
+
+template <size_t r, size_t rC>
+void check_set_dynamic_overloads(const ElementType& element)
+{
+  FixedSet<r, rC> set;
+  set.bind(element);
+  using DynamicRangeType = typename FixedSet<r, rC>::DynamicRangeType;
+  using DynamicDerivativeRangeType = typename FixedSet<r, rC>::DynamicDerivativeRangeType;
+
+  // all results are deliberately left empty, so the interface has to resize and ensure_size the entries
+  std::vector<DynamicRangeType> values;
+  set.evaluate(inside_point, values);
+  ASSERT_EQ(FixedSet<r, rC>::set_size, values.size());
+  for (size_t ii = 0; ii < values.size(); ++ii)
+    for (size_t row = 0; row < r; ++row) {
+      if constexpr (rC == 1)
+        EXPECT_DOUBLE_EQ(expected_value(ii, row, 0), values[ii][row]);
+      else
+        for (size_t col = 0; col < rC; ++col)
+          EXPECT_DOUBLE_EQ(expected_value(ii, row, col), values[ii].get_entry(row, col));
+    }
+
+  std::vector<DynamicDerivativeRangeType> jacobians;
+  set.jacobians(inside_point, jacobians);
+  ASSERT_EQ(FixedSet<r, rC>::set_size, jacobians.size());
+
+  std::vector<DynamicDerivativeRangeType> derivatives;
+  set.derivatives(first_derivative_multiindex(), inside_point, derivatives);
+  ASSERT_EQ(FixedSet<r, rC>::set_size, derivatives.size());
+
+  for (size_t ii = 0; ii < jacobians.size(); ++ii)
+    for (size_t row = 0; row < r; ++row) {
+      if constexpr (rC == 1) {
+        for (size_t dd = 0; dd < dim_domain; ++dd) {
+          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, 0, dd), jacobians[ii].get_entry(row, dd));
+          EXPECT_DOUBLE_EQ(expected_derivative(ii, row, 0, dd), derivatives[ii].get_entry(row, dd));
+        }
+      } else {
+        for (size_t col = 0; col < rC; ++col)
+          for (size_t dd = 0; dd < dim_domain; ++dd) {
+            EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), jacobians[ii][row].get_entry(col, dd));
+            EXPECT_DOUBLE_EQ(expected_derivative(ii, row, col, dd), derivatives[ii][row].get_entry(col, dd));
+          }
+      }
+    }
+} // ... check_set_dynamic_overloads(...)
+
+
+template <size_t r, size_t rC>
+void check_set_argument_checks(const ElementType& element)
+{
+  FixedSet<r, rC> set;
+  set.bind(element);
+  using SingleDerivativeRangeType = typename FixedSet<r, rC>::SingleDerivativeRangeType;
+
+  std::vector<double> values;
+  std::vector<SingleDerivativeRangeType> derivatives;
+
+  EXPECT_THROW(set.evaluate(inside_point, values, /*row=*/r, /*col=*/0), Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(set.jacobians(inside_point, derivatives, /*row=*/0, /*col=*/rC),
+               Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(set.derivatives(first_derivative_multiindex(), inside_point, derivatives, /*row=*/r, /*col=*/0),
+               Common::Exceptions::shapes_do_not_match);
+
+  // assert_inside_reference_element() is what FixedSet calls at the top of evaluate()/jacobians()
+  std::vector<typename FixedSet<r, rC>::RangeType> range_values;
+  EXPECT_THROW(set.evaluate(outside_point, range_values), Functions::Exceptions::wrong_input_given);
+} // ... check_set_argument_checks(...)
+
+
+TEST_F(ElementFunctionInterfaceTest, set_defaults_throw)
+{
+  check_set_defaults_throw<2, 1>(element_);
+  check_set_defaults_throw<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, set_of_set_wrappers)
+{
+  check_set_of_set_wrappers<2, 1>(element_);
+  check_set_of_set_wrappers<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, set_single_component_accessors)
+{
+  check_set_single_component_accessors<2, 1>(element_);
+  check_set_single_component_accessors<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, set_dynamic_overloads)
+{
+  check_set_dynamic_overloads<2, 1>(element_);
+  check_set_dynamic_overloads<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, set_argument_checks)
+{
+  check_set_argument_checks<2, 1>(element_);
+  check_set_argument_checks<2, 3>(element_);
+}
+
+
+// =============================================================================== ElementFunctionInterface
+
+
+template <size_t r, size_t rC>
+void check_function_defaults_throw(const ElementType& element)
+{
+  ThrowingFunction<r, rC> func;
+  func.bind(element);
+
+  EXPECT_THROW(func.evaluate(inside_point), Dune::NotImplemented);
+  EXPECT_THROW(func.jacobian(inside_point), Dune::NotImplemented);
+  EXPECT_THROW(func.derivative(first_derivative_multiindex(), inside_point), Dune::NotImplemented);
+} // ... check_function_defaults_throw(...)
+
+
+template <size_t r, size_t rC>
+void check_function_set_bridge(const ElementType& element)
+{
+  using FunctionType = FixedFunction<r, rC>;
+  FunctionType func;
+  func.bind(element);
+
+  // a single function is a set of size one
+  EXPECT_EQ(1u, func.size());
+  EXPECT_EQ(1u, func.max_size());
+
+  // the set-flavoured methods have to forward to the single-valued ones; all results are deliberately left empty
+  std::vector<typename FunctionType::RangeType> values;
+  func.evaluate(inside_point, values);
+  ASSERT_EQ(1u, values.size());
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[0][row]);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values[0][row][col]);
+  }
+
+  std::vector<typename FunctionType::DerivativeRangeType> jacobians;
+  func.jacobians(inside_point, jacobians);
+  ASSERT_EQ(1u, jacobians.size());
+  expect_derivative_eq<r, rC>(jacobians[0], FunctionType::jacobian_index);
+
+  std::vector<typename FunctionType::DerivativeRangeType> derivatives;
+  func.derivatives(first_derivative_multiindex(), inside_point, derivatives);
+  ASSERT_EQ(1u, derivatives.size());
+  // derivative() reports different values than jacobian(), so this confirms which one was dispatched to
+  expect_derivative_eq<r, rC>(derivatives[0], FunctionType::derivative_index);
+} // ... check_function_set_bridge(...)
+
+
+template <size_t r, size_t rC>
+void check_function_single_component_accessors(const ElementType& element)
+{
+  using FunctionType = FixedFunction<r, rC>;
+  FunctionType func;
+  func.bind(element);
+
+  for (size_t row = 0; row < r; ++row)
+    for (size_t col = 0; col < rC; ++col) {
+      EXPECT_DOUBLE_EQ(expected_value(0, row, col), func.evaluate(inside_point, row, col));
+
+      const auto jacobian = func.jacobian(inside_point, row, col);
+      for (size_t dd = 0; dd < dim_domain; ++dd)
+        EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::jacobian_index, row, col, dd), jacobian[dd]);
+
+      const auto derivative = func.derivative(first_derivative_multiindex(), inside_point, row, col);
+      for (size_t dd = 0; dd < dim_domain; ++dd)
+        EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::derivative_index, row, col, dd), derivative[dd]);
+    }
+} // ... check_function_single_component_accessors(...)
+
+
+template <size_t r, size_t rC>
+void check_function_dynamic_overloads(const ElementType& element)
+{
+  using FunctionType = FixedFunction<r, rC>;
+  FunctionType func;
+  func.bind(element);
+
+  // all results are default constructed, so the interface has to ensure_size them
+  typename FunctionType::DynamicRangeType values;
+  func.evaluate(inside_point, values);
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      EXPECT_DOUBLE_EQ(expected_value(0, row, 0), values[row]);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        EXPECT_DOUBLE_EQ(expected_value(0, row, col), values.get_entry(row, col));
+  }
+
+  typename FunctionType::DynamicDerivativeRangeType jacobian;
+  func.jacobian(inside_point, jacobian);
+  typename FunctionType::DynamicDerivativeRangeType derivative;
+  func.derivative(first_derivative_multiindex(), inside_point, derivative);
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t dd = 0; dd < dim_domain; ++dd) {
+        EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::jacobian_index, row, 0, dd), jacobian.get_entry(row, dd));
+        EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::derivative_index, row, 0, dd),
+                         derivative.get_entry(row, dd));
+      }
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t dd = 0; dd < dim_domain; ++dd) {
+          EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::jacobian_index, row, col, dd),
+                           jacobian[row].get_entry(col, dd));
+          EXPECT_DOUBLE_EQ(expected_derivative(FunctionType::derivative_index, row, col, dd),
+                           derivative[row].get_entry(col, dd));
+        }
+    }
+  }
+} // ... check_function_dynamic_overloads(...)
+
+
+template <size_t r, size_t rC>
+void check_function_argument_checks(const ElementType& element)
+{
+  FixedFunction<r, rC> func;
+  func.bind(element);
+
+  EXPECT_THROW(func.evaluate(inside_point, /*row=*/r, /*col=*/0), Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(func.jacobian(inside_point, /*row=*/0, /*col=*/rC), Common::Exceptions::shapes_do_not_match);
+  EXPECT_THROW(func.derivative(first_derivative_multiindex(), inside_point, /*row=*/r, /*col=*/0),
+               Common::Exceptions::shapes_do_not_match);
+
+  EXPECT_THROW(func.evaluate(outside_point), Functions::Exceptions::wrong_input_given);
+} // ... check_function_argument_checks(...)
+
+
+TEST_F(ElementFunctionInterfaceTest, function_defaults_throw)
+{
+  check_function_defaults_throw<2, 1>(element_);
+  check_function_defaults_throw<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, function_set_bridge)
+{
+  check_function_set_bridge<2, 1>(element_);
+  check_function_set_bridge<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, function_single_component_accessors)
+{
+  check_function_single_component_accessors<2, 1>(element_);
+  check_function_single_component_accessors<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, function_dynamic_overloads)
+{
+  check_function_dynamic_overloads<2, 1>(element_);
+  check_function_dynamic_overloads<2, 3>(element_);
+}
+
+TEST_F(ElementFunctionInterfaceTest, function_argument_checks)
+{
+  check_function_argument_checks<2, 1>(element_);
+  check_function_argument_checks<2, 3>(element_);
+}
+
+
+} // namespace

--- a/dune/xt/test/functions/interface_fixture.hh
+++ b/dune/xt/test/functions/interface_fixture.hh
@@ -1,0 +1,194 @@
+// This file is part of the dune-xt project:
+//   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+// Copyright 2009-2021 dune-xt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-xt developers
+
+/// \file
+/// \brief Shared scaffolding for the tests of the function and flux function interfaces.
+///
+/// element_function_interface.cc and element_flux_function_interface.cc both need a grid, one element to bind to and
+/// the same deterministic expectation values; keeping that here rather than in both files avoids duplicating it.
+
+#ifndef DUNE_XT_TEST_FUNCTIONS_INTERFACE_FIXTURE_HH
+#define DUNE_XT_TEST_FUNCTIONS_INTERFACE_FIXTURE_HH
+
+#include <array>
+#include <cstddef>
+
+#include <dune/common/fvector.hh>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/grid/gridprovider/provider.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/type_traits.hh>
+
+#include <gtest/gtest.h>
+
+namespace Dune::XT::Test {
+
+
+/// \brief Provides a cube grid and one element of it, bindable by any of the element (flux) function interfaces.
+struct FunctionInterfaceTestBase : public ::testing::Test
+{
+  using GridType = CUBEGRID_2D;
+  using GridProviderType = Grid::GridProvider<GridType>;
+  using ElementType = Grid::extract_entity_t<GridType>;
+  static constexpr size_t dim_domain = GridType::dimension;
+  using DomainType = FieldVector<double, dim_domain>;
+
+  FunctionInterfaceTestBase()
+    : grid_(Grid::make_cube_grid<GridType>(0., 1., 2))
+    , leaf_view_(grid_.leaf_view())
+    // which element we bind to is irrelevant: everything under test is element independent, it merely requires the
+    // object to be bound at all
+    , element_(*elements(leaf_view_).begin())
+  {
+  }
+
+  const GridProviderType grid_;
+  const typename GridProviderType::LeafGridViewType leaf_view_;
+  const ElementType element_;
+}; // struct FunctionInterfaceTestBase
+
+
+/// \brief A point inside the reference element of a cube, which is [0, 1]^d.
+inline FunctionInterfaceTestBase::DomainType inside_point()
+{
+  return FunctionInterfaceTestBase::DomainType(0.25);
+}
+
+/// \brief A point outside that reference element, to trip assert_inside_reference_element().
+inline FunctionInterfaceTestBase::DomainType outside_point()
+{
+  return FunctionInterfaceTestBase::DomainType(1.5);
+}
+
+/// \brief Deterministic, pairwise distinct values, so every accessed component can be identified in an assertion.
+inline double expected_value(const size_t function_index, const size_t row, const size_t col)
+{
+  return 100. * function_index + 10. * row + col + 1.;
+}
+
+/// \brief As expected_value(), for a derivative/jacobian component in direction dd.
+inline double expected_derivative(const size_t function_index, const size_t row, const size_t col, const size_t dd)
+{
+  return 1000. * function_index + 100. * row + 10. * col + dd + 1.;
+}
+
+/// \brief The multi-index (value, ..., value), used to pick the derivative order.
+inline std::array<size_t, FunctionInterfaceTestBase::dim_domain> multiindex(const size_t value)
+{
+  std::array<size_t, FunctionInterfaceTestBase::dim_domain> alpha;
+  alpha.fill(value);
+  return alpha;
+}
+
+
+/**
+ * \name Filling and checking the range/derivative containers.
+ *
+ * A range is indexed [row] for rC == 1 and [row][col] otherwise; a derivative appends the direction, [row][dd] resp.
+ * [row][col][dd]. Both shapes are shared between the plain function and the flux function interfaces -- the latter
+ * only differ in that the trailing dimension of a derivative is the state dimension rather than the domain dimension,
+ * which is what the `dim` parameter stands for. The dynamic_* variants take the same shapes in the dynamic containers,
+ * where the innermost two indices become a get_entry(...) call.
+ * \{
+ */
+
+template <size_t r, size_t rC, class RangeType>
+RangeType filled_range(const size_t function_index)
+{
+  RangeType result;
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      result[row] = expected_value(function_index, row, 0);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        result[row][col] = expected_value(function_index, row, col);
+  }
+  return result;
+} // ... filled_range(...)
+
+template <size_t r, size_t rC, size_t dim, class DerivativeRangeType>
+DerivativeRangeType filled_derivative(const size_t function_index)
+{
+  DerivativeRangeType result;
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t dd = 0; dd < dim; ++dd)
+        result[row][dd] = expected_derivative(function_index, row, 0, dd);
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t dd = 0; dd < dim; ++dd)
+          result[row][col][dd] = expected_derivative(function_index, row, col, dd);
+    }
+  }
+  return result;
+} // ... filled_derivative(...)
+
+template <size_t r, size_t rC, class RangeType>
+void expect_range_eq(const RangeType& actual, const size_t function_index)
+{
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      EXPECT_DOUBLE_EQ(expected_value(function_index, row, 0), actual[row]);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        EXPECT_DOUBLE_EQ(expected_value(function_index, row, col), actual[row][col]);
+  }
+} // ... expect_range_eq(...)
+
+template <size_t r, size_t rC, class DynamicRangeType>
+void expect_dynamic_range_eq(const DynamicRangeType& actual, const size_t function_index)
+{
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1)
+      EXPECT_DOUBLE_EQ(expected_value(function_index, row, 0), actual[row]);
+    else
+      for (size_t col = 0; col < rC; ++col)
+        EXPECT_DOUBLE_EQ(expected_value(function_index, row, col), actual.get_entry(row, col));
+  }
+} // ... expect_dynamic_range_eq(...)
+
+template <size_t r, size_t rC, size_t dim, class DerivativeRangeType>
+void expect_derivative_eq(const DerivativeRangeType& actual, const size_t function_index)
+{
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t dd = 0; dd < dim; ++dd)
+        EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, 0, dd), actual[row][dd]);
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t dd = 0; dd < dim; ++dd)
+          EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, col, dd), actual[row][col][dd]);
+    }
+  }
+} // ... expect_derivative_eq(...)
+
+template <size_t r, size_t rC, size_t dim, class DynamicDerivativeRangeType>
+void expect_dynamic_derivative_eq(const DynamicDerivativeRangeType& actual, const size_t function_index)
+{
+  for (size_t row = 0; row < r; ++row) {
+    if constexpr (rC == 1) {
+      for (size_t dd = 0; dd < dim; ++dd)
+        EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, 0, dd), actual.get_entry(row, dd));
+    } else {
+      for (size_t col = 0; col < rC; ++col)
+        for (size_t dd = 0; dd < dim; ++dd)
+          EXPECT_DOUBLE_EQ(expected_derivative(function_index, row, col, dd), actual[row].get_entry(col, dd));
+    }
+  }
+} // ... expect_dynamic_derivative_eq(...)
+
+/// \}
+
+
+} // namespace Dune::XT::Test
+
+#endif // DUNE_XT_TEST_FUNCTIONS_INTERFACE_FIXTURE_HH


### PR DESCRIPTION
Part of #341. Raises coverage of `dune/xt/functions/interfaces`, the worst directory in the `dune/xt/functions` subtree.

## Why

Codecov (v2 API, `main`) puts `dune/xt/functions/interfaces` at **24.45%** — 499 lines, 371 missed:

| file | coverage | missed |
|---|---:|---:|
| `interfaces/element-flux-functions.hh` | **5.15%** | 129 |
| `interfaces/element-functions.hh` | **20.56%** | 169 |
| `interfaces/function.hh` | 30.23% | 60 |
| `interfaces/flux-function.hh` | 33.33% | 6 |
| `interfaces/grid-function.hh` | 77.78% | 7 |

The line-level report shows the misses are not exotic paths. They are almost entirely the layers the interfaces provide *on top of* whatever a concrete function implements:

- the `DUNE_THROW(NotImplemented, …)` bodies every "should be implemented" virtual carries,
- the single-component accessors — `evaluate(x, row, col)`, `jacobian(…)`, `derivative(alpha, …, row, col)` — and the `single_*_helper*` dispatch behind them,
- the `Dynamic{Range,DerivativeRange}Type` overloads that `ensure_size`/`convert` into dynamic containers,
- `assert_correct_dims` and `assert_inside_reference_element` (`DUNE_XT_FUNCTIONS_DISABLE_CHECKS` is never defined anywhere in the build, so the checked variants are compiled in — Codecov reports those lines as *missed*, not absent),
- the `size()`/`max_size()`/vector-bridging adapters that make a single element function behave as a set of size one.

None of it is reachable from a test of a concrete function: every implementation in `dune/xt/functions` overrides the "should be implemented" virtuals, and `GenericElementFunction*` / `GenericFluxFunction` mark them `final`.

## What

Two new test binaries, built on minimal subclasses that override exactly as much as each case needs and leave the rest to the interface:

- **`dune/xt/test/functions/element_function_interface.cc`** — `ElementFunctionSetInterface`, `ElementFunctionInterface`
- **`dune/xt/test/functions/element_flux_function_interface.cc`** — `ElementFluxFunctionSetInterface`, `ElementFluxFunctionInterface`, `FluxFunctionInterface`

Four small classes per file: a `Throwing*` one implementing only the pure virtuals (so the `NotImplemented` defaults fire), and a `Fixed*` one implementing only the "should be implemented" methods (so everything layered above them runs for real).

Both files:

- instantiate at `rC == 1` **and** `rC == 3`, so both `if constexpr` branches of every accessor and helper are taken;
- pass deliberately empty result containers, to reach the `resize` / `ensure_size` paths;
- **assert on values**, not just that an expression compiles. The existing `*_interface_operators.cc` files in this directory are compile-only smoke tests — that pattern is deliberately not extended here;
- use pairwise distinct values per `(function index, row, col, direction)`, so reading the wrong component fails the assertion rather than silently passing;
- have `jacobian()` and `derivative()` report *different* values, so the tests can tell which of the two an interface method dispatched to (e.g. that `derivatives_of_set` with the all-ones multi-index really lands in `jacobians`).

No CMake change is required: `add_subdir_tests(functions)` globs `*.cc` and labels the targets `dune-gdt-test`, which is what the test presets filter on.

## Not verified locally

This environment has no dune-common/dune-grid/vcpkg tree, so **the new files have not been compiled or run here** — correctness is by inspection against the interface headers. CI is the first real build. Two things a reviewer should watch for specifically:

- **overload hiding.** Overriding one `evaluate`/`jacobian`/`derivative` overload hides the rest, so each `Fixed*` class carries the matching `using BaseType::…` declarations. If any are missing or wrong, it shows up as an overload-resolution error, not a wrong result.
- **`clang-format`.** Formatted with clang-format 18; the repo pins 22 via pre-commit, so pre-commit.ci may adjust whitespace.

## Two findings surfaced while writing this, both out of scope here

1. **The `.tpl` templated test suites are dead** — all 49 of them across `dune/xt/test`. `DuneXTTesting.cmake:127` globs `${CMAKE_CURRENT_SOURCE_DIR}/${subdir}/*.tpl`, but `finalize_test_setup()` runs from `dune/CMakeLists.txt:28`, so it looks in `<src>/dune/functions/*.tpl` — a path that does not exist. Nothing is generated, built, or run. Filed as **#370** with the full analysis (two further defects would still block it even after fixing the glob) and an investigation plan. This is the single biggest lever on `dune/xt/functions` coverage and the reason `element-flux-functions.hh` sits at 5%: `generic_flux_function.tpl` is the only thing that instantiates `GenericFluxFunction`, and it never runs.

2. **Possible latent bug in the flux jacobian accessors.** `ElementFluxFunctionSetInterface` sizes its jacobian types from the *state* dimension (`JacobianRangeSelector = DerivativeRangeTypeSelector<s, …>`, so `SingleJacobianRangeType = FieldVector<R, s>`), but the matrix-valued branches of the single-component accessors iterate over the *domain* dimension `d` — `element-flux-functions.hh:255-256` and `:476-477`. When `d > s` that writes past the end of the result. These tests use `s == d` and therefore do not exercise it. Not fixed here: it is a behaviour change in library code and wants its own reasoning and test. Happy to file it separately if you agree it is a bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHDE3WDE5BwHkQVTTkUfrW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for element and flux-function interfaces.
  * Verified default behaviors, wrapper methods, component accessors, dynamic outputs, and derivative handling.
  * Added checks for expected exceptions when methods are unimplemented, inputs have invalid shapes, or points fall outside the reference element.
  * Confirmed local-function binding and deterministic evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->