### PR TITLE
test(gdt): cover the filtered Operator.apply walk, and close out the Tier 2 partials accounting (#338)

### DIFF
--- a/python/gdt/test/test_hypothesis_operator_local.py
+++ b/python/gdt/test/test_hypothesis_operator_local.py
@@ -269,6 +269,10 @@ def test_forward_operator_element_filter_masks_indicator_contributions(spec):
     assert np.all(kept | dropped)
     assert r_boundary.sum() <= r_all.sum() + tol
     assert np.all(r_boundary >= -tol)
+    # every grid here has at least one boundary cell, so the filter must retain something; without
+    # this the assertions above would also pass for a filter that behaved like ApplyOnNoElements
+    # (an all-zero r_boundary is trivially "all dropped").
+    assert np.any(kept)
 
 
 @pytest.mark.skipif(
@@ -299,8 +303,13 @@ def test_forward_operator_boundary_filter_drops_the_interior_cells():
 
     assert len(r_all) == 16
     assert np.allclose(r_all, 1.0 / 16.0, rtol=1e-9, atol=1e-12)
-    # 12 of the 16 cells touch the boundary, the remaining 4 are dropped by the filter
-    assert np.count_nonzero(r_boundary > 1e-12) == 12
+    # Every entry is either the full cell volume or exactly zero -- the filter masks whole cells,
+    # it never scales one. 12 of the 16 cells touch the boundary, the remaining 4 are dropped.
+    kept = np.isclose(r_boundary, 1.0 / 16.0, rtol=1e-9, atol=1e-12)
+    dropped = np.abs(r_boundary) <= 1e-12
+    assert np.all(kept | dropped)
+    assert np.count_nonzero(kept) == 12
+    assert np.count_nonzero(dropped) == 4
     assert np.isclose(r_boundary.sum(), 12.0 / 16.0, rtol=1e-9, atol=1e-12)
 
 

--- a/python/gdt/test/test_hypothesis_operator_local.py
+++ b/python/gdt/test/test_hypothesis_operator_local.py
@@ -235,8 +235,9 @@ def _indicator_result(grid, filter_factory):
     )
     indicator = LocalElementBilinearFormIndicatorOperator(local_form)
     op += (indicator, filter_factory(grid))
-    # single-argument apply returns a freshly allocated range vector
-    return np.asarray(op.apply(GF(grid, 1.0)), dtype=float)
+    # Applied to a GridFunction source, apply() returns a freshly allocated DiscreteFunction in the
+    # range space (only the vector-source overload returns a bare vector), so go through .dofs.
+    return np.asarray(op.apply(GF(grid, 1.0)).dofs.vector, dtype=float)
 
 
 @given(spec=GRIDS)

--- a/python/gdt/test/test_hypothesis_operator_local.py
+++ b/python/gdt/test/test_hypothesis_operator_local.py
@@ -10,7 +10,7 @@
 # ~~~
 """Local forms/operators appended to operators with an element filter, and the operator ``linear`` flag.
 
-Two partial branches in the operator layer are only reachable by appending local pieces that the
+Three partial branches in the operator layer are only reachable by appending local pieces that the
 existing operator tests never construct -- a non-trivial element filter, and a *nonlinear* local
 operator:
 
@@ -18,6 +18,9 @@ operator:
     ``MatrixOperator::apply_local``. Every existing assembly appends element bilinear forms without a
     filter (the default ``ApplyOnAllElements``), so the ``if`` is only ever taken. A ``BilinearForm``
     carrying a real element filter, appended and assembled, drives both sides.
+  * dune/gdt/operators/forward-operator.hh:318 -- the same ``if (filter.contains(...))``, here inside
+    the ``ForwardOperatorAssembler`` that ``Operator::apply`` walks. Reached by appending a local
+    element (indicator) operator *with* a filter and calling ``Operator.apply``.
   * dune/gdt/operators/operator.hh:225 and :259 -- ``linear_ = linear_ && local_operator.linear()``
     in the local-element (no-filter) and local-intersection (with-filter) ``operator+=`` overloads.
     Only advection operators report ``linear() == true`` and none are bound as *local* operators, so
@@ -28,11 +31,18 @@ The element filter used is ``ApplyOnBoundaryElements`` (true on boundary cells, 
 ones) together with the trivial ``ApplyOnAllElements`` / ``ApplyOnNoElements`` bookends, all bound in
 dune.xt.grid. No new bindings are introduced.
 
-(The sibling ``forward-operator.hh:318`` filter check -- the same ``if (filter.contains(...))`` inside
-the ``ForwardOperatorAssembler`` that ``Operator::apply`` walks -- would be reached by applying a
-filtered local element indicator operator through ``Operator.apply``. That grid-walking
-``Operator.apply``-with-a-local-operator path is not exercised by any C++ test and is left out here;
-the appending is fine, only the walk is untested.)
+``Operator.apply`` builds a ``ForwardOperatorAssembler`` and walks it, which is a path no C++ test
+drives (the C++ indicator test binds and applies the local operator directly). It is the same
+``XT::Grid::Walker`` machinery the already-passing ``BilinearForm.apply2`` tests run -- an
+element-and-intersection functor over the leaf view -- with a local element operator writing one
+scalar per element instead of accumulating into a field, so the walk itself is covered ground; only
+the assembler on top of it is new. Note the local operator carries *no* intersection part here, so
+nothing dereferences an outside element.
+
+As a side effect the walk also drives the resize guard in
+``LocalElementIntegralBilinearForm::apply2`` (dune/gdt/local/bilinear-forms/integrals.hh:117) through
+its true-then-false sequence: the indicator operator's result buffer starts out 0x0 and is reused
+across elements, so the first element resizes it and every later one does not.
 """
 
 import numpy as np
@@ -200,6 +210,97 @@ def test_boundary_element_filter_is_a_strict_subset_with_interior_elements():
     # none would give q_boundary == 0 -- both are excluded here.
     assert q_boundary > 1e-6
     assert q_boundary < q_all - 1e-6
+
+
+def _indicator_result(grid, filter_factory):
+    """Per-element indicator vector of a mass integrand, filtered by ``filter_factory(grid)``.
+
+    The indicator writes integral_E (source^2 * weight) into element E's FV dof; with a unit source
+    and unit weight that is exactly vol(E), so the vector is the element-volume vector masked by the
+    filter.
+    """
+    from dune.gdt import (
+        FiniteVolumeSpace,
+        LocalElementBilinearFormIndicatorOperator,
+        LocalElementIntegralBilinearForm,
+        LocalElementProductIntegrand,
+        Operator,
+    )
+    from dune.xt.functions import GridFunction as GF
+
+    space = FiniteVolumeSpace(grid)
+    op = Operator(grid, source_space=space, range_space=space)
+    local_form = LocalElementIntegralBilinearForm(
+        LocalElementProductIntegrand(GF(grid, 1.0))
+    )
+    indicator = LocalElementBilinearFormIndicatorOperator(local_form)
+    op += (indicator, filter_factory(grid))
+    # single-argument apply returns a freshly allocated range vector
+    return np.asarray(op.apply(GF(grid, 1.0)), dtype=float)
+
+
+@given(spec=GRIDS)
+def test_forward_operator_element_filter_masks_indicator_contributions(spec):
+    from dune.xt.grid import (
+        ApplyOnAllElements,
+        ApplyOnBoundaryElements,
+        ApplyOnNoElements,
+    )
+
+    grid = spec.make_grid()
+
+    r_all = _indicator_result(grid, ApplyOnAllElements)
+    r_none = _indicator_result(grid, ApplyOnNoElements)
+    r_boundary = _indicator_result(grid, ApplyOnBoundaryElements)
+
+    # every element contributes its (strictly positive) volume; on the unit box they sum to 1.
+    assert np.all(r_all > 0.0)
+    assert np.isclose(r_all.sum(), 1.0, rtol=1e-9, atol=1e-9)
+
+    # ApplyOnNoElements never fires apply_local -> prepared (zero) range is returned unchanged.
+    assert np.allclose(r_none, 0.0, atol=1e-12)
+
+    # ApplyOnBoundaryElements keeps a boundary cell's volume and zeroes every interior cell, so each
+    # entry is either 0 or exactly the unfiltered volume, and the masked sum cannot exceed the total.
+    tol = 1e-10
+    kept = np.isclose(r_boundary, r_all, rtol=1e-9, atol=tol)
+    dropped = np.abs(r_boundary) <= tol
+    assert np.all(kept | dropped)
+    assert r_boundary.sum() <= r_all.sum() + tol
+    assert np.all(r_boundary >= -tol)
+
+
+@pytest.mark.skipif(
+    not has_grid(dim=2, element="cube"),
+    reason="no 2d cube grid bindings available in this build",
+)
+def test_forward_operator_boundary_filter_drops_the_interior_cells():
+    """The filtered ``Operator.apply`` really masks: a 4x4 cube grid has 4 interior cells.
+
+    As for the matrix-operator case above, the property test's bounds alone would also hold for a
+    filter that kept everything or nothing. Here the geometry is known, so the exact split can be
+    asserted: 12 boundary cells keep their volume 1/16, the 4 interior ones are zeroed.
+    """
+    from dune.xt.grid import (
+        ApplyOnAllElements,
+        ApplyOnBoundaryElements,
+        Cube,
+        Dim,
+        make_cube_grid,
+    )
+
+    grid = make_cube_grid(
+        Dim(2), Cube(), lower_left=[0, 0], upper_right=[1, 1], num_elements=[4, 4]
+    )
+
+    r_all = _indicator_result(grid, ApplyOnAllElements)
+    r_boundary = _indicator_result(grid, ApplyOnBoundaryElements)
+
+    assert len(r_all) == 16
+    assert np.allclose(r_all, 1.0 / 16.0, rtol=1e-9, atol=1e-12)
+    # 12 of the 16 cells touch the boundary, the remaining 4 are dropped by the filter
+    assert np.count_nonzero(r_boundary > 1e-12) == 12
+    assert np.isclose(r_boundary.sum(), 12.0 / 16.0, rtol=1e-9, atol=1e-12)
 
 
 @given(spec=GRIDS, order=ORDERS, weight=WEIGHTS)


### PR DESCRIPTION
Continues #338 (Tier 2 partials reduction) after #366.

## What this adds

One test module change: `python/gdt/test/test_hypothesis_operator_local.py` regains the
`forward-operator.hh:318` sub-test that 2f194e6 removed.

That removal was collateral damage. The segfault in that CI run happened in
`test_hypothesis_bilinear_form_intersection.py`, which pytest collects *before*
`test_hypothesis_operator_local.py` — so the forward-operator test never actually executed. It was
dropped on suspicion, not on evidence.

The path it covers is `Operator.apply`, which builds a `ForwardOperatorAssembler` and walks it with
an `XT::Grid::Walker`. That is the same walker the already-passing element-only
`BilinearForm.apply2` tests drive (an element-and-intersection functor over the leaf view;
intersections are walked, with no intersection data attached). The only new piece is the assembler
on top of it. The appended local operator is an *element* indicator operator with no intersection
part, so nothing dereferences an outside element — unlike the quaternary coupling integrand in the
module that crashed.

Both sides of `if (filter.contains(operator_.assembly_grid_view(), element))` are driven via
`ApplyOnAllElements` / `ApplyOnNoElements` / `ApplyOnBoundaryElements`, plus a deterministic 4x4
cube-grid case pinning the exact split (12 boundary cells kept, 4 interior cells zeroed) so a filter
selecting everything or nothing could not pass.

As a side effect the multi-element walk also runs the resize guard in
`LocalElementIntegralBilinearForm::apply2` (`local/bilinear-forms/integrals.hh:117`) through its
true-then-false sequence: the indicator's result buffer starts 0x0 and is then reused across
elements.

No new bindings.

## Binding-surface verification for the rows still open in #338

The issue's first acceptance criterion is to verify the binding-surface assumptions before writing
tests. Re-checked against the actual binding sources on `main`:

| Row | Verdict |
|---|---|
| `local/integrands/*` value-returning `evaluate()` (product.hh:122, linear-advection.hh:106, ipdg.hh:279, interfaces.hh:402/545/705 — 6 partials) | **Not bound.** All five integrand-interface binding headers carry a literal `// order/evaluate` placeholder with nothing bound after it: `binary_element_interface.hh:59`, `binary_intersection_interface.hh:59`, `quaternary_intersection_interface.hh:57`, `unary_element_interface.hh:45`, `unary_intersection_interface.hh:45`. No integrand `evaluate` overload — value-returning or buffer-taking — is reachable from Python for any integrand. Row drops. |
| `local/bilinear-forms/integrals.hh:117,225,360` (3 partials) | **Not directly reachable either** — `apply2` is likewise unbound on all three local bilinear-form interfaces (`element_interface.cc:84`, `intersection_interface.cc:84`, `coupling_intersection_interface.cc:86` all have the same `// apply2` placeholder). Reachable only *indirectly* through assemblers, and both in-tree assemblers defeat the guard: `LocalElementBilinearFormAssembler` pre-sizes `local_matrix_` to `max_local_size() x max_local_size()`, and `BilinearFormAssembler` uses a 1x1 buffer with size-1 local functions. The indicator operator (0x0 buffer, reused) is the one caller that flips the first operand, which this PR now exercises for :117. The `result.cols() < cols` operand needs a buffer with enough rows but too few columns — no Python-reachable caller produces that, so it belongs in the native-C++ bucket (#339). |
| `bilinear-form.hh:434,460` (2 partials) | Still dropped — the grid-walking `BilinearForm::apply2` with intersection/coupling data segfaults (see 2f194e6). Not re-attempted here; see below. |
| `matrix.hh:442`, `operator.hh:225,259` | Already covered by #366. |
| `forward-operator.hh:318` | Covered by this PR. |

## Note on the `BilinearForm.apply2` crash

Not fixed or re-attempted here (out of the issue's scope: no library changes), but worth recording
for whoever picks it up. `BilinearForm::apply2` hardcodes `walker.walk(/*use_tbb=*/true)`
(`bilinear-form.hh:168`), whereas `MatrixOperator::assemble` defaults to `use_tbb=false`
(`matrix.hh:481`) — which is why IPDG intersection forms assemble fine into a matrix but crash
through `apply2`. `Operator::apply` (`operator.hh:154`) and `ForwardOperator` (`forward-operator.hh:155`)
hardcode `true` as well. Whether the crash is a threading issue on the shared grid view's
intersection iteration or something in the quaternary coupling path is unresolved; the element-only
`apply2` tests pass under the same `use_tbb=true` walk, so it is specific to having intersection
data attached.

## Test plan

- `bindings` build + `Test with CTest` in CI (the only verifier — no local dune build here).
- Watch the codecov comment for `forward-operator.hh:318` and `integrals.hh:117` moving off partial.

Closes #338 if CI is green — the remaining rows are verified-unreachable from Python and belong to
#339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CpB3XwsS4CEM6bXR7oaHj

---
_Generated by [Claude Code](https://claude.ai/code/session_012CpB3XwsS4CEM6bXR7oaHj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for applying operators to selected mesh elements.
  * Verified that all-element, no-element, and boundary-element filters produce the expected contributions.
  * Added checks confirming that interior cells are excluded while boundary cells retain their values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->