### PR TITLE
fix(cmake): make `cmake --install` work for the python packages

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -254,15 +254,22 @@ jobs:
       # generated per-directory script, which needs no built targets and so can
       # run right after configure) rather than the whole build tree with a
       # plain `cmake --install`: the latter also runs
-      # DunePybindxiInstallPythonPackage.cmake's install(CODE) rule for the
-      # Python wheel, which calls dune-common's `dune_execute_process` -- a
-      # macro that is not available in the standalone `cmake -P` process an
-      # install script runs in, so it always fails with "Unknown CMake
-      # command". That is a pre-existing bug in the Python packaging install
-      # path, unrelated to and out of scope for issue #388's cmake/modules
-      # manifest fix (tracked separately in #401); scoping the smoke test to
-      # cmake/modules keeps it testing what the issue is actually about.
+      # DunePybindxiInstallPythonPackage.cmake's install(CODE) rule, which
+      # shells out to `pip wheel` and therefore needs the compiled bindings
+      # that only exist much later in this workflow.
+      #
+      # The grep is the regression test for issue #401: install(CODE) text is
+      # not run at configure time but by the generated cmake_install.cmake,
+      # which CMake executes as a standalone `cmake -P` script that never
+      # includes dune-common's CMake modules. Any dune-common macro called from
+      # there (`dune_execute_process` was the one that broke `cmake --install`)
+      # is undefined in that process, and the failure only shows up when the
+      # rule actually runs -- which is exactly what nothing in CI does.
       run: |
+        if grep -rn --include=cmake_install.cmake -e dune_execute_process "build/${{ matrix.preset }}"; then
+          echo "::error::install(CODE) calls dune_execute_process, which is undefined in the standalone install script (see #401)"
+          exit 1
+        fi
         prefix="$(mktemp -d)"
         cmake "-DCMAKE_INSTALL_PREFIX=${prefix}" -P "build/${{ matrix.preset }}/cmake/modules/cmake_install.cmake"
         module="$(find "${prefix}" -type f -name DuneXTHints.cmake -print -quit)"

--- a/cmake/modules/DunePybindxiInstallPythonPackage.cmake
+++ b/cmake/modules/DunePybindxiInstallPythonPackage.cmake
@@ -139,10 +139,27 @@ function(dune_pybindxi_install_python_package)
   # Construct the wheel installation commandline
   set(wheel_command "${RUN_IN_ENV_SCRIPT}" "python3" -m pip wheel -w ${DUNE_PYTHON_WHEELHOUSE} ${pyinst_fullpath})
 
+  # Render the wheel commandline as an explicitly quoted argument list for the install script below. The list cannot
+  # simply be expanded into the install(CODE) text: that text is re-parsed by a separate CMake parser, where an unquoted
+  # ${wheel_command} would split on any space in DUNE_PYTHON_WHEELHOUSE, RUN_IN_ENV_SCRIPT or the package path.
+  set(wheel_command_code "")
+  foreach(arg IN LISTS wheel_command)
+    string(REPLACE "\\" "\\\\" arg "${arg}")
+    string(REPLACE "\"" "\\\"" arg "${arg}")
+    string(APPEND wheel_command_code " \"${arg}\"")
+  endforeach()
+
   # Add the installation rule
+  #
+  # NB: install(CODE) text does not run at configure time, but from the generated cmake_install.cmake, which CMake
+  # executes as a standalone `cmake -P` script. That process does not include dune-common's CMake modules, so
+  # dune-common's dune_execute_process() macro is undefined there and using it made `cmake --install` fail with "Unknown
+  # CMake command" (see issue #401). Plain execute_process() plus an explicit result check needs no includes and keeps
+  # the same abort-with-a-useful-message behaviour.
   install(
     CODE "message(\"Installing wheel for python package at ${pyinst_fullpath}...\")
-                dune_execute_process(COMMAND ${wheel_command}
-                                     ERROR_MESSAGE \"Error installing wheel for python package at ${pyinst_fullpath}\"
-                                     )")
+                execute_process(COMMAND${wheel_command_code} RESULT_VARIABLE dune_pybindxi_wheel_result)
+                if(NOT dune_pybindxi_wheel_result EQUAL \"0\")
+                  message(FATAL_ERROR \"Error installing wheel for python package at ${pyinst_fullpath}\")
+                endif()")
 endfunction()


### PR DESCRIPTION
Fixes #401.

## The bug

`cmake/modules/DunePybindxiInstallPythonPackage.cmake` registered the Python wheel install rule as

```cmake
install(
  CODE "message(...)
              dune_execute_process(COMMAND ${wheel_command} ERROR_MESSAGE ...)")
```

`install(CODE ...)` text is not evaluated during configure — it is written verbatim into the generated `cmake_install.cmake`, which CMake runs as a standalone `cmake -P` script. That process never includes dune-common's CMake modules, so `dune_execute_process` is undefined there and `cmake --install` always aborted:

```
CMake Error at build/<preset>/python/cmake_install.cmake:47 (dune_execute_process):
  Unknown CMake command "dune_execute_process".
```

## The fix

Replace it with plain `execute_process()` plus an explicit `RESULT_VARIABLE` check. That needs no includes and preserves the descriptive abort message the `ERROR_MESSAGE` argument used to provide (`COMMAND_ERROR_IS_FATAL ANY` would have worked too, but loses the message).

The commandline is rendered into the install script as an explicitly quoted argument list rather than by expanding `${wheel_command}` into the code text. The generated text is re-parsed by a second CMake parser, where an unquoted expansion would split on any space in `DUNE_PYTHON_WHEELHOUSE`, `RUN_IN_ENV_SCRIPT` or the package path — a latent bug in the original spelling as well.

## Regression guard

The existing "Test install" step in `non_docker_build.yml` was scoped to the `cmake/modules` subtree partly *because* of this bug; its comment documented it as a known workaround. That paragraph is replaced with the remaining, still-valid reason (the wheel rule shells out to `pip wheel`, which needs the compiled bindings that only exist much later in the workflow), plus a cheap guard that fails the step if any generated `cmake_install.cmake` calls `dune_execute_process`. This catches the class of bug — a dune-common macro reached from install-script context — right after configure, without paying for a full wheel build.

## Verification

Reproduced the generation in a standalone project with spaces in every path and ran `cmake --install` against it:

* success path — all 8 arguments arrive intact, spaces and all, with no shell-level splitting;
* failure path — non-zero exit produces `CMake Error ... Error installing wheel for python package at /some path/with spaces/xt` and `cmake --install` exits 1.

`cmake-format` and `cmake-lint` (with the repo's `.cmake_format.py`) are clean on the changed file.

The `install(CODE)` rule itself is not exercised end-to-end here — that needs a full configured Dune stack with built bindings, which this environment does not have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCytBzYeC7gBfv1pWjqHht)_