### PR TITLE
fix(lint): pin ruff's default rule selection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   hooks:
   - id: actionlint
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: cb8c523fd4835aba42af70f4cad5568db4df0b6c  # frozen: v0.16.0
+  rev: cb8c523fd4835aba42af70f4cad5568db4df0b6c # frozen: v0.16.0
   hooks:
   - id: ruff
   - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   hooks:
   - id: actionlint
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 2700fd5671c633760d912769c041bfcde2b9a01b # frozen: v0.15.22
+  rev: cb8c523fd4835aba42af70f4cad5568db4df0b6c  # frozen: v0.16.0
   hooks:
   - id: ruff
   - id: ruff-format

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+# Ruff 0.16 enables a much larger set of rules by default (413, up from 59).
+# Pin the previous default selection explicitly so upgrading ruff doesn't
+# silently expand what pre-commit enforces across the repo.
+# See https://astral.sh/blog/ruff-v0.16.0
+[lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Summary

PR #404 (the `pre-commit.ci` autoupdate bumping `ruff-pre-commit` to `v0.16.0`) is failing its `pre-commit.ci - pr` check with a `ruff (legacy alias)` error.

Root cause: [ruff 0.16.0 enables a much larger default rule set (413 rules, up from 59)](https://astral.sh/blog/ruff-v0.16.0) when no project-level ruff configuration exists — which is the case in this repo. That surfaced ~120 new violations across previously-clean files (e.g. `cmake/modules/versioneer.py`, several `python/xt/test/*.py` files), none of which are actual regressions in this branch's diff.

- Added `ruff.toml` at the repo root, pinning `select = ["E4", "E7", "E9", "F"]` — the documented migration path to keep the previous default rule set. This keeps the effective lint policy stable across future ruff upgrades instead of silently expanding whenever ruff's own defaults change.

## Test plan

- [x] `pre-commit run --all-files` passes locally (all hooks, including `ruff` and `ruff-format`, pass across the whole repository with ruff 0.16.0).
- [x] Verified without the new config, `ruff check .` reports 120 errors with ruff 0.16.0 but `All checks passed!` with the previously pinned 0.15.8, confirming the default-rule-set change is the cause.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtBTRdfmQipN5YctYpe2Sk)_