### PR TITLE
ci(docs): capture Xvfb's own error log on docs failure

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -640,7 +640,12 @@ jobs:
         cd "${RUNNER_TEMP}"
         OUT="${GITHUB_WORKSPACE}/build/docs_html"
         # --no-project: ignore the repo-root pyproject stub; run in the venv built above
-        xvfb-run -a uv run --no-project \
+        # -e: Xvfb's own stderr is a separate process from the notebook kernel, so it
+        # survives a kernel death that would otherwise lose whatever the X server saw
+        # (a crashed VTK render is a plausible non-signal way to kill the kernel: Xlib's
+        # default fatal-IO-error handler calls exit() directly, which faulthandler cannot
+        # trap and dmesg never sees since it is a userspace X11 event, not a kernel one).
+        xvfb-run -a -e "${RUNNER_TEMP}/xvfb-error.log" uv run --no-project \
           --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
           python -m sphinx --keep-going -j 1 -b html \
           "${GITHUB_WORKSPACE}/docs/source" "${OUT}"
@@ -669,6 +674,12 @@ jobs:
       # is unavailable or empty (e.g. a signal faulthandler already caught).
       if: failure()
       run: sudo dmesg --time-format iso | tail -n 200 || true
+
+    - name: Dump Xvfb error log on docs failure
+      # See the -e flag above: this is the X server's own stderr, independent of whatever
+      # the notebook kernel process managed (or failed) to report on its own.
+      if: failure()
+      run: cat "${RUNNER_TEMP}/xvfb-error.log" 2>/dev/null || echo "(no xvfb-error.log, or it is empty)"
 
     - name: Upload built docs HTML
       if: always()

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -679,7 +679,12 @@ jobs:
       # See the -e flag above: this is the X server's own stderr, independent of whatever
       # the notebook kernel process managed (or failed) to report on its own.
       if: failure()
-      run: cat "${RUNNER_TEMP}/xvfb-error.log" 2>/dev/null || echo "(no xvfb-error.log, or it is empty)"
+      run: |
+        if [[ -s "${RUNNER_TEMP}/xvfb-error.log" ]]; then
+          cat "${RUNNER_TEMP}/xvfb-error.log"
+        else
+          echo "(no xvfb-error.log, or it is empty)"
+        fi
 
     - name: Upload built docs HTML
       if: always()

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -624,8 +624,18 @@ jobs:
       # emits one page per class/function (group_by="namespace"), a far larger document
       # set whose per-worker environment copies under "-j auto" OOM-killed the 16 GB box
       # mid-write. Single-threaded keeps peak RAM bounded; the 60 min timeout is ample.
+      #
+      # PYTHONFAULTHANDLER: a notebook kernel that dies from a deadly signal (segfault,
+      # abort) surfaces to sphinx only as nbclient.exceptions.DeadKernelError: Kernel died,
+      # with no traceback -- nb_execution_raise_on_error=False only covers python-level
+      # cell errors, never a killed kernel process. faulthandler installs handlers for
+      # SIGSEGV/SIGABRT/SIGFPE/SIGBUS that dump the C-level Python stack to the kernel's
+      # inherited stderr (this job's own log) before the process dies, turning an
+      # otherwise undiagnosable failure into one with an actual traceback. It cannot catch
+      # SIGKILL (the OOM-killer's signal); "Dump dmesg on docs failure" below covers that.
       env:
         DUNE_GDT_BENCHMARK_DATA: ${{ github.workspace }}/build/benchmark_data
+        PYTHONFAULTHANDLER: "1"
       run: |
         cd "${RUNNER_TEMP}"
         OUT="${GITHUB_WORKSPACE}/build/docs_html"
@@ -651,6 +661,14 @@ jobs:
           cat "${f}"
           echo "::endgroup::"
         done
+
+    - name: Dump dmesg on docs failure
+      # A notebook kernel killed by SIGKILL (the OOM-killer) leaves no report above and no
+      # faulthandler output either (PYTHONFAULTHANDLER only catches signals a process can
+      # trap); the kernel log is the only place that death is recorded. Non-fatal if dmesg
+      # is unavailable or empty (e.g. a signal faulthandler already caught).
+      if: failure()
+      run: sudo dmesg --time-format iso | tail -n 200 || true
 
     - name: Upload built docs HTML
       if: always()


### PR DESCRIPTION
## Summary

Diagnostic follow-up to the `Build docs` kernel death investigated on #379. `Build docs` has failed 4 of 5 attempts with an identical `nbclient.exceptions.DeadKernelError: Kernel died` on `docs/source/example__ESV2007_estimates.md`.

Two rounds of instrumentation already landed on #379 and were fully checked on the most recent failure:
- `PYTHONFAULTHANDLER=1` — no output. Rules out a trappable signal (`SIGSEGV`/`SIGABRT`/`SIGFPE`/`SIGBUS`/`SIGILL`).
- `dmesg` dump on failure — nothing between VM boot and the crash. Rules out the standard OOM-killer.

That narrows it to either an unusual `SIGKILL`, or — a candidate that fits every constraint above — a **plain, non-signal process exit**: Xlib's default fatal-IO-error handler calls `exit()` directly on certain X11 protocol errors, which neither `faulthandler` nor `dmesg` would ever catch. `example__ESV2007_estimates.md` is the first notebook to call `visualize_function` repeatedly (5 times), and #393 (merged into `main` since) independently found the entire `k3d`/VTK visualisation path had **zero test coverage** before that — `k3d` was missing from the ctest dependency group, so `HAVE_K3D` was permanently `False` under test. The `Build docs` job may be the first place this path ever actually executes under CI.

## Change

Cherry-picks the two existing diagnostics from #379 (`PYTHONFAULTHANDLER=1`, `dmesg`-on-failure), then adds:
- `xvfb-run -e "${RUNNER_TEMP}/xvfb-error.log"` to capture the X server's own stderr — a separate process from the notebook kernel, so it survives a kernel death that would otherwise lose whatever the X server saw.
- A dump-on-failure step for that log.

This branch is based on current `main` (not #379), so a `Build docs` run here also serves as an uncoupled test of whether the crash is #379-specific at all: if it reproduces here too, with no code from #379 present, that would settle the question outright.

## Note

Diagnostics only — no behavioral change to the build itself. Companion to [claude/issue-378-isolate-keep-alive](https://github.com/dune-gdt/dune-gdt/pull/new/claude/issue-378-isolate-keep-alive), which isolates just the `py::keep_alive` binding change from #379 on top of this same `main`, as a second independent test.

cc @renefritze — opened per your go-ahead in the #379 thread to run both remaining diagnostic ideas as separate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SW6ihHXRUL9Wv9q9wux24Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation build diagnostics for notebook execution failures.
  * Added additional reporting for kernel termination and display-server errors to make build issues easier to investigate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->