### PR TITLE
Fix broken cmake/modules install list and manifest inconsistencies

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -254,11 +254,12 @@ jobs:
       run: |
         prefix="$(mktemp -d)"
         cmake --install "build/${{ matrix.preset }}" --prefix "${prefix}"
-        moduledir="$(dirname "$(find "${prefix}" -name DuneXTHints.cmake -print -quit)")"
-        if [[ -z "${moduledir}" ]]; then
+        module="$(find "${prefix}" -type f -name DuneXTHints.cmake -print -quit)"
+        if [[ ! -f "${module}" ]]; then
           echo "::error::DuneXTHints.cmake was not installed"
           exit 1
         fi
+        moduledir="$(dirname "${module}")"
         cmake "-DCMAKE_MODULE_PATH=${moduledir}" -P /dev/stdin <<< 'include(DuneXTHints)'
 
     - name: Build

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -239,29 +239,6 @@ jobs:
       run: >
         cmake --preset=${{ matrix.preset }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
-    - name: Test install
-      # Regression test for issue #388: nothing else in this workflow ever runs
-      # `cmake --install`, so a broken install(FILES) list (e.g. referencing a
-      # nonexistent file, or omitting a file another installed module
-      # `include()`s) stayed unnoticed until a downstream consumer's configure
-      # failed. None of this project's install() rules depend on built targets
-      # (only headers/cmake modules are installed), so this can run right after
-      # configure. The second check reproduces the exact failure mode from the
-      # issue: FindMKL/FindCBLAS/FindLAPACKE all `include(DuneXTHints)`, so an
-      # installed tree that is missing DuneXTHints.cmake would leave
-      # LIB_HINTS/INCLUDE_HINTS/append_to_each/include_sys_dir undefined for
-      # downstream consumers.
-      run: |
-        prefix="$(mktemp -d)"
-        cmake --install "build/${{ matrix.preset }}" --prefix "${prefix}"
-        module="$(find "${prefix}" -type f -name DuneXTHints.cmake -print -quit)"
-        if [[ ! -f "${module}" ]]; then
-          echo "::error::DuneXTHints.cmake was not installed"
-          exit 1
-        fi
-        moduledir="$(dirname "${module}")"
-        cmake "-DCMAKE_MODULE_PATH=${moduledir}" -P /dev/stdin <<< 'include(DuneXTHints)'
-
     - name: Build
       # Cap the library build at the memory-bounded -j too: ninja would otherwise
       # default to nproc+2, and the heavy template TUs can exhaust the 16 GB runner.
@@ -285,6 +262,30 @@ jobs:
       # bindings_jobs (cpu/2) caps these memory-heavy pybind11 TUs below the wider
       # linux_build_jobs used elsewhere, to stay under the 16 GB runner.
       run: cmake --build --preset=${{ matrix.preset }} --target bindings --parallel -- -j ${{ needs.config.outputs.bindings_jobs }}
+
+    - name: Test install
+      # Regression test for issue #388: nothing else in this workflow ever runs
+      # `cmake --install`, so a broken install(FILES) list (e.g. referencing a
+      # nonexistent file, or omitting a file another installed module
+      # `include()`s) stayed unnoticed until a downstream consumer's configure
+      # failed. Runs after every build step (not right after configure): some
+      # install() rules -- e.g. dune/xt/test/CMakeLists.txt's gtest_dune_xt
+      # library -- install built target files, which do not exist yet earlier
+      # in the job. The second check reproduces the exact failure mode from the
+      # issue: FindMKL/FindCBLAS/FindLAPACKE all `include(DuneXTHints)`, so an
+      # installed tree that is missing DuneXTHints.cmake would leave
+      # LIB_HINTS/INCLUDE_HINTS/append_to_each/include_sys_dir undefined for
+      # downstream consumers.
+      run: |
+        prefix="$(mktemp -d)"
+        cmake --install "build/${{ matrix.preset }}" --prefix "${prefix}"
+        module="$(find "${prefix}" -type f -name DuneXTHints.cmake -print -quit)"
+        if [[ ! -f "${module}" ]]; then
+          echo "::error::DuneXTHints.cmake was not installed"
+          exit 1
+        fi
+        moduledir="$(dirname "${module}")"
+        cmake "-DCMAKE_MODULE_PATH=${moduledir}" -P /dev/stdin <<< 'include(DuneXTHints)'
 
     - name: Test with CTest
       # Runs both the C++ suite and the Python (pytest) suite — the latter is now

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -239,6 +239,28 @@ jobs:
       run: >
         cmake --preset=${{ matrix.preset }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
+    - name: Test install
+      # Regression test for issue #388: nothing else in this workflow ever runs
+      # `cmake --install`, so a broken install(FILES) list (e.g. referencing a
+      # nonexistent file, or omitting a file another installed module
+      # `include()`s) stayed unnoticed until a downstream consumer's configure
+      # failed. None of this project's install() rules depend on built targets
+      # (only headers/cmake modules are installed), so this can run right after
+      # configure. The second check reproduces the exact failure mode from the
+      # issue: FindMKL/FindCBLAS/FindLAPACKE all `include(DuneXTHints)`, so an
+      # installed tree that is missing DuneXTHints.cmake would leave
+      # LIB_HINTS/INCLUDE_HINTS/append_to_each/include_sys_dir undefined for
+      # downstream consumers.
+      run: |
+        prefix="$(mktemp -d)"
+        cmake --install "build/${{ matrix.preset }}" --prefix "${prefix}"
+        moduledir="$(dirname "$(find "${prefix}" -name DuneXTHints.cmake -print -quit)")"
+        if [[ -z "${moduledir}" ]]; then
+          echo "::error::DuneXTHints.cmake was not installed"
+          exit 1
+        fi
+        cmake "-DCMAKE_MODULE_PATH=${moduledir}" -P /dev/stdin <<< 'include(DuneXTHints)'
+
     - name: Build
       # Cap the library build at the memory-bounded -j too: ninja would otherwise
       # default to nproc+2, and the heavy template TUs can exhaust the 16 GB runner.

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -239,6 +239,40 @@ jobs:
       run: >
         cmake --preset=${{ matrix.preset }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
+    - name: Test install
+      # Regression test for issue #388: nothing else in this workflow ever runs
+      # `cmake --install`, so a broken install(FILES) list (e.g. referencing a
+      # nonexistent file, or omitting a file another installed module
+      # `include()`s) stayed unnoticed until a downstream consumer's configure
+      # failed. The second check reproduces the exact failure mode from the
+      # issue: FindMKL/FindCBLAS/FindLAPACKE all `include(DuneXTHints)`, so an
+      # installed tree that is missing DuneXTHints.cmake would leave
+      # LIB_HINTS/INCLUDE_HINTS/append_to_each/include_sys_dir undefined for
+      # downstream consumers.
+      #
+      # This deliberately installs only the cmake/modules subtree (its
+      # generated per-directory script, which needs no built targets and so can
+      # run right after configure) rather than the whole build tree with a
+      # plain `cmake --install`: the latter also runs
+      # DunePybindxiInstallPythonPackage.cmake's install(CODE) rule for the
+      # Python wheel, which calls dune-common's `dune_execute_process` -- a
+      # macro that is not available in the standalone `cmake -P` process an
+      # install script runs in, so it always fails with "Unknown CMake
+      # command". That is a pre-existing bug in the Python packaging install
+      # path, unrelated to and out of scope for issue #388's cmake/modules
+      # manifest fix (tracked separately in #401); scoping the smoke test to
+      # cmake/modules keeps it testing what the issue is actually about.
+      run: |
+        prefix="$(mktemp -d)"
+        cmake "-DCMAKE_INSTALL_PREFIX=${prefix}" -P "build/${{ matrix.preset }}/cmake/modules/cmake_install.cmake"
+        module="$(find "${prefix}" -type f -name DuneXTHints.cmake -print -quit)"
+        if [[ ! -f "${module}" ]]; then
+          echo "::error::DuneXTHints.cmake was not installed"
+          exit 1
+        fi
+        moduledir="$(dirname "${module}")"
+        cmake "-DCMAKE_MODULE_PATH=${moduledir}" -P /dev/stdin <<< 'include(DuneXTHints)'
+
     - name: Build
       # Cap the library build at the memory-bounded -j too: ninja would otherwise
       # default to nproc+2, and the heavy template TUs can exhaust the 16 GB runner.
@@ -262,30 +296,6 @@ jobs:
       # bindings_jobs (cpu/2) caps these memory-heavy pybind11 TUs below the wider
       # linux_build_jobs used elsewhere, to stay under the 16 GB runner.
       run: cmake --build --preset=${{ matrix.preset }} --target bindings --parallel -- -j ${{ needs.config.outputs.bindings_jobs }}
-
-    - name: Test install
-      # Regression test for issue #388: nothing else in this workflow ever runs
-      # `cmake --install`, so a broken install(FILES) list (e.g. referencing a
-      # nonexistent file, or omitting a file another installed module
-      # `include()`s) stayed unnoticed until a downstream consumer's configure
-      # failed. Runs after every build step (not right after configure): some
-      # install() rules -- e.g. dune/xt/test/CMakeLists.txt's gtest_dune_xt
-      # library -- install built target files, which do not exist yet earlier
-      # in the job. The second check reproduces the exact failure mode from the
-      # issue: FindMKL/FindCBLAS/FindLAPACKE all `include(DuneXTHints)`, so an
-      # installed tree that is missing DuneXTHints.cmake would leave
-      # LIB_HINTS/INCLUDE_HINTS/append_to_each/include_sys_dir undefined for
-      # downstream consumers.
-      run: |
-        prefix="$(mktemp -d)"
-        cmake --install "build/${{ matrix.preset }}" --prefix "${prefix}"
-        module="$(find "${prefix}" -type f -name DuneXTHints.cmake -print -quit)"
-        if [[ ! -f "${module}" ]]; then
-          echo "::error::DuneXTHints.cmake was not installed"
-          exit 1
-        fi
-        moduledir="$(dirname "${module}")"
-        cmake "-DCMAKE_MODULE_PATH=${moduledir}" -P /dev/stdin <<< 'include(DuneXTHints)'
 
     - name: Test with CTest
       # Runs both the C++ suite and the Python (pytest) suite — the latter is now

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -28,8 +28,8 @@ install(
         FindMKL.cmake
         FindMPI4PY.cmake
         FindSpe10Data.cmake
+        DuneXTHints.cmake
         GridUtils.cmake
-        Hints.cmake
         XtCompilerSupport.cmake
         XtTooling.cmake
   DESTINATION ${DUNE_INSTALL_MODULEDIR})

--- a/dune.module
+++ b/dune.module
@@ -17,5 +17,5 @@ Module: dune-gdt
 # USE DUNE_GDT_GIT_VERSION in cmake scripts instead
 Version: SET.BY.CMAKE
 Maintainer: dune-gdt@dune-community.ovh
-Depends: dune-common (>= 2.8) dune-geometry (>= 2.8) dune-grid (>= 2.8) dune-istl (>= 2.8) dune-localfunctions (>= 2.8)
-Suggests: dune-testtools (>= 2.8) dune-alugrid (>= 2.8) dune-grid-glue (>= 2.8) dune-uggrid (>= 2.8)
+Depends: dune-common (>= 2.8) dune-geometry (>= 2.8) dune-grid (>= 2.8) dune-istl (>= 2.8) dune-localfunctions (>= 2.8) dune-testtools (>= 2.8) dune-alugrid (>= 2.8)
+Suggests: dune-uggrid (>= 2.8)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -54,7 +54,6 @@
     "exprtk",
     "gtest",
     "nanobench",
-    "pybind11",
     "eigen3",
     "tbb",
     "openblas",


### PR DESCRIPTION
Fixes #388.

## Summary

- `cmake/modules/CMakeLists.txt` installed a nonexistent `Hints.cmake` instead of the real `DuneXTHints.cmake`. `install(FILES)` on a missing file errors at install time, and even if the entry were just dropped, downstream consumers would still break: `FindMKL.cmake`, `FindCBLAS.cmake` and `FindLAPACKE.cmake` all start with `include(DuneXTHints)`, and those three *are* installed — so `LIB_HINTS`/`INCLUDE_HINTS`/`append_to_each`/`include_sys_dir` would be undefined for an installed dune-gdt.
- `vcpkg.json` listed `pybind11` twice (lines 41 and 57) — dropped the duplicate.
- `dune.module`'s `Suggests:` line was out of sync with `CMakeLists.txt`: `dune-testtools` and `dune-alugrid` are actually `REQUIRED` (moved to `Depends:`), and `dune-grid-glue` was removed from the build entirely (dropped from `Suggests:`). `dune-uggrid` stays in `Suggests:` since it's genuinely optional (feature-gated via `VCPKG_MANIFEST_FEATURES`).
- Added an install smoke test to the Linux CI job (`build-linux`), since nothing in `.github/workflows/non_docker_build.yml` previously ran `cmake --install` — that's exactly what let the broken install list sit unnoticed. The new step installs into a scratch prefix right after configure and then does `include(DuneXTHints)` against the installed module dir, reproducing the failure mode described in the issue.

## Test plan

- [x] `cmake/modules/CMakeLists.txt` now lists `DuneXTHints.cmake` (verified the file exists at that path, `Hints.cmake` does not).
- [x] `vcpkg.json` validated as well-formed JSON with no duplicate `pybind11` entry.
- [x] `dune.module`'s `Depends`/`Suggests` now match the modules `CMakeLists.txt` actually requires/features-gates.
- [ ] CI (`build-linux`) exercises the new "Test install" step on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S5xnaCFM5R94i1YbgEbQYL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build and Installation**
  - Added a CI “Test install” step that performs a modules-only install and verifies the required CMake integration module can be included successfully.
  - Updated the installed CMake modules to include `DuneXTHints.cmake` instead of the previous `Hints.cmake`.

- **Dependencies**
  - Adjusted module metadata so `dune-alugrid` and `dune-testtools` are treated as required dependencies rather than suggestions.
  - Added `exprtk`, `gtest`, and `nanobench` to package-based dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->