### PR TITLE
fix(gdt.stokes): make the taylorhood positive-definiteness check unconditional

### DIFF
--- a/dune/gdt/test/stokes/stokes-taylorhood.hh
+++ b/dune/gdt/test/stokes/stokes-taylorhood.hh
@@ -164,11 +164,7 @@ public:
     EXPECT_TRUE(is_symmetric(A.matrix()));
     for (const auto& DoF : dirichlet_constraints.dirichlet_DoFs())
       B.matrix().clear_row(DoF);
-#if defined(NDEBUG) || HAVE_MKL || HAVE_LAPACKE
-    // This check is very slow if compiled in debug mode without LAPACKE,
-    // so we disable it in that case to avoid a test timeout.
     EXPECT_TRUE(is_positive_definite(A.matrix()));
-#endif
 
     // Fix value of p at first DoF to 0 to ensure the uniqueness of the solution, i.e, we have set the m-th row of
     // [A B; B^T 0] to the unit vector.


### PR DESCRIPTION
## Summary

- `dune/gdt/test/stokes/stokes-taylorhood.hh` guarded `EXPECT_TRUE(is_positive_definite(A.matrix()))` behind `#if defined(NDEBUG) || HAVE_MKL || HAVE_LAPACKE`, a leftover from before #376 made LAPACKE mandatory.
- Since `HAVE_LAPACKE` was 0 in CI and the `clang22-debug` leg is by definition not `NDEBUG`, the condition was false on that leg, so the assertion was silently never compiled — the test passed without ever checking the Stokes system matrix is positive definite.
- #376 removed the three analogous guards in the generalized-eigensolver test suites but missed this fourth occurrence.
- Now that LAPACKE is mandatory (per #376), "no LAPACKE" is no longer a reachable configuration, so the debug-mode timeout concern behind the guard no longer applies. Dropped the `#if`/`#endif` and left the assertion unconditional.

Fixes #382

## Test plan

- [ ] CI: confirm the `clang22-debug` leg still completes in reasonable time now that the assertion is live there for the first time (per the issue's suggestion to watch this on the first run).
- [x] `clang-format --dry-run -Werror` clean on the changed file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSEg3ZZVpy5c8vxFaHSq2x)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Stokes Taylor–Hood test to consistently verify that the assembled velocity matrix is positive definite.
  * Improved test coverage across build configurations, including debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->