### PR TITLE
test(python): isolate the space-binding keep_alive fix from #379

### DIFF
--- a/python/gdt/dune/gdt/spaces/binding_helpers.hh
+++ b/python/gdt/dune/gdt/spaces/binding_helpers.hh
@@ -1,0 +1,78 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#ifndef PYTHON_DUNE_GDT_SPACES_BINDING_HELPERS_HH
+#define PYTHON_DUNE_GDT_SPACES_BINDING_HELPERS_HH
+
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include <pybind11/pybind11.h>
+
+#include <dune/xt/common/string.hh>
+#include <dune/xt/common/type_traits.hh>
+
+namespace Dune {
+namespace GDT {
+namespace bindings {
+
+
+/**
+ * \brief The name under which a space binding registers its python class, e.g.
+ *        "ContinuousLagrangeSpace2dCubeYaspgridTo2d".
+ *
+ * Every space binding derives its class name the same way - class_id, grid, range dimension, field - and every one of
+ * them used to spell that derivation out again. Keeping it here makes the naming convention a single decision rather
+ * than one repeated per space.
+ *
+ * \param always_append_range_dim  RaviartThomasSpace is vector valued by construction (r == d) and tags even its 1d
+ *                                 binding "..._to_1d"; the others only tag r > 1.
+ */
+template <size_t r, class R>
+std::string
+space_class_name(const std::string& class_id, const std::string& grid_id, const bool always_append_range_dim = false)
+{
+  std::string class_name = class_id + "_" + grid_id;
+  if (always_append_range_dim || r > 1)
+    class_name += "_to_" + XT::Common::to_string(r) + "d";
+  if (!std::is_same<R, double>::value)
+    class_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
+  return XT::Common::to_camel_case(class_name);
+} // ... space_class_name(...)
+
+
+/// \brief The name of the module-level factory a space binding adds next to its class, e.g. "ContinuousLagrangeSpace".
+template <class R>
+std::string space_factory_name(const std::string& class_id)
+{
+  std::string space_type_name = class_id;
+  if (!std::is_same<R, double>::value)
+    space_type_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
+  return XT::Common::to_camel_case(space_type_name);
+}
+
+
+/// \brief Adds the __repr__ that every space binding shares (the space's own operator<<).
+template <class BoundType>
+void add_space_repr(BoundType& c)
+{
+  c.def("__repr__", [](const typename BoundType::type& self) {
+    std::stringstream ss;
+    ss << self;
+    return ss.str();
+  });
+}
+
+
+} // namespace bindings
+} // namespace GDT
+} // namespace Dune
+
+#endif // PYTHON_DUNE_GDT_SPACES_BINDING_HELPERS_HH

--- a/python/gdt/dune/gdt/spaces/finite_volume_binding.hh
+++ b/python/gdt/dune/gdt/spaces/finite_volume_binding.hh
@@ -1,0 +1,135 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2020)
+
+#ifndef PYTHON_DUNE_GDT_SPACES_FINITE_VOLUME_BINDING_HH
+#define PYTHON_DUNE_GDT_SPACES_FINITE_VOLUME_BINDING_HH
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <dune/xt/grid/gridprovider/provider.hh>
+
+#include <dune/gdt/spaces/interface.hh>
+
+#include <python/xt/dune/xt/common/configuration.hh>
+#include <python/xt/dune/xt/common/fvector.hh>
+#include <python/xt/dune/xt/grid/grids.bindings.hh>
+#include <python/xt/dune/xt/grid/traits.hh>
+#include <python/gdt/dune/gdt/spaces/binding_helpers.hh>
+
+namespace Dune {
+namespace GDT {
+namespace bindings {
+
+
+/**
+ * \brief Binds a piecewise constant space that is constructed from nothing but a grid view.
+ *
+ * GDT::FiniteVolumeSpace (dune/gdt/spaces/l2/finite-volume.hh, one DoF per element) and
+ * GDT::FiniteVolumeSkeletonSpace (dune/gdt/spaces/skeleton/finite-volume.hh, one DoF per intersection) share their
+ * whole binding surface - a single-argument constructor, a __repr__ and a module-level factory - and used to be bound
+ * by two files that differed only in the name of the space. SpaceType is the template of the space to bind.
+ *
+ * \note Assumes that GV is the leaf view!
+ */
+template <template <class, size_t, size_t, class> class SpaceType, class GV, size_t r = 1, class R = double>
+class FiniteVolumeSpaceBinding
+{
+  using G = typename GV::Grid;
+  static const size_t d = G::dimension;
+
+public:
+  using type = SpaceType<GV, r, 1, R>;
+  using base_type = GDT::SpaceInterface<GV, r, 1, R>;
+  using bound_type = pybind11::class_<type, base_type>;
+
+  static bound_type bind(pybind11::module& m, const std::string& grid_id, const std::string& class_id)
+  {
+    namespace py = pybind11;
+    using namespace pybind11::literals;
+
+    const auto ClassName = space_class_name<r, R>(class_id, grid_id);
+    bound_type c(m, ClassName.c_str(), ClassName.c_str());
+    c.def(py::init([](XT::Grid::GridProvider<G>& grid_provider) {
+            return new type(grid_provider.leaf_view()); // Otherwise we get an error here!
+          }),
+          // A space holds the grid *view*, which points into the grid the provider owns: without this, a space
+          // built from a temporary provider outlives its grid and every later use is a use-after-free (#378).
+          py::keep_alive<1, 2>(),
+          "grid_provider"_a);
+    add_space_repr(c);
+
+    const auto FactoryName = space_factory_name<R>(class_id);
+    if (r == 1)
+      m.def(
+          FactoryName.c_str(),
+          [](XT::Grid::GridProvider<G>& grid, const XT::Grid::bindings::Dimension<r>&) {
+            return new type(grid.leaf_view()); // Otherwise we get an error here!
+          },
+          py::keep_alive<0, 1>(), // see the init above
+          "grid"_a,
+          "dim_range"_a = XT::Grid::bindings::Dimension<r>());
+    else
+      m.def(
+          FactoryName.c_str(),
+          [](XT::Grid::GridProvider<G>& grid, const XT::Grid::bindings::Dimension<r>&) {
+            return new type(grid.leaf_view()); // Otherwise we get an error here!
+          },
+          py::keep_alive<0, 1>(), // see the init above
+          "grid"_a,
+          "dim_range"_a);
+
+    return c;
+  } // ... bind(...)
+}; // class FiniteVolumeSpaceBinding
+
+
+/**
+ * \brief Binds FiniteVolumeSpaceBinding<SpaceType, ...> for every grid the build instantiates.
+ *
+ * bind_vector_valued has to stay false for a space that is only implemented for r == 1: the `if constexpr` below is
+ * what keeps the vector-valued instantiation from being compiled at all in that case (it would hit the
+ * "Untested for these dimensions!" static_assert on the space's primary template).
+ */
+template <template <class, size_t, size_t, class> class SpaceType,
+          bool bind_vector_valued,
+          class GridTypes = Dune::XT::Grid::bindings::AvailableGridTypes>
+struct FiniteVolumeSpaceBinding_for_all_grids
+{
+  using G = Dune::XT::Common::tuple_head_t<GridTypes>;
+  using GV = typename G::LeafGridView;
+  static const constexpr size_t d = G::dimension;
+
+  static void bind(pybind11::module& m, const std::string& class_id)
+  {
+    using Dune::XT::Grid::bindings::grid_name;
+
+    FiniteVolumeSpaceBinding<SpaceType, GV>::bind(m, grid_name<G>::value(), class_id);
+    if constexpr (bind_vector_valued)
+      if (d > 1)
+        FiniteVolumeSpaceBinding<SpaceType, GV, d>::bind(m, grid_name<G>::value(), class_id);
+    // add your extra dimensions here
+    // ...
+    FiniteVolumeSpaceBinding_for_all_grids<SpaceType, bind_vector_valued, Dune::XT::Common::tuple_tail_t<GridTypes>>::
+        bind(m, class_id);
+  }
+};
+
+template <template <class, size_t, size_t, class> class SpaceType, bool bind_vector_valued>
+struct FiniteVolumeSpaceBinding_for_all_grids<SpaceType, bind_vector_valued, Dune::XT::Common::tuple_null_type>
+{
+  static void bind(pybind11::module& /*m*/, const std::string& /*class_id*/) {}
+};
+
+
+} // namespace bindings
+} // namespace GDT
+} // namespace Dune
+
+#endif // PYTHON_DUNE_GDT_SPACES_FINITE_VOLUME_BINDING_HH

--- a/python/gdt/dune/gdt/spaces/h1/continuous-lagrange.hh
+++ b/python/gdt/dune/gdt/spaces/h1/continuous-lagrange.hh
@@ -21,6 +21,7 @@
 #include <python/xt/dune/xt/common/fvector.hh>
 #include <python/xt/dune/xt/grid/grids.bindings.hh>
 #include <python/xt/dune/xt/grid/traits.hh>
+#include <python/gdt/dune/gdt/spaces/binding_helpers.hh>
 
 namespace Dune {
 namespace GDT {
@@ -47,46 +48,41 @@ public:
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    std::string class_name = class_id + "_" + grid_id;
-    if (r > 1)
-      class_name += "_to_" + XT::Common::to_string(r) + "d";
-    if (!std::is_same<R, double>::value)
-      class_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
-    const auto ClassName = XT::Common::to_camel_case(class_name);
+    const auto ClassName = space_class_name<r, R>(class_id, grid_id);
     bound_type c(m, ClassName.c_str(), ClassName.c_str());
     c.def(py::init([](XT::Grid::GridProvider<G>& grid_provider, const int order, const std::string& logging_prefix) {
             return new type(grid_provider.leaf_view(), order, logging_prefix);
           }),
+          // A space holds the grid *view*, which points into the grid the provider owns: without this, a space built
+          // from a temporary provider (`ContinuousLagrangeSpace(make_grid(), order=1)`) outlives its grid and every
+          // later use of it is a use-after-free (#378).
+          py::keep_alive<1, 2>(),
           "grid_provider"_a,
           "order"_a,
           "logging_prefix"_a = "");
-    c.def("__repr__", [](const type& self) {
-      std::stringstream ss;
-      ss << self;
-      return ss.str();
-    });
+    add_space_repr(c);
 
-    std::string space_type_name = class_id;
-    if (!std::is_same<R, double>::value)
-      space_type_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
+    const auto FactoryName = space_factory_name<R>(class_id);
     if (r == 1)
       m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
+          FactoryName.c_str(),
           [](XT::Grid::GridProvider<G>& grid,
              const int order,
              const XT::Grid::bindings::Dimension<r>&,
              const std::string& logging_prefix) { return new type(grid.leaf_view(), order, logging_prefix); },
+          py::keep_alive<0, 1>(), // see the init above
           "grid"_a,
           "order"_a,
           "dim_range"_a = XT::Grid::bindings::Dimension<r>(),
           "logging_prefix"_a = "");
     else
       m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
+          FactoryName.c_str(),
           [](XT::Grid::GridProvider<G>& grid,
              const int order,
              const XT::Grid::bindings::Dimension<r>&,
              const std::string& logging_prefix) { return new type(grid.leaf_view(), order, logging_prefix); },
+          py::keep_alive<0, 1>(), // see the init above
           "grid"_a,
           "order"_a,
           "dim_range"_a,

--- a/python/gdt/dune/gdt/spaces/hdiv/raviart-thomas.cc
+++ b/python/gdt/dune/gdt/spaces/hdiv/raviart-thomas.cc
@@ -20,6 +20,7 @@
 #include <python/xt/dune/xt/common/fvector.hh>
 #include <python/xt/dune/xt/grid/grids.bindings.hh>
 #include <python/xt/dune/xt/grid/traits.hh>
+#include <python/gdt/dune/gdt/spaces/binding_helpers.hh>
 
 namespace Dune {
 namespace GDT {
@@ -46,32 +47,26 @@ public:
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    std::string class_name = class_id + "_" + grid_id;
-    class_name += "_to_" + XT::Common::to_string(size_t(d)) + "d";
-    if (!std::is_same<R, double>::value)
-      class_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
-    const auto ClassName = XT::Common::to_camel_case(class_name);
+    const auto ClassName = space_class_name<d, R>(class_id, grid_id, /*always_append_range_dim=*/true);
     bound_type c(m, ClassName.c_str(), ClassName.c_str());
     c.def(py::init([](XT::Grid::GridProvider<G>& grid_provider, const int order, const std::string& logging_prefix) {
             return new type(grid_provider.leaf_view(), order, logging_prefix); // Otherwise we get an error here!
           }),
+          // A space holds the grid *view*, which points into the grid the provider owns: without this, a space
+          // built from a temporary provider outlives its grid and every later use is a use-after-free (#378).
+          py::keep_alive<1, 2>(),
           "grid_provider"_a,
           "order"_a,
           "logging_prefix"_a = "");
-    c.def("__repr__", [](const type& self) {
-      std::stringstream ss;
-      ss << self;
-      return ss.str();
-    });
+    add_space_repr(c);
 
-    std::string space_type_name = class_id;
-    if (!std::is_same<R, double>::value)
-      space_type_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
+    const auto FactoryName = space_factory_name<R>(class_id);
     m.def(
-        XT::Common::to_camel_case(space_type_name).c_str(),
+        FactoryName.c_str(),
         [](XT::Grid::GridProvider<G>& grid, const int order, const std::string& logging_prefix) {
           return new type(grid.leaf_view(), order, logging_prefix); // Otherwise we get an error here!
         },
+        py::keep_alive<0, 1>(), // see the init above
         "grid"_a,
         "order"_a,
         "logging_prefix"_a = "");

--- a/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange.hh
+++ b/python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange.hh
@@ -21,6 +21,7 @@
 #include <python/xt/dune/xt/common/fvector.hh>
 #include <python/xt/dune/xt/grid/grids.bindings.hh>
 #include <python/xt/dune/xt/grid/traits.hh>
+#include <python/gdt/dune/gdt/spaces/binding_helpers.hh>
 
 namespace Dune {
 namespace GDT {
@@ -47,18 +48,16 @@ public:
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    std::string class_name = class_id + "_" + grid_id;
-    if (r > 1)
-      class_name += "_to_" + XT::Common::to_string(r) + "d";
-    if (!std::is_same<R, double>::value)
-      class_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
-    const auto ClassName = XT::Common::to_camel_case(class_name);
+    const auto ClassName = space_class_name<r, R>(class_id, grid_id);
     bound_type c(m, ClassName.c_str(), ClassName.c_str());
     c.def_property_readonly("dimwise_global_mapping", [](type& self) { return self.dimwise_global_mapping; });
     c.def(py::init([](XT::Grid::GridProvider<G>& grid_provider, const int order, const bool dimwise_global_mapping) {
             return new type(grid_provider.leaf_view(), order, dimwise_global_mapping); // Otherwise we get an error
                                                                                        // here!
           }),
+          // A space holds the grid *view*, which points into the grid the provider owns: without this, a space
+          // built from a temporary provider outlives its grid and every later use is a use-after-free (#378).
+          py::keep_alive<1, 2>(),
           "grid_provider"_a,
           "order"_a,
           "dimwise_global_mapping"_a = (r == 1) ? false : true);
@@ -86,37 +85,33 @@ public:
           return std::move(points);
         },
         py::call_guard<py::gil_scoped_release>());
-    c.def("__repr__", [](const type& self) {
-      std::stringstream ss;
-      ss << self;
-      return ss.str();
-    });
+    add_space_repr(c);
 
-    std::string space_type_name = class_id;
-    if (!std::is_same<R, double>::value)
-      space_type_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
+    const auto FactoryName = space_factory_name<R>(class_id);
     if (r == 1)
       m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
+          FactoryName.c_str(),
           [](XT::Grid::GridProvider<G>& grid,
              const int order,
              const bool dimwise_global_mapping,
              const XT::Grid::bindings::Dimension<r>&) {
             return new type(grid.leaf_view(), order, dimwise_global_mapping); // Otherwise we get an error here!
           },
+          py::keep_alive<0, 1>(), // see the init above
           "grid"_a,
           "order"_a,
           "dimwise_global_mapping"_a = (r == 1) ? false : true,
           "dim_range"_a = XT::Grid::bindings::Dimension<r>());
     else
       m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
+          FactoryName.c_str(),
           [](XT::Grid::GridProvider<G>& grid,
              const int order,
              const bool dimwise_global_mapping,
              const XT::Grid::bindings::Dimension<r>&) {
             return new type(grid.leaf_view(), order, dimwise_global_mapping); // Otherwise we get an error here!
           },
+          py::keep_alive<0, 1>(), // see the init above
           "grid"_a,
           "order"_a,
           "dimwise_global_mapping"_a = (r == 1) ? false : true,

--- a/python/gdt/dune/gdt/spaces/l2/finite-volume.cc
+++ b/python/gdt/dune/gdt/spaces/l2/finite-volume.cc
@@ -10,115 +10,10 @@
 #include "config.h"
 
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
-#include <dune/xt/grid/gridprovider/provider.hh>
 
 #include <dune/gdt/spaces/l2/finite-volume.hh>
 
-#include <python/xt/dune/xt/common/configuration.hh>
-#include <python/xt/dune/xt/common/fvector.hh>
-#include <python/xt/dune/xt/grid/grids.bindings.hh>
-#include <python/xt/dune/xt/grid/traits.hh>
-
-namespace Dune {
-namespace GDT {
-namespace bindings {
-
-
-/**
- * \note Assumes that GV is the leaf view!
- */
-template <class GV, size_t r = 1, class R = double>
-class FiniteVolumeSpace
-{
-  using G = typename GV::Grid;
-  static const size_t d = G::dimension;
-
-public:
-  using type = GDT::FiniteVolumeSpace<GV, r, 1, R>;
-  using base_type = GDT::SpaceInterface<GV, r, 1, R>;
-  using bound_type = pybind11::class_<type, base_type>;
-
-  static bound_type
-  bind(pybind11::module& m, const std::string& grid_id, const std::string& class_id = "finite_volume_space")
-  {
-    namespace py = pybind11;
-    using namespace pybind11::literals;
-
-    std::string class_name = class_id + "_" + grid_id;
-    if (r > 1)
-      class_name += "_to_" + XT::Common::to_string(r) + "d";
-    if (!std::is_same<R, double>::value)
-      class_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
-    const auto ClassName = XT::Common::to_camel_case(class_name);
-    bound_type c(m, ClassName.c_str(), ClassName.c_str());
-    c.def(py::init([](XT::Grid::GridProvider<G>& grid_provider) {
-            return new type(grid_provider.leaf_view()); // Otherwise we get an error here!
-          }),
-          "grid_provider"_a);
-    c.def("__repr__", [](const type& self) {
-      std::stringstream ss;
-      ss << self;
-      return ss.str();
-    });
-
-    std::string space_type_name = class_id;
-    if (!std::is_same<R, double>::value)
-      space_type_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
-    if (r == 1)
-      m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
-          [](XT::Grid::GridProvider<G>& grid, const XT::Grid::bindings::Dimension<r>&) {
-            return new type(grid.leaf_view()); // Otherwise we get an error here!
-          },
-          "grid"_a,
-          "dim_range"_a = XT::Grid::bindings::Dimension<r>());
-    else
-      m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
-          [](XT::Grid::GridProvider<G>& grid, const XT::Grid::bindings::Dimension<r>&) {
-            return new type(grid.leaf_view()); // Otherwise we get an error here!
-          },
-          "grid"_a,
-          "dim_range"_a);
-
-    return c;
-  } // ... bind(...)
-}; // class FiniteVolumeSpace
-
-
-} // namespace bindings
-} // namespace GDT
-} // namespace Dune
-
-
-template <class GridTypes = Dune::XT::Grid::bindings::AvailableGridTypes>
-struct FiniteVolumeSpace_for_all_grids
-{
-  using G = Dune::XT::Common::tuple_head_t<GridTypes>;
-  using GV = typename G::LeafGridView;
-  static const constexpr size_t d = G::dimension;
-
-  static void bind(pybind11::module& m)
-  {
-    using Dune::GDT::bindings::FiniteVolumeSpace;
-    using Dune::XT::Grid::bindings::grid_name;
-
-    FiniteVolumeSpace<GV>::bind(m, grid_name<G>::value());
-    if (d > 1)
-      FiniteVolumeSpace<GV, d>::bind(m, grid_name<G>::value());
-    // add your extra dimensions here
-    // ...
-    FiniteVolumeSpace_for_all_grids<Dune::XT::Common::tuple_tail_t<GridTypes>>::bind(m);
-  }
-};
-
-template <>
-struct FiniteVolumeSpace_for_all_grids<Dune::XT::Common::tuple_null_type>
-{
-  static void bind(pybind11::module& /*m*/) {}
-};
+#include <python/gdt/dune/gdt/spaces/finite_volume_binding.hh>
 
 
 PYBIND11_MODULE(_spaces_l2_finite_volume, m)
@@ -135,5 +30,8 @@ PYBIND11_MODULE(_spaces_l2_finite_volume, m)
 
   py::module::import("dune.gdt._spaces_interface");
 
-  FiniteVolumeSpace_for_all_grids<XT::Grid::bindings::AvailableGridTypes>::bind(m);
+  bindings::FiniteVolumeSpaceBinding_for_all_grids<GDT::FiniteVolumeSpace,
+                                                   /*bind_vector_valued=*/true,
+                                                   XT::Grid::bindings::AvailableGridTypes>::bind(m,
+                                                                                                 "finite_volume_space");
 }

--- a/python/gdt/dune/gdt/spaces/skeleton/finite-volume.cc
+++ b/python/gdt/dune/gdt/spaces/skeleton/finite-volume.cc
@@ -10,112 +10,10 @@
 #include "config.h"
 
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
-#include <dune/xt/grid/gridprovider/provider.hh>
 
 #include <dune/gdt/spaces/skeleton/finite-volume.hh>
 
-#include <python/xt/dune/xt/common/configuration.hh>
-#include <python/xt/dune/xt/common/fvector.hh>
-#include <python/xt/dune/xt/grid/grids.bindings.hh>
-#include <python/xt/dune/xt/grid/traits.hh>
-
-namespace Dune {
-namespace GDT {
-namespace bindings {
-
-
-/**
- * \note Assumes that GV is the leaf view!
- */
-template <class GV, size_t r = 1, class R = double>
-class FiniteVolumeSkeletonSpace
-{
-  using G = typename GV::Grid;
-  static const size_t d = G::dimension;
-
-public:
-  using type = GDT::FiniteVolumeSkeletonSpace<GV, r, 1, R>;
-  using base_type = GDT::SpaceInterface<GV, r, 1, R>;
-  using bound_type = pybind11::class_<type, base_type>;
-
-  static bound_type
-  bind(pybind11::module& m, const std::string& grid_id, const std::string& class_id = "finite_volume_skeleton_space")
-  {
-    namespace py = pybind11;
-    using namespace pybind11::literals;
-
-    std::string class_name = class_id + "_" + grid_id;
-    if (r > 1)
-      class_name += "_to_" + XT::Common::to_string(r) + "d";
-    if (!std::is_same<R, double>::value)
-      class_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
-    const auto ClassName = XT::Common::to_camel_case(class_name);
-    bound_type c(m, ClassName.c_str(), ClassName.c_str());
-    c.def(py::init([](XT::Grid::GridProvider<G>& grid_provider) {
-            return new type(grid_provider.leaf_view()); // Otherwise we get an error here!
-          }),
-          "grid_provider"_a);
-    c.def("__repr__", [](const type& self) {
-      std::stringstream ss;
-      ss << self;
-      return ss.str();
-    });
-
-    std::string space_type_name = class_id;
-    if (!std::is_same<R, double>::value)
-      space_type_name += "_" + XT::Common::Typename<R>::value(/*fail_wo_typeid=*/true);
-    if (r == 1)
-      m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
-          [](XT::Grid::GridProvider<G>& grid, const XT::Grid::bindings::Dimension<r>&) {
-            return new type(grid.leaf_view()); // Otherwise we get an error here!
-          },
-          "grid"_a,
-          "dim_range"_a = XT::Grid::bindings::Dimension<r>());
-    else
-      m.def(
-          XT::Common::to_camel_case(space_type_name).c_str(),
-          [](XT::Grid::GridProvider<G>& grid, const XT::Grid::bindings::Dimension<r>&) {
-            return new type(grid.leaf_view()); // Otherwise we get an error here!
-          },
-          "grid"_a,
-          "dim_range"_a);
-
-    return c;
-  } // ... bind(...)
-}; // class FiniteVolumeSkeletonSpace
-
-
-} // namespace bindings
-} // namespace GDT
-} // namespace Dune
-
-
-template <class GridTypes = Dune::XT::Grid::bindings::AvailableGridTypes>
-struct FiniteVolumeSkeletonSpace_for_all_grids
-{
-  using G = Dune::XT::Common::tuple_head_t<GridTypes>;
-  using GV = typename G::LeafGridView;
-  static const constexpr size_t d = G::dimension;
-
-  static void bind(pybind11::module& m)
-  {
-    using Dune::GDT::bindings::FiniteVolumeSkeletonSpace;
-    using Dune::XT::Grid::bindings::grid_name;
-
-    FiniteVolumeSkeletonSpace<GV>::bind(m, grid_name<G>::value());
-
-    FiniteVolumeSkeletonSpace_for_all_grids<Dune::XT::Common::tuple_tail_t<GridTypes>>::bind(m);
-  }
-};
-
-template <>
-struct FiniteVolumeSkeletonSpace_for_all_grids<Dune::XT::Common::tuple_null_type>
-{
-  static void bind(pybind11::module& /*m*/) {}
-};
+#include <python/gdt/dune/gdt/spaces/finite_volume_binding.hh>
 
 
 PYBIND11_MODULE(_spaces_skeleton_finite_volume, m)
@@ -132,5 +30,9 @@ PYBIND11_MODULE(_spaces_skeleton_finite_volume, m)
 
   py::module::import("dune.gdt._spaces_interface");
 
-  FiniteVolumeSkeletonSpace_for_all_grids<XT::Grid::bindings::AvailableGridTypes>::bind(m);
+  // bind_vector_valued=false: FiniteVolumeSkeletonSpace is only specialised for r == rC == 1
+  bindings::FiniteVolumeSpaceBinding_for_all_grids<
+      GDT::FiniteVolumeSkeletonSpace,
+      /*bind_vector_valued=*/false,
+      XT::Grid::bindings::AvailableGridTypes>::bind(m, "finite_volume_skeleton_space");
 }


### PR DESCRIPTION
## Summary

Diagnostic-only PR, **not meant to merge as-is**. Part of the same investigation as #379 and #402.

#379's `Build docs` job has died 4 of 5 times with an identical `nbclient.exceptions.DeadKernelError: Kernel died` on `docs/source/example__ESV2007_estimates.md`. That notebook never calls either of #379's changed estimator functions (they're imported but unused there), and its three spaces are all built from a *named* `grid` variable, so `py::keep_alive` shouldn't change any lifetime on that path — but "shouldn't" isn't "doesn't," and two rounds of CI instrumentation (`PYTHONFAULTHANDLER`, `dmesg`) came back empty rather than confirming it.

## Change

Carries over **only** the seven files from #379 that add `py::keep_alive` + the shared naming helpers to the space factory bindings:

- `python/gdt/dune/gdt/spaces/binding_helpers.hh` (new)
- `python/gdt/dune/gdt/spaces/finite_volume_binding.hh` (new)
- `python/gdt/dune/gdt/spaces/h1/continuous-lagrange.hh`
- `python/gdt/dune/gdt/spaces/hdiv/raviart-thomas.cc`
- `python/gdt/dune/gdt/spaces/l2/discontinuous-lagrange.hh`
- `python/gdt/dune/gdt/spaces/l2/finite-volume.cc`
- `python/gdt/dune/gdt/spaces/skeleton/finite-volume.cc`

Deliberately drops `dune/gdt/exceptions.hh`, `dune/gdt/tools/grid-quality-estimates.hh`, both test files, and the C++ test additions — none of those can be involved if this crashes too.

## What the outcome means

- **`Build docs` fails here too** → the binding change is at least sufficient to reproduce it, narrowing #379's surface considerably (though see #402: if it *also* reproduces on plain `main` with no `#379` code at all, that would point elsewhere entirely, e.g. the untested `k3d`/VTK path noted in #393).
- **`Build docs` passes here** → the crash needs something from #379's estimator/test changes after all, despite the notebook not calling them directly, or is otherwise not reproducible from the bindings alone.

cc @renefritze — opened per your go-ahead in the #379 thread to run both remaining diagnostic ideas as separate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SW6ihHXRUL9Wv9q9wux24Y)_