### PR TITLE
xt: actually glob, generate and register the .tpl test suites (#370)

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -91,7 +91,7 @@ jobs:
         (( linux_cpu >= 2 )) || { echo "::error::linux_cpu must be >= 2 (got $linux_cpu)"; exit 1; }
         {
           # Cap compile concurrency by RAM: the GitHub-hosted runner has only
-          # 16 GB. Ordinary TUs (the library and the ~400 test binaries) peak
+          # 16 GB. Ordinary TUs (the library and the ~520 test binaries) peak
           # ~2 GB each, so cpu-1 keeps their peak RAM well under the box while
           # using all but one vCPU.
           echo "linux_build_jobs=$((linux_cpu - 1))"
@@ -99,7 +99,7 @@ jobs:
           # peak far higher (well above 4 GB each) -- building them at the shared
           # cpu-1 OOM-killed the 16 GB runner -- so give them a tighter cap.
           echo "bindings_jobs=$((linux_cpu / 2))"
-          # Tests are ~400 short, IO-light executables: oversubscribe at 2x vCPU.
+          # Tests are ~640 short, IO-light ctest entries: oversubscribe at 2x vCPU.
           echo "ctest_parallel=$((linux_cpu * 2))"
         } >> "$GITHUB_OUTPUT"
 
@@ -121,7 +121,7 @@ jobs:
     # /tmp ltrans explosion like build_wheels.
     runs-on: ubuntu-26.04
     # A fully cold leg (no build cache) compiles every vcpkg dependency as a shared
-    # library, the project, the ~400 test binaries and the Python bindings from
+    # library, the project, the ~520 test binaries and the Python bindings from
     # scratch; on the 4 vCPU hosted runner with the memory-bounded -j caps above
     # that is slower than the old self-hosted fleet, so the timeout is generous.
     # Warm runs restore the ccache and finish much faster.
@@ -161,7 +161,7 @@ jobs:
     env:
       # Compiler-level cache. Unlike the build/ cache (keyed on the vcpkg/preset
       # hash), the ccache survives manifest changes and partial rebuilds, so the
-      # 400+ test-binary translation units stay warm across runs.
+      # ~520 test-binary translation units stay warm across runs.
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_MAXSIZE: "2G"
 
@@ -246,8 +246,9 @@ jobs:
 
     - name: Build test binaries
       run: |
-        # test_binaries is ~400 separate executables, several of which are
-        # template-heavy TUs that peak around ~2 GB RAM each. Cap concurrency by
+        # test_binaries is ~520 separate executables (breakdown under "Test with
+        # CTest" below), several of which are template-heavy TUs that peak around
+        # ~2 GB RAM each. Cap concurrency by
         # memory: -j cpu-1 (linux_build_jobs from the config job) keeps peak RAM
         # (~2 GB * (cpu-1)) well under the GitHub-hosted runner (16 GB) while using
         # all but one of its vCPUs. With a warm ccache most of these are cache hits.
@@ -269,7 +270,15 @@ jobs:
       # visualisation-backed binding test has a headless display. The pytest tests
       # write coverage.py data files (coverage-xt, coverage-gdt) into the build dir
       # for the coverage_python target below. ctest_parallel (2x vCPU, from the
-      # config job) oversubscribes the ~400 short/IO-light C++ executables.
+      # config job) oversubscribes the short/IO-light C++ executables.
+      #
+      # Sizing, counted from the tree in issue #370 (the previous "~400" matched
+      # nothing countable): 123 plain hand-written .cc suites -> 123 binaries; 29
+      # meta-ini (.mini) suites -> 112 binaries and 235 ctest entries; 49 templated
+      # (.tpl) suites -> 283 generated binaries. Total ~518 executables and ~641
+      # ctest entries, before the Python suites. The .tpl share was zero until the
+      # glob bug diagnosed in that issue was fixed, so the figure this replaces
+      # predates the dune-xt/dune-gdt merge at best.
       run: |
         xvfb-run -a ctest --preset=${{ matrix.preset }} --parallel ${{ needs.config.outputs.ctest_parallel }}
 

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -124,7 +124,35 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
 
   _process_sources("${test_sources}" "${subdir}")
 
-  file(GLOB_RECURSE test_templates "${CMAKE_CURRENT_SOURCE_DIR}/${subdir}/*.tpl")
+  # Glob the templated suites relative to ${fullpath} (the full path add_subdir_tests() recorded), exactly as the .cc
+  # glob above does. This used to splice ${subdir} onto ${CMAKE_CURRENT_SOURCE_DIR}, which is dune/ here (this macro
+  # runs from finalize_test_setup(), invoked in dune/CMakeLists.txt), so it looked for dune/functions/*.tpl,
+  # dune/la/*.tpl, ... -- directories that do not exist. All 49 templated suites were silently skipped (issue #370).
+  file(GLOB_RECURSE test_templates "${fullpath}/*.tpl")
+  # Record what was picked up so finalize_test_setup() can cross-check it against the whole tree (see the guard there).
+  get_property(dxt_seen_templates GLOBAL PROPERTY dxt_seen_test_templates_prop)
+  list(APPEND dxt_seen_templates ${test_templates})
+  set_property(GLOBAL PROPERTY dxt_seen_test_templates_prop "${dxt_seen_templates}")
+
+  # Both the configure-time expansion below (CMake needs the generated file list to declare the targets) and the
+  # build-time regeneration in add_custom_command run the same command:
+  #
+  # * `uv run --no-project --with ...` supplies jinja2/pyparsing without a manually-managed venv, the same way the
+  #   coverage targets in dxt_add_python_tests() pull gcovr/coverage.py, and `--python ${Python_EXECUTABLE}` pins the
+  #   interpreter the rest of the build resolved (see the uv block in the top-level CMakeLists.txt).
+  # * PYTHONPATH points at the binary-dir assembly of the `dune.xt` package -- the symlinked sources plus the configured
+  #   _version.py that dune_pybindxi_install_python_package() and python/xt/dune/xt/CMakeLists.txt put there. The
+  #   per-suite .py configs import dune.xt.codegen / dune.xt.test.grid_types, and the source tree on its own is not
+  #   importable because dune/xt/__init__.py imports the generated _version. add_subdirectory(python) precedes
+  #   add_subdirectory(dune) in the top-level CMakeLists.txt, so the assembly exists by the time we get here.
+  #
+  # This replaces the former ${RUN_IN_ENV_SCRIPT} wrapper, which has been unset ever since the dune-testtools virtualenv
+  # was dropped (its find_program is commented out in CMakeLists.txt), and the ${PROJECT_SOURCE_DIR}/python/ scripts/
+  # path, which has never existed -- the script lives in python/xt/scripts/.
+  set(dxt_codegen_command
+      ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_BINARY_DIR}/python/xt" uv run --no-project --with jinja2 --with
+      pyparsing --python ${Python_EXECUTABLE} python ${PROJECT_SOURCE_DIR}/python/xt/scripts/dxt_code_generation.py)
+
   foreach(template ${test_templates})
     set(ranks "1")
     if(template MATCHES "mpi")
@@ -142,27 +170,26 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
       endif()
     endforeach(mod DEPENDENCIES)
 
-    # TODO dxt_code_geneartion.py should be avail in the venv when called from this target
     dune_execute_process(
       COMMAND
-      ${RUN_IN_ENV_SCRIPT}
-      ${PROJECT_SOURCE_DIR}/python/scripts/dxt_code_generation.py
+      ${dxt_codegen_command}
       "${config_fn}"
       "${template}"
       "${CMAKE_BINARY_DIR}"
       "${out_fn}"
       "${last_dep_bindir}"
       OUTPUT_VARIABLE
-      codegen_output)
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/codegen.${testbase}.log" ${codegen_output})
+      codegen_output
+      ERROR_MESSAGE
+      "failed to expand the templated test suite ${template}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/codegen.${testbase}.log" "${codegen_output}")
     file(GLOB generated_sources "${out_fn}.*")
     if("" STREQUAL "${generated_sources}")
       set(generated_sources ${out_fn})
     endif()
     add_custom_command(
       OUTPUT "${generated_sources}"
-      COMMAND ${RUN_IN_ENV_SCRIPT} ${PROJECT_SOURCE_DIR}/python/scripts/dxt_code_generation.py "${config_fn}"
-              "${template}" "${CMAKE_BINARY_DIR}" "${out_fn}" "${last_dep_bindir}"
+      COMMAND ${dxt_codegen_command} "${config_fn}" "${template}" "${CMAKE_BINARY_DIR}" "${out_fn}" "${last_dep_bindir}"
       DEPENDS "${config_fn}" "${template}"
       VERBATIM USES_TERMINAL)
     foreach(gen_source ${generated_sources})
@@ -184,29 +211,27 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
         ${COMMON_LIBS}
         ${GRID_LIBS}
         gtest_dune_xt
-        COMMAND
-        ${RUN_IN_ENV_SCRIPT}
         CMD_ARGS
-        ${CMAKE_CURRENT_BINARY_DIR}/${target}
         --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/${target}.xml
         TIMEOUT
         ${DXT_TEST_TIMEOUT}
         MPI_RANKS
-        ${ranks})
+        ${ranks}
+        LABELS
+        dune-gdt-test
+        subdir_${subdir})
       list(APPEND ${subdir}_dxt_test_binaries ${target})
       set(dxt_test_names_${target} ${target})
-      set_tests_properties(${target} PROPERTIES LABELS subdir_${subdir})
     endforeach()
   endforeach(template ${test_templates})
   add_custom_target(${subdir}_test_templates SOURCES ${test_templates})
 
-  # this excludes meta-ini variation test cases because there binary name != test name
-  foreach(test ${${subdir}_dxt_test_binaries})
-    if(TEST test)
-      set_tests_properties(${test} PROPERTIES TIMEOUT ${DXT_TEST_TIMEOUT})
-      set_tests_properties(${test} PROPERTIES LABELS subdir_${subdir})
-    endif(TEST test)
-  endforeach()
+  # A loop used to re-apply TIMEOUT and LABELS to every ${subdir}_dxt_test_binaries entry here, guarded by `if(TEST
+  # test)` -- the unexpanded literal `test`, so it asked whether a ctest test named "test" exists and the body never
+  # ran. It is gone rather than repaired: both branches above now pass TIMEOUT and the full label set (dune-gdt-test
+  # plus subdir_${subdir}) straight to dune_add_test/dune_add_system_test, and re-setting LABELS here would clobber
+  # dune-gdt-test -- the label every ctest preset filters on -- which is precisely the bug this loop's sibling at the
+  # .tpl branch caused (issue #370).
 
   add_custom_target(${subdir}_test_binaries DEPENDS ${${subdir}_dxt_test_binaries})
 
@@ -244,6 +269,22 @@ macro(FINALIZE_TEST_SETUP)
 
     list(APPEND dxt_test_binaries "${${subdir}_dxt_test_binaries}")
   endforeach()
+
+  # Regression guard for issue #370: the per-subdir *.tpl glob resolved to a non-existent path for years, so all 49
+  # templated suites were skipped without a word -- there was no counterpart to the empty-test_sources AUTHOR_WARNING in
+  # _process_subdir_tests(). Warning per subdir would fire for every dune/gdt/test subdir (none of which has templates),
+  # so the check is made once, here: every *.tpl file in the module must have been picked up by one of the per-subdir
+  # globs. This also catches a suite added under a directory nobody passed to add_subdir_tests().
+  file(GLOB_RECURSE dxt_all_templates "${PROJECT_SOURCE_DIR}/dune/*.tpl")
+  get_property(dxt_seen_templates GLOBAL PROPERTY dxt_seen_test_templates_prop)
+  list(LENGTH dxt_all_templates dxt_all_templates_count)
+  list(LENGTH dxt_seen_templates dxt_seen_templates_count)
+  if(NOT dxt_all_templates_count EQUAL dxt_seen_templates_count)
+    message(
+      AUTHOR_WARNING
+        "found ${dxt_all_templates_count} templated (*.tpl) test suites under dune/, but add_subdir_tests() picked up "
+        "only ${dxt_seen_templates_count} -- the rest generate no tests and contribute no coverage")
+  endif()
 
   if(Alberta_FOUND)
     foreach(test ${dxt_test_binaries})

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -167,22 +167,18 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
     string(REPLACE ".tpl" ".py" config_fn "${template}")
     string(REPLACE ".tpl" ".tpl.cc" out_fn "${template}")
     string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" out_fn "${out_fn}")
-    # get the last completed cache for the codegen execution during configure time
-    foreach(mod ${ALL_DEPENDENCIES})
-      dune_module_path(MODULE ${mod} RESULT ${mod}_binary_dir BUILD_DIR)
-      if(IS_DIRECTORY ${${mod}_binary_dir})
-        set(last_dep_bindir ${${mod}_binary_dir})
-      endif()
-    endforeach(mod DEPENDENCIES)
-
+    # Third and fifth argument are the primary and fallback directory to read a CMakeCache.txt from; both are the
+    # snapshot dxt_write_codegen_cache() wrote (see finalize_test_setup()). This used to pass ${CMAKE_BINARY_DIR} with
+    # the binary dir of the last dependency module as fallback, and neither holds a cache when it is needed -- see the
+    # comment on the snapshot for why.
     dune_execute_process(
       COMMAND
       ${dxt_codegen_command}
       "${config_fn}"
       "${template}"
-      "${CMAKE_BINARY_DIR}"
+      "${dxt_codegen_cache_dir}"
       "${out_fn}"
-      "${last_dep_bindir}"
+      "${dxt_codegen_cache_dir}"
       OUTPUT_VARIABLE
       codegen_output
       ERROR_MESSAGE
@@ -194,7 +190,8 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
     endif()
     add_custom_command(
       OUTPUT "${generated_sources}"
-      COMMAND ${dxt_codegen_command} "${config_fn}" "${template}" "${CMAKE_BINARY_DIR}" "${out_fn}" "${last_dep_bindir}"
+      COMMAND ${dxt_codegen_command} "${config_fn}" "${template}" "${dxt_codegen_cache_dir}" "${out_fn}"
+              "${dxt_codegen_cache_dir}"
       DEPENDS "${config_fn}" "${template}"
       VERBATIM USES_TERMINAL)
     foreach(gen_source ${generated_sources})
@@ -255,8 +252,49 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
   endforeach()
 endmacro(_PROCESS_SUBDIR_TESTS)
 
+# Snapshot the live CMake cache for the templated-test codegen.
+#
+# The .tpl suites are expanded by python/xt/scripts/dxt_code_generation.py, which reads a CMakeCache.txt (via
+# dune.xt.cmake.parse_cache) to decide which grid managers and LA backends to instantiate for -- see
+# dune/xt/test/functions/grids.py, python/xt/dune/xt/test/grid_types.py and dune.xt.codegen. But CMake only writes
+# ${CMAKE_BINARY_DIR}/CMakeCache.txt at the END of a successful configure, so on a cold build dir there is no cache to
+# read at the point the codegen has to run. That is what the script's fallback argument was for: the binary dir of the
+# last configured dependency module, which under dunecontrol was a completed CMake build with its own cache. It no
+# longer is -- the dune modules come from vcpkg now, and vcpkg_installed/<triplet>/share/dune-common holds no
+# CMakeCache.txt -- so both the primary and the fallback path were dead (issue #370).
+#
+# Writing our own snapshot sidesteps the ordering problem entirely: by the time finalize_test_setup() runs, every
+# find_package() whose result the configs consult has already populated the cache, and we can serialise it on demand in
+# the format parse_cache expects.
+macro(DXT_WRITE_CODEGEN_CACHE)
+  set(dxt_codegen_cache_dir ${CMAKE_BINARY_DIR}/dxt-codegen-cache)
+  file(MAKE_DIRECTORY ${dxt_codegen_cache_dir})
+  set(dxt_cache_dump "# Snapshot of the live CMake cache, written by finalize_test_setup() for the .tpl codegen.\n")
+  get_cmake_property(dxt_cache_vars CACHE_VARIABLES)
+  foreach(dxt_cache_var IN LISTS dxt_cache_vars)
+    # parse_cache tokenises names with Word(alphanums + "/_- .") and parses with parseAll=True, so a single name it
+    # cannot tokenise would fail the whole file. Skip those rather than risk the configure; nothing the configs read has
+    # such a name.
+    if(NOT dxt_cache_var MATCHES "^[A-Za-z0-9/_.-]+$")
+      continue()
+    endif()
+    get_property(
+      dxt_cache_var_type
+      CACHE ${dxt_cache_var}
+      PROPERTY TYPE)
+    if(NOT dxt_cache_var_type)
+      set(dxt_cache_var_type "UNINITIALIZED")
+    endif()
+    # A real CMakeCache.txt cannot hold an embedded newline, and parse_cache is line-based; flatten defensively.
+    string(REPLACE "\n" " " dxt_cache_var_value "${${dxt_cache_var}}")
+    string(APPEND dxt_cache_dump "${dxt_cache_var}:${dxt_cache_var_type}=${dxt_cache_var_value}\n")
+  endforeach()
+  file(WRITE ${dxt_codegen_cache_dir}/CMakeCache.txt "${dxt_cache_dump}")
+endmacro()
+
 macro(FINALIZE_TEST_SETUP)
   get_headercheck_targets()
+  dxt_write_codegen_cache()
   get_property(dxt_test_dirs GLOBAL PROPERTY dxt_test_dirs_prop)
   set(combine_targets test_templates test_binaries check recheck)
 

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -139,7 +139,11 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
   #
   # * `uv run --no-project --with ...` supplies jinja2/pyparsing without a manually-managed venv, the same way the
   #   coverage targets in dxt_add_python_tests() pull gcovr/coverage.py, and `--python ${Python_EXECUTABLE}` pins the
-  #   interpreter the rest of the build resolved (see the uv block in the top-level CMakeLists.txt).
+  #   interpreter the rest of the build resolved (see the uv block in the top-level CMakeLists.txt). Both are bounded to
+  #   their current major version: template expansion is build-critical, and both libraries have broken across a major
+  #   bump before (jinja2 2->3, pyparsing 2->3). They are deliberately *not* pinned exactly here -- python/xt/uv.lock
+  #   already resolves them (jinja2 3.1.6, pyparsing 3.3.2) and is what the dependency tooling updates, so an exact
+  #   version repeated in CMake would be a second source of truth that silently drifts from it.
   # * PYTHONPATH points at the binary-dir assembly of the `dune.xt` package -- the symlinked sources plus the configured
   #   _version.py that dune_pybindxi_install_python_package() and python/xt/dune/xt/CMakeLists.txt put there. The
   #   per-suite .py configs import dune.xt.codegen / dune.xt.test.grid_types, and the source tree on its own is not
@@ -150,8 +154,9 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
   # was dropped (its find_program is commented out in CMakeLists.txt), and the ${PROJECT_SOURCE_DIR}/python/ scripts/
   # path, which has never existed -- the script lives in python/xt/scripts/.
   set(dxt_codegen_command
-      ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_BINARY_DIR}/python/xt" uv run --no-project --with jinja2 --with
-      pyparsing --python ${Python_EXECUTABLE} python ${PROJECT_SOURCE_DIR}/python/xt/scripts/dxt_code_generation.py)
+      ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_BINARY_DIR}/python/xt" uv run --no-project --with "jinja2>=3,<4"
+      --with "pyparsing>=3,<4" --python ${Python_EXECUTABLE} python
+      ${PROJECT_SOURCE_DIR}/python/xt/scripts/dxt_code_generation.py)
 
   foreach(template ${test_templates})
     set(ranks "1")

--- a/dune/xt/test/la/matrixinverter_for_complex_matrix_2.tpl
+++ b/dune/xt/test/la/matrixinverter_for_complex_matrix_2.tpl
@@ -96,7 +96,16 @@ TEST_F(MatrixInverterForComplexMatrix_{{T_NAME}}, is_constructible)
 
 TEST_F(MatrixInverterForComplexMatrix_{{T_NAME}}, gives_correct_inverse)
 {
-  gives_correct_inverse({ {"direct", "1e-13"}, {"moore_penrose", "1e-13"} });
+  // moore_penrose is compared at 1e-11 rather than the 1e-13 used for direct. gives_correct_inverse() compares
+  // component-wise and relatively (real and imaginary parts as separate scalars), and this 10x10 pseudo-inverse has
+  // components spanning three orders of magnitude: at 1e-13, 6 of its 200 components failed, all of them ones whose
+  // expected value is near zero (3.4e-03 down the list). Their absolute error is 2-5e-15 -- a few ULP on a matrix whose
+  // entries reach 2.28 -- but dividing that by a 3.4e-03 component yields a relative error of 7.2e-13. The largest
+  // absolute deviation anywhere in the matrix is 1.4e-14, and direct inversion plus the two Common* backends match at
+  // 1e-13, so the result is right; the expectations were simply captured against a different LAPACK. 1e-11 leaves ~14x
+  // headroom over the observed worst case while still being orders of magnitude tighter than an actually wrong inverse.
+  // This surfaced the first time the suite ran after the codegen was repaired (issue #370).
+  gives_correct_inverse({ {"direct", "1e-13"}, {"moore_penrose", "1e-11"} });
 }
 
 {% endfor %}


### PR DESCRIPTION
Closes #370.

All seven deliverables are answered. Steps 1–3 were established before any behaviour change; steps 4–6 are measured from this PR's own CI, against the merge base `8db3c3ff` (same preset, same runner class, same pipeline).

**Result: 49 templated suites, 283 generated translation units, 246 new ctest entries, +3953 covered lines, ~11 coverage points on both target areas, for ~1 minute of steady-state build.**

## 1. The glob is empty — confirmed

`_process_subdir_tests` is reached from `finalize_test_setup()`, invoked at `dune/CMakeLists.txt:28`, so `CMAKE_CURRENT_SOURCE_DIR` is `dune/`. Replaying both globs standalone with the real paths:

```
common:    .cc=29   .tpl(as written -> dune/common/*.tpl)=0     .tpl(with ${fullpath})=1
grid:      .cc=16   .tpl(as written -> dune/grid/*.tpl)=0       .tpl(with ${fullpath})=3
la:        .cc=4    .tpl(as written -> dune/la/*.tpl)=0         .tpl(with ${fullpath})=23
functions: .cc=6    .tpl(as written -> dune/functions/*.tpl)=0  .tpl(with ${fullpath})=22
```

0 vs 49. `dune/functions`, `dune/la`, `dune/grid` and `dune/common` do not exist in this tree. There was no `AUTHOR_WARNING` on the empty-`test_templates` path, which is why it never made a sound.

## 2. "~400 test binaries" matched nothing countable

| source | binaries | ctest entries |
|---|---:|---:|
| 123 plain hand-written `.cc` suites | 123 | 123 |
| 29 meta-ini (`.mini`) suites | 112 | 235 |
| 49 templated (`.tpl`) suites | **0 before** / 283 after | 0 / 283 |

The `.mini` figures come from running dune-testtools' `expand_meta_ini` over each file and counting distinct `__exec_suffix` values against configurations (`periodic_gridview.mini` alone is 96). CI confirms the totals: instrumented binaries went **262 → 508**, ctest entries **348 → 594**. The comments are corrected to the counted values.

## 3–4. The four defects

Each was sufficient on its own to produce zero output.

**Defect 1 — wrong glob root.** `${CMAKE_CURRENT_SOURCE_DIR}/${subdir}` → `${fullpath}`, matching the `.cc` glob directly above it.

**Defect 2 — the codegen invocation could not have run.** The path was `python/scripts/dxt_code_generation.py`, but the script lives in `python/xt/scripts/`; and `${RUN_IN_ENV_SCRIPT}` has been unset since the dune-testtools virtualenv wrapper was dropped (`find_program` commented out at `CMakeLists.txt:129`), so CMake would have tried to exec the `.py` directly. Both invocations now share one command via `uv run --no-project` pinned to `${Python_EXECUTABLE}`, with `PYTHONPATH` on the binary-dir `dune.xt` assembly — required, because the source tree alone is not importable (`dune/xt/__init__.py` imports the generated `_version`).

**Defect 3 — missing label.** The `.tpl` branch passed no `LABELS` to `dune_add_test` and then overwrote them with `subdir_${subdir}` only, so every preset — all of which filter on `dune-gdt-test` — would have skipped the binaries it had just built. CI confirms the fix: the tests report as `dune-gdt-test subdir_la`.

**Defect 4 — no CMake cache to read (found by this PR's first green-configure run).** `dxt_code_generation.py` reads a `CMakeCache.txt`; CMake writes `${CMAKE_BINARY_DIR}/CMakeCache.txt` only at the *end* of a successful configure (verified with a minimal probe project: absent on the first configure, present on the second), and the script's fallback — the last dependency module's binary dir — was written for dunecontrol and now resolves into `vcpkg_installed/<triplet>/share/dune-common`, which has no cache. `finalize_test_setup()` now serialises the live cache to its own directory and points the codegen there.

**Bonus — the dead loop.** `if(TEST test)` asked whether a ctest test literally named `test` exists. Deleted rather than repaired: `dune_add_test` now sets `TIMEOUT` and the full label set directly, and re-setting `LABELS` there would clobber `dune-gdt-test` — defect 3 again.

**Regression guard.** A per-subdir `AUTHOR_WARNING` would fire for all twelve `dune/gdt/test` subdirs, none of which has templates. Instead `finalize_test_setup()` cross-checks once that every `*.tpl` under `dune/` was picked up, which also catches a suite added under an unregistered directory.

### Do they compile and pass?

All 49 compiled — no compile errors at all. One test failed on first run and it was a stale expectation, not a defect: `test_matrixinverter_for_complex_matrix_2`, `moore_penrose`, on 2 of its 5 backends. The comparison is component-wise *relative*; **6 of 200 components** exceeded 1e-13, every one a near-zero component (worst: expected magnitude 3.4e-03, absolute error 2.4e-15 → 7.2e-13 relative). Largest absolute deviation anywhere is 1.4e-14 on a matrix with entries up to 2.28, and `direct` matches at 1e-13 for all five backends. `b66c7be` widens `moore_penrose` to 1e-11 (~14× headroom) with the reasoning recorded in the source.

## 5. Cost

Same preset, main vs PR:

| step | main | PR | Δ |
|---|---:|---:|---:|
| Configure CMake | 26m51s | 22m05s | −4m46s |
| Build test binaries | 1m21s | 2m32s | +1m11s |
| Build Python bindings | 23m19s | 17m49s | −5m30s |
| Test with CTest | 8m49s | 8m18s | −31s |
| **whole leg** | **64m18s** | **54m17s** | **−10m01s** |

Both legs had a warm ccache holding the generated TUs, so this is the **steady-state** cost: ~+1 minute of build. The **cold** cost comes from the earlier `7e212fc` run, whose cache held every pre-existing TU but none of the generated ones — **93m43s** vs main's **48m21s**, so roughly **+45 minutes once** to fill the cache. Even that sits well inside the 240-minute timeout, and no leg approached an OOM. Ctest is free: 246 more entries in slightly less wall clock (498.00 s vs 526.86 s).

## 6. Benefit

| area | main `8db3c3ff` | PR `b66c7be` | Δ pts | lines covered |
|---|---:|---:|---:|---:|
| `dune/xt/functions` | 61.53% | **72.71%** | **+11.18** | 1217 → 2169 (**+952**) |
| `dune/xt/la` | 66.15% | **77.25%** | **+11.10** | 3048 → 5396 (**+2348**) |
| `dune/xt/common` | 69.56% | 71.52% | +1.96 | 3049 → 3229 (+180) |
| `dune/xt/grid` | 86.55% | 84.43% | −2.12 | 2040 → 2147 (+107) |
| `dune/xt/test` | 97.60% | 95.33% | −2.27 | 4023 → 4389 (+366) |
| **total** | **79.24%** | **80.84%** | **+1.60** | 28195 → 32148 (**+3953**) |

Read the percentages alongside the absolute column: llvm-cov reports only lines from *instantiated* templates, so the reportable base grows as new instantiations appear (`dune/xt/la` 4608 → 6985 lines, `dune/xt/functions` 1978 → 2983). Much of these headers was previously not merely uncovered but invisible to the report. That also explains the two negative deltas — `dune/xt/grid` gained 186 reportable lines and covered 107, so its ratio dips while its absolute coverage rises. No area covers fewer lines than on main.

## 7. Landing strategy

**All 49 suites on, in the normal PR CI** — not a curated subset, not a separate scheduled job. +3953 covered lines and ~11 points on both target areas, for ~1 minute of steady-state build and a one-time cache fill, does not need hedging. The subset lever remains available (a filter on `test_templates` in `_process_subdir_tests`) if the picture ever changes.

## Follow-ups this surfaced (deliberately not fixed here)

1. **Alberta grid variants are never generated.** `grids.py` gates on `is_found(cache, "ALBERTA_FOUND")`, but `find_package(Alberta)` sets a normal variable, not a cache entry — so despite the preset building the alberta vcpkg feature, those instantiations are skipped. This is the entire gap between the 594 entries observed and the ~641 predicted, and it is free coverage left on the table.
2. **The meta-ini label is one label containing a space.** `_process_sources` passes `LABELS "subdir_${subdir} dune-gdt-test"` — a space-separated string where CMake expects a `;`-list — which ctest's label summary shows verbatim as `subdir_grid dune-gdt-test = ... (164 tests)`. Those tests run today only because `ctest -L` matches by regex, so `dune-gdt-test` happens to match as a substring. Directly adjacent to #350/#357.