### PR TITLE
xt: publish ALBERTA_FOUND to the codegen cache snapshot

### DIFF
--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -289,7 +289,41 @@ macro(DXT_WRITE_CODEGEN_CACHE)
     string(REPLACE "\n" " " dxt_cache_var_value "${${dxt_cache_var}}")
     string(APPEND dxt_cache_dump "${dxt_cache_var}:${dxt_cache_var_type}=${dxt_cache_var_value}\n")
   endforeach()
+
+  # Synthetic entries: guards the codegen configs ask for that are NOT cache variables.
+  #
+  # A find_package() result such as Alberta_FOUND is a *normal* variable, so it is not in CACHE_VARIABLES and the loop
+  # above cannot see it -- no matter how it is spelled. The configs guard on such names by string (the `guards` dict in
+  # python/xt/dune/xt/test/grid_types.py, _if_active() in dune/xt/test/functions/grids.py), and both fail closed and
+  # silently on a key that is not in the snapshot. This block is the CMake -> codegen contract for those: keep it in
+  # sync with the guard names on the Python side, which is the only thing tying the two together.
+  #
+  # The sibling grid guards (`dune-alugrid`, `dune-uggrid`, `dune-grid`) need no entry here: they are the *_DIR cache
+  # paths of the dune modules, for which parse_cache synthesizes a boolean companion key itself.
+  #
+  # Issue #374: `ALBERTA_FOUND` was never published and is also cased differently from the `Alberta_FOUND` that
+  # find_package(Alberta) sets (CMake variables are case-sensitive), so the guard could never match and both Alberta
+  # grid variants -- 2d_simplex_albertagrid and 3d_simplex_albertagrid -- were dropped from every templated suite that
+  # fans out over grid types. Publish under the name the configs ask for, and take the value from either casing so a
+  # dune-grid that only sets the find_package_handle_standard_args upper-case alias still counts.
+  if(Alberta_FOUND OR ALBERTA_FOUND)
+    set(dxt_alberta_found "TRUE")
+  else()
+    set(dxt_alberta_found "FALSE")
+  endif()
+  string(APPEND dxt_cache_dump "ALBERTA_FOUND:BOOL=${dxt_alberta_found}\n")
+
   file(WRITE ${dxt_codegen_cache_dir}/CMakeCache.txt "${dxt_cache_dump}")
+
+  # Every preset requests the alberta vcpkg feature, so a build that has it enabled but did not find Alberta is losing
+  # ~47 ctest entries for a reason worth naming rather than rediscovering (issue #374 was exactly that gap, measured as
+  # 594 registered tests against ~641 expected).
+  if("alberta" IN_LIST VCPKG_MANIFEST_FEATURES AND NOT dxt_alberta_found)
+    message(
+      AUTHOR_WARNING
+        "the alberta vcpkg feature is enabled, but find_package(Alberta) did not succeed -- the Alberta grid variants "
+        "of the templated (*.tpl) test suites will not be generated and contribute no coverage")
+  endif()
 endmacro()
 
 macro(FINALIZE_TEST_SETUP)

--- a/dune/xt/test/functions/grids.py
+++ b/dune/xt/test/functions/grids.py
@@ -13,6 +13,8 @@
 
 import itertools
 
+from dune.xt.codegen import is_found
+
 
 def _make_alu(dimDomain):
     tmpl = "Dune::ALUGrid<{d},{d},Dune::{g},Dune::{r}>"
@@ -29,14 +31,6 @@ def _if_active(val, guard, cache):
     return val if is_found(cache, guard) else []
 
 
-def is_found(cache, name):
-    if name in cache.keys():
-        if isinstance(cache[name], bool):
-            return cache[name]
-        return "notfound" not in cache[name].lower()
-    return False
-
-
 def type_and_dim(cache, dimDomain):
     grid_alu = _if_active(_make_alu(dimDomain), "dune-alugrid", cache)
     grid_yasp = [
@@ -51,6 +45,8 @@ def type_and_dim(cache, dimDomain):
     grid_ug = _if_active(
         [(f"Dune::UGGrid<{d}>", d) for d in dimDomain if d != 1], "dune-uggrid", cache
     )
+    # ALBERTA_FOUND is not a cache variable: dxt_write_codegen_cache() appends it to the snapshot
+    # from find_package(Alberta)'s normal variable, under this name (see DuneXTTesting.cmake).
     grid_alberta = _if_active(
         [("Dune::AlbertaGrid<{d},{d}>".format(d=d), d) for d in dimDomain if d != 1],
         "ALBERTA_FOUND",

--- a/python/xt/dune/xt/cmake.py
+++ b/python/xt/dune/xt/cmake.py
@@ -14,6 +14,20 @@
 import os
 import pprint
 
+# The constants CMake's own `if()` treats as false; everything else (a non-zero number, any other
+# word) is true. See https://cmake.org/cmake/help/latest/command/if.html#constant.
+_CMAKE_FALSE_CONSTANTS = frozenset(
+    ("", "0", "OFF", "NO", "FALSE", "N", "IGNORE", "NOTFOUND")
+)
+
+
+def is_cmake_true(value):
+    """Evaluate a CMake constant the way `if()` would."""
+    if isinstance(value, bool):
+        return value
+    value = value.strip().upper()
+    return not (value in _CMAKE_FALSE_CONSTANTS or value.endswith("-NOTFOUND"))
+
 
 def parse_cache(filepath):
     import pyparsing as p
@@ -29,8 +43,15 @@ def parse_cache(filepath):
     kv = {}
     types = {}
     for key, type, value in grammar.parseFile(filepath, parseAll=True):
-        kv[key] = value.strip()
+        value = value.strip()
         types[key] = type
+        if type == "BOOL":
+            # Hand BOOL entries to the configs as actual booleans. The guards read them either by
+            # truthiness (grid_types._is_usable) or by looking for "notfound" in the string
+            # (codegen.is_found), and both of those would take the string "FALSE" for a yes.
+            kv[key] = is_cmake_true(value)
+            continue
+        kv[key] = value
         if key.endswith("_DIR"):
             kv[key[:-4]] = os.path.isdir(value)
     return kv, types

--- a/python/xt/dune/xt/codegen.py
+++ b/python/xt/dune/xt/codegen.py
@@ -22,7 +22,12 @@ def typeid_to_typedef_name(typeid, replacement="_"):
 
 def is_found(cache, name):
     if name in cache.keys():
-        return "notfound" not in cache[name].lower()
+        value = cache[name]
+        # BOOL entries and the *_DIR companion keys arrive from parse_cache already reduced to a
+        # bool; a path-valued entry is a string that spells out its own absence as "<NAME>-NOTFOUND".
+        if isinstance(value, bool):
+            return value
+        return "notfound" not in value.lower()
     return False
 
 

--- a/python/xt/dune/xt/test/grid_types.py
+++ b/python/xt/dune/xt/test/grid_types.py
@@ -24,6 +24,8 @@ except ImportError as e:
 
 from collections import namedtuple
 
+from dune.xt.codegen import is_found
+
 arguments = {
     "alu": namedtuple("alu_args", "dim element_type refinement"),
     "yasp": namedtuple("yasp_args", "dim"),
@@ -36,6 +38,10 @@ templates = {
     "ug": "Dune::UGGrid<{dim}>",
     "alberta": "Dune::AlbertaGrid<{dim},{dim}>",
 }
+# Keys looked up in the CMake cache snapshot the codegen reads. The dune-* ones are the boolean
+# companions parse_cache derives from the modules' *_DIR cache paths; ALBERTA_FOUND is not a cache
+# variable at all and is appended to the snapshot by dxt_write_codegen_cache() (DuneXTTesting.cmake)
+# from find_package(Alberta)'s normal variable -- keep the two names in sync.
 guards = {
     "alu": "dune-alugrid",
     "yasp": "dune-grid",
@@ -45,10 +51,7 @@ guards = {
 
 
 def _is_usable(grid, cache):
-    try:
-        return cache[guards[grid]]
-    except KeyError:
-        return False
+    return is_found(cache, guards[grid])
 
 
 def all_args(dims):

--- a/python/xt/test/test_cmake.py
+++ b/python/xt/test/test_cmake.py
@@ -13,7 +13,7 @@ import pytest
 
 pytest.importorskip("pyparsing")
 
-from dune.xt.cmake import parse_cache  # noqa: E402
+from dune.xt.cmake import is_cmake_true, parse_cache  # noqa: E402
 
 
 def _write_cache(path, body):
@@ -28,7 +28,8 @@ def test_parse_cache_basic_key_value_and_types(tmp_path):
     )
     kv, types = parse_cache(cache)
     assert kv["FOO"] == "bar"
-    assert kv["ENABLE"] == "ON"
+    # BOOL entries are handed to the configs as booleans, not as the raw CMake spelling.
+    assert kv["ENABLE"] is True
     assert types["FOO"] == "STRING"
     assert types["ENABLE"] == "BOOL"
 
@@ -62,3 +63,62 @@ def test_parse_cache_dir_entry_missing(tmp_path):
     )
     kv, _ = parse_cache(cache)
     assert kv["dune-istl"] is False
+
+
+@pytest.mark.parametrize("value", ("ON", "YES", "TRUE", "Y", "1", "2", "on", "true"))
+def test_is_cmake_true_truthy_constants(value):
+    assert is_cmake_true(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "OFF",
+        "NO",
+        "FALSE",
+        "N",
+        "IGNORE",
+        "NOTFOUND",
+        "0",
+        "",
+        "  ",
+        "Alberta-NOTFOUND",
+    ),
+)
+def test_is_cmake_true_falsy_constants(value):
+    assert is_cmake_true(value) is False
+
+
+def test_is_cmake_true_passes_booleans_through():
+    assert is_cmake_true(True) is True
+    assert is_cmake_true(False) is False
+
+
+def test_parse_cache_bool_entries_are_booleans(tmp_path):
+    # A BOOL entry must not reach the configs as a string: both guard implementations
+    # (codegen.is_found and grid_types._is_usable) would read the string "FALSE" as a yes.
+    cache = _write_cache(
+        tmp_path / "CMakeCache.txt",
+        "YES_ON:BOOL=ON\nYES_TRUE:BOOL=TRUE\nNO_OFF:BOOL=OFF\nNO_FALSE:BOOL=FALSE\nNO_ZERO:BOOL=0\n",
+    )
+    kv, types = parse_cache(cache)
+    assert kv["YES_ON"] is True
+    assert kv["YES_TRUE"] is True
+    assert kv["NO_OFF"] is False
+    assert kv["NO_FALSE"] is False
+    assert kv["NO_ZERO"] is False
+    assert types["NO_OFF"] == "BOOL"
+
+
+def test_parse_cache_alberta_guard_entry(tmp_path):
+    # Regression test for issue #374: dxt_write_codegen_cache() appends ALBERTA_FOUND to the
+    # snapshot (find_package(Alberta) sets a normal variable, which is not part of the cache).
+    # It is only useful to the configs if it survives parsing as a boolean in both directions.
+    kv, _ = parse_cache(
+        _write_cache(tmp_path / "found.txt", "ALBERTA_FOUND:BOOL=TRUE\n")
+    )
+    assert kv["ALBERTA_FOUND"] is True
+    kv, _ = parse_cache(
+        _write_cache(tmp_path / "missing.txt", "ALBERTA_FOUND:BOOL=FALSE\n")
+    )
+    assert kv["ALBERTA_FOUND"] is False

--- a/python/xt/test/test_codegen.py
+++ b/python/xt/test/test_codegen.py
@@ -76,3 +76,10 @@ def test_la_backends_skips_missing_istl():
 
 def test_la_backends_empty_cache():
     assert la_backends({}) == []
+
+
+def test_is_found_accepts_boolean_values():
+    # parse_cache reduces BOOL entries (and the *_DIR companions) to real booleans; the guard has
+    # to read those as-is instead of looking for "notfound" in a string.
+    assert is_found({"ALBERTA_FOUND": True}, "ALBERTA_FOUND") is True
+    assert is_found({"ALBERTA_FOUND": False}, "ALBERTA_FOUND") is False

--- a/python/xt/test/test_functions_grids_config.py
+++ b/python/xt/test/test_functions_grids_config.py
@@ -1,0 +1,80 @@
+# ~~~
+# This file is part of the dune-xt project:
+#   https://zivgitlab.uni-muenster.de/ag-ohlberger/dune-community/dune-xt
+# Copyright 2009-2026 dune-xt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+
+import importlib.util
+import pathlib
+
+import pytest
+
+# dune/xt/test/functions/grids.py is a codegen *config* module, not part of the dune.xt package: the
+# .py configs next to the .tpl suites import it as a plain `grids` module, with their own directory
+# on sys.path. Load it by path so the fan-out it drives -- one generated test binary per grid type,
+# across ~15 suites under dune/xt/test/functions -- is covered here too.
+_grids_py = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "dune"
+    / "xt"
+    / "test"
+    / "functions"
+    / "grids.py"
+)
+if not _grids_py.is_file():
+    pytest.skip(
+        f"codegen config {_grids_py} not available (no source tree)",
+        allow_module_level=True,
+    )
+
+_spec = importlib.util.spec_from_file_location("grids", _grids_py)
+grids = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(grids)
+
+
+def _names(cache, dims=(1, 2, 3)):
+    return [grids.pretty_print(g, d) for g, d in grids.type_and_dim(cache, dims)]
+
+
+def test_alberta_variants_are_generated_when_the_guard_is_published():
+    # Regression test for issue #374: ALBERTA_FOUND was never part of the CMake cache snapshot the
+    # codegen reads (find_package(Alberta) sets a normal variable, and under a different casing),
+    # so _if_active() always failed closed and both Alberta variants were silently missing from
+    # every functions/ suite. dxt_write_codegen_cache() publishes the guard now.
+    assert _names({"ALBERTA_FOUND": True}) == [
+        "2d_simplex_albertagrid",
+        "3d_simplex_albertagrid",
+        "1d_cube_yaspgrid",
+        "2d_cube_yaspgrid",
+        "3d_cube_yaspgrid",
+        "1d_cube_onedgrid",
+    ]
+
+
+def test_alberta_variants_are_absent_without_the_guard():
+    assert "2d_simplex_albertagrid" not in _names({"ALBERTA_FOUND": False})
+    # a guard missing from the cache entirely must fail closed, not raise
+    assert "2d_simplex_albertagrid" not in _names({})
+
+
+def test_all_grid_managers_enabled():
+    cache = {"ALBERTA_FOUND": True, "dune-alugrid": True, "dune-uggrid": True}
+    names = _names(cache, dims=(2,))
+    assert names == [
+        "2d_simplex_albertagrid",
+        "2d_cube_alunonconformgrid",
+        "2d_simplex_alunonconformgrid",
+        "2d_simplex_aluconformgrid",
+        "2d_cube_yaspgrid",
+        "2d_simplex_uggrid",
+    ]
+
+
+def test_pretty_print_rejects_unknown_grid():
+    with pytest.raises(RuntimeError):
+        grids.pretty_print("Dune::SomeOtherGrid<2,2>", 2)

--- a/python/xt/test/test_grid_types.py
+++ b/python/xt/test/test_grid_types.py
@@ -67,3 +67,20 @@ def test_all_types_alu_formatting():
     types = grid_types.all_types(cache=cache, dims=(2,), gridnames=["alu"])
     assert "Dune::ALUGrid<2,2,Dune::simplex,Dune::nonconforming>" in types
     assert "Dune::ALUGrid<2,2,Dune::cube,Dune::nonconforming>" in types
+
+
+def test_alberta_guard_toggles_the_alberta_types():
+    # Regression test for issue #374: nothing published ALBERTA_FOUND into the cache snapshot the
+    # codegen reads, so this guard never matched and the Alberta grid variants were dropped from
+    # every templated suite. dxt_write_codegen_cache() now appends it (see DuneXTTesting.cmake).
+    assert grid_types.guards["alberta"] == "ALBERTA_FOUND"
+    enabled = grid_types.all_types(
+        cache={"ALBERTA_FOUND": True}, dims=(2, 3), gridnames=["alberta"]
+    )
+    assert enabled == ["Dune::AlbertaGrid<2,2>", "Dune::AlbertaGrid<3,3>"]
+    assert (
+        grid_types.all_types(
+            cache={"ALBERTA_FOUND": False}, dims=(2, 3), gridnames=["alberta"]
+        )
+        == []
+    )


### PR DESCRIPTION
Fixes #374.

## What was wrong

The `.tpl` suites gate their Alberta grid variants on an `ALBERTA_FOUND` key in the CMake cache snapshot the codegen reads, and nothing ever put one there — for the two independent reasons the issue names:

* `find_package(Alberta)` sets `Alberta_FOUND` as a **normal** variable, so it is not in `CACHE_VARIABLES` and cannot appear in the snapshot `dxt_write_codegen_cache()` serialises. The sibling grid guards only work because they are `*_DIR` cache paths, for which `parse_cache()` synthesizes a boolean companion key (`dune-alugrid_DIR` → `dune-alugrid`).
* CMake variables are case-sensitive, so even a cached `Alberta_FOUND` would never have matched the `ALBERTA_FOUND` the configs ask for.

Both guards fail closed and silently on a missing key (`is_found` returns `False`, `_is_usable` swallowed the `KeyError`), so `2d_simplex_albertagrid` and `3d_simplex_albertagrid` were dropped from every suite that fans out over grid types — the 22 configs under `dune/xt/test/functions/` — with no diagnostic.

## What this does

**CMake side** (`cmake/modules/DuneXTTesting.cmake`) — `dxt_write_codegen_cache()` appends a synthetic entry to the snapshot under the name the configs ask for:

```cmake
if(Alberta_FOUND OR ALBERTA_FOUND)   # either casing, in case only the FPHSA alias is set
  ...
string(APPEND dxt_cache_dump "ALBERTA_FOUND:BOOL=${dxt_alberta_found}\n")
```

It also warns when the `alberta` vcpkg feature is enabled (every preset requests it) but `find_package(Alberta)` did not succeed — the same silent-gap class as the `*.tpl` glob guard added in #370/#373, which is how this went unnoticed. Both ends of the coupling now carry a comment, since the guard name is the only thing tying them together.

**Python side** — the guards had to be able to read a `FALSE` correctly, which they could not:

* `parse_cache()` reduces `BOOL` entries to real Python booleans (`is_cmake_true()`, CMake's own `if()` constant rules). Without this, `grid_types._is_usable` would return the truthy string `"FALSE"` and `codegen.is_found` would report the truthy `"notfound" not in "false"` — i.e. Alberta enabled on a build that does not have it.
* `codegen.is_found()` grew the bool branch. That makes it identical to the private copy in `dune/xt/test/functions/grids.py`, so that copy is gone and the config imports the shared one (the codegen script already imports `dune.xt`, so no new dependency).
* `grid_types._is_usable()` routes through `is_found()` instead of returning the raw cache value.

## Verification

* `pytest` over the pure-Python suites passes (48 tests in the four touched modules, plus the codegen/script tests).
* The new CMake block was exercised standalone with `cmake -P` across all four cases (neither variable set / `Alberta_FOUND` / uppercase alias only / not found without the feature): correct entry and correct warning in each.
* End-to-end through a realistic snapshot (header comment + `*_DIR` entries + `ALBERTA_FOUND:BOOL=TRUE`), `grids.type_and_dim()` now yields **14** grid types including both albertagrid variants, up from 12 — matching the "2 of 14 grid types" in the issue. With `ALBERTA_FOUND:BOOL=FALSE` or the key absent, it stays at 12.

The ctest-count check from the issue (`ctest --preset=clang22-release_coverage -N | grep -c albertagrid` non-zero, total rising from 594 toward ~641) needs a full configure and is left to CI.

## Tests

* `test_cmake.py` — `is_cmake_true()` truthy/falsy constants, `BOOL` entries parsed as booleans, `ALBERTA_FOUND` round-trip in both directions.
* `test_codegen.py` — `is_found()` on boolean values.
* `test_grid_types.py` — the alberta guard toggles the Alberta types, and the guard name matches what CMake publishes.
* `test_functions_grids_config.py` (new) — loads `dune/xt/test/functions/grids.py` (a codegen config, not part of the package) by path and pins the fan-out: Alberta variants present when the guard is published, absent when it is false or missing, and the full 6-type list for a 2d build with every grid manager.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVCmVyWp3w2yMVZJxjEjbv)_