### PR TITLE
test(xt): spe10 GTEST_SKIP() + generalize the alberta unmet-feature warning

### DIFF
--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -266,6 +266,23 @@ endmacro(_PROCESS_SUBDIR_TESTS)
 # Writing our own snapshot sidesteps the ordering problem entirely: by the time finalize_test_setup() runs, every
 # find_package() whose result the configs consult has already populated the cache, and we can serialise it on demand in
 # the format parse_cache expects.
+
+# Warn when an optional grid vcpkg feature is enabled but the dependency it pulls in was not actually found -- the
+# generalized form of the alberta-only check issue #374 added. `found_var` is a CMake variable/cache-entry name (not a
+# value): it is expanded with `${found_var}` so it works for both an ordinary variable (`dxt_alberta_found`) and a
+# *_DIR cache path (`dune-uggrid_DIR`, which CMake's if() already treats as false when it ends in "-NOTFOUND").
+# Issue #390 notes this is the one other optional grid feature left ungeneralized: `dune-alugrid`/`dune-grid` are
+# mandatory vcpkg dependencies (always installed), not optional features, so `uggrid` is the only sibling case to
+# `alberta` among the guards that shrink a templated (*.tpl) test suite's `::testing::Types<...>` list.
+macro(DXT_WARN_IF_OPTIONAL_GRID_FEATURE_UNMET feature found_var description)
+  if("${feature}" IN_LIST VCPKG_MANIFEST_FEATURES AND NOT ${found_var})
+    message(
+      AUTHOR_WARNING
+        "the ${feature} vcpkg feature is enabled, but ${description} -- the corresponding grid variants "
+        "of the templated (*.tpl) test suites will not be generated and contribute no coverage")
+  endif()
+endmacro()
+
 macro(DXT_WRITE_CODEGEN_CACHE)
   set(dxt_codegen_cache_dir ${CMAKE_BINARY_DIR}/dxt-codegen-cache)
   file(MAKE_DIRECTORY ${dxt_codegen_cache_dir})
@@ -317,13 +334,10 @@ macro(DXT_WRITE_CODEGEN_CACHE)
 
   # Every preset requests the alberta vcpkg feature, so a build that has it enabled but did not find Alberta is losing
   # ~47 ctest entries for a reason worth naming rather than rediscovering (issue #374 was exactly that gap, measured as
-  # 594 registered tests against ~641 expected).
-  if("alberta" IN_LIST VCPKG_MANIFEST_FEATURES AND NOT dxt_alberta_found)
-    message(
-      AUTHOR_WARNING
-        "the alberta vcpkg feature is enabled, but find_package(Alberta) did not succeed -- the Alberta grid variants "
-        "of the templated (*.tpl) test suites will not be generated and contribute no coverage")
-  endif()
+  # 594 registered tests against ~641 expected). `uggrid` is the other optional grid feature with the same failure
+  # mode (issue #390).
+  dxt_warn_if_optional_grid_feature_unmet(alberta dxt_alberta_found "find_package(Alberta) did not succeed")
+  dxt_warn_if_optional_grid_feature_unmet(uggrid dune-uggrid_DIR "find_package(dune-uggrid) did not succeed")
 endmacro()
 
 macro(FINALIZE_TEST_SETUP)

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -269,17 +269,16 @@ endmacro(_PROCESS_SUBDIR_TESTS)
 
 # Warn when an optional grid vcpkg feature is enabled but the dependency it pulls in was not actually found -- the
 # generalized form of the alberta-only check issue #374 added. `found_var` is a CMake variable/cache-entry name (not a
-# value): it is expanded with `${found_var}` so it works for both an ordinary variable (`dxt_alberta_found`) and a
-# *_DIR cache path (`dune-uggrid_DIR`, which CMake's if() already treats as false when it ends in "-NOTFOUND").
-# Issue #390 notes this is the one other optional grid feature left ungeneralized: `dune-alugrid`/`dune-grid` are
-# mandatory vcpkg dependencies (always installed), not optional features, so `uggrid` is the only sibling case to
-# `alberta` among the guards that shrink a templated (*.tpl) test suite's `::testing::Types<...>` list.
+# value): it is expanded with `${found_var}` so it works for both an ordinary variable (`dxt_alberta_found`) and a *_DIR
+# cache path (`dune-uggrid_DIR`, which CMake's if() already treats as false when it ends in "-NOTFOUND"). Issue #390
+# notes this is the one other optional grid feature left ungeneralized: `dune-alugrid`/`dune-grid` are mandatory vcpkg
+# dependencies (always installed), not optional features, so `uggrid` is the only sibling case to `alberta` among the
+# guards that shrink a templated (*.tpl) test suite's `::testing::Types<...>` list.
 macro(DXT_WARN_IF_OPTIONAL_GRID_FEATURE_UNMET feature found_var description)
   if("${feature}" IN_LIST VCPKG_MANIFEST_FEATURES AND NOT ${found_var})
     message(
-      AUTHOR_WARNING
-        "the ${feature} vcpkg feature is enabled, but ${description} -- the corresponding grid variants "
-        "of the templated (*.tpl) test suites will not be generated and contribute no coverage")
+      AUTHOR_WARNING "the ${feature} vcpkg feature is enabled, but ${description} -- the corresponding grid variants "
+                     "of the templated (*.tpl) test suites will not be generated and contribute no coverage")
   endif()
 endmacro()
 
@@ -334,8 +333,8 @@ macro(DXT_WRITE_CODEGEN_CACHE)
 
   # Every preset requests the alberta vcpkg feature, so a build that has it enabled but did not find Alberta is losing
   # ~47 ctest entries for a reason worth naming rather than rediscovering (issue #374 was exactly that gap, measured as
-  # 594 registered tests against ~641 expected). `uggrid` is the other optional grid feature with the same failure
-  # mode (issue #390).
+  # 594 registered tests against ~641 expected). `uggrid` is the other optional grid feature with the same failure mode
+  # (issue #390).
   dxt_warn_if_optional_grid_feature_unmet(alberta dxt_alberta_found "find_package(Alberta) did not succeed")
   dxt_warn_if_optional_grid_feature_unmet(uggrid dune-uggrid_DIR "find_package(dune-uggrid) did not succeed")
 endmacro()

--- a/dune/xt/test/functions/spe10_model1.tpl
+++ b/dune/xt/test/functions/spe10_model1.tpl
@@ -58,7 +58,7 @@ TEST_F(Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, is_construct
       {0, 0},
       {Dune::XT::Functions::Spe10::internal::model_1_length_x, Dune::XT::Functions::Spe10::internal::model_1_length_z});
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -68,7 +68,7 @@ TEST_F(Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, has_default_
   auto cfg = FunctionType::defaults();
   EXPECT_EQ(cfg.get<std::string>("name"), FunctionType::static_id());
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -96,7 +96,7 @@ TEST_F(Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, is_visualiza
   const auto leaf_view = grid_.leaf_view();
   visualize(default_function, leaf_view, "test__Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}__is_visualizable");
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -114,7 +114,7 @@ TEST_F(Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, is_bindable)
     local_f->bind(element);
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -135,7 +135,7 @@ TEST_F(Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, local_order)
     EXPECT_EQ(expected_order, actual_order);
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -163,7 +163,7 @@ TEST_F(Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, local_evalua
     }
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -188,7 +188,7 @@ TEST_F(Spe10Model1Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, local_jacobi
     }
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 

--- a/dune/xt/test/functions/spe10_model2.tpl
+++ b/dune/xt/test/functions/spe10_model2.tpl
@@ -62,7 +62,7 @@ TEST_F(Spe10Model2Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, is_construct
                          Dune::XT::Functions::Spe10::internal::model_2_length_z},
                         {6, 22, 8});
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -96,7 +96,7 @@ TEST_F(Spe10Model2Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, is_visualiza
   const auto leaf_view = grid_.leaf_view();
   visualize(function, leaf_view, "test__Spe10Model2Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}__is_visualizable", /*subsampling=*/false);
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -116,7 +116,7 @@ TEST_F(Spe10Model2Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, is_bindable)
     local_f->bind(element);
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -138,7 +138,7 @@ TEST_F(Spe10Model2Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, local_order)
     EXPECT_EQ(expected_order, actual_order);
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -162,7 +162,7 @@ TEST_F(Spe10Model2Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, local_evalua
     }
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 
@@ -188,7 +188,7 @@ TEST_F(Spe10Model2Function_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, local_jacobi
     }
   }
 #else
-  std::cout << "Test disabled, missing spe10 data files!" << std::endl;
+  GTEST_SKIP() << "spe10 data files are missing";
 #endif
 }
 


### PR DESCRIPTION
## Summary

Two commits addressing #390, in the order the issue asks for:

1. **Immediate fix** — `dune/xt/test/functions/spe10_model1.tpl` / `spe10_model2.tpl`: all 13 `#else` branches of `#if HAVE_SPE10_DATA` guards printed a message and fell through to the end of the `TEST_F` body, which gtest counts as a **pass**. Replaced each with `GTEST_SKIP() << "spe10 data files are missing";`, matching the one other `GTEST_SKIP()` use already in the tree (`bilinear_forms_restricted_integrals.cc:401`). `FindSpe10Data.cmake`'s warn-and-`return()` behavior on a failed download is left as-is — the issue agrees warn-and-skip is the right call there, only the test-side visibility was wrong.

2. **Wider pattern** — `cmake/modules/DuneXTTesting.cmake`: issue #374 added a one-off `AUTHOR_WARNING` for the case where the `alberta` vcpkg feature is enabled but `find_package(Alberta)` failed (which silently drops both Alberta grid variants from every templated `*.tpl` suite). Investigated how many other guards have the same "shrinks a `::testing::Types<...>` list with no visible signal" failure mode: only four guard names do this at all (`dune-alugrid`, `dune-grid`, `dune-uggrid`, `ALBERTA_FOUND`, read in `python/xt/dune/xt/test/grid_types.py` and `dune/xt/test/functions/grids.py`), and of those `dune-alugrid`/`dune-grid` are mandatory vcpkg dependencies rather than optional features — leaving `uggrid` as the one other case with the same shape as `alberta`. Extracted the check into a small `dxt_warn_if_optional_grid_feature_unmet(feature, found_var, description)` macro and applied it to both `alberta` and `uggrid`, rather than leaving `uggrid` as a second silent gap waiting to be rediscovered.

## Test plan

- [x] Verified `grep -c GTEST_SKIP` reports 7 (model1) + 6 (model2) = 13, matching the 13 guards named in the issue, with zero remaining `std::cout << "Test disabled` lines.
- [x] Extracted the new/changed CMake macro into a standalone script and ran it under `cmake -P` with the project's actual policy version (`cmake_minimum_required(VERSION 3.29...4.0)` covers `CMP0057`/`IN_LIST`) against three cases: feature enabled + not found (warns), feature enabled + a `*_DIR-NOTFOUND` value (warns), feature enabled + found (no warning) — all three behaved as expected.
- [ ] No local build environment (spe10 data + full vcpkg dependency set) was available to run the actual test binaries or a full CMake configure end-to-end; recommend CI confirms the `.tpl` → generated `.cc` templating still builds cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_018faT9BbvwZn4SkPNFqFtf9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build-time warnings when optional Alberta or UGGrid dependencies are unavailable.
  - Clarified that related test suites will not be generated or included in coverage when dependencies are missing.

- **Tests**
  - SPE10 Model 1 and Model 2 tests now appear as skipped when required data files are unavailable, rather than reporting misleading disabled-test messages.
  - Applied consistent handling across construction, visualization, binding, order, evaluation, and Jacobian checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->