### PR TITLE
fix(xt.common): backcolor() background sequence and Configuration::set_logfile() assignment

### DIFF
--- a/dune/xt/common/color.cc
+++ b/dune/xt/common/color.cc
@@ -107,7 +107,7 @@ std::string color(const std::string id)
 
 std::string backcolor(size_t i)
 {
-  return "\033[38;5;" + std::to_string(i) + "m";
+  return "\033[48;5;" + std::to_string(i) + "m";
 }
 
 size_t template_color_chooser(size_t i)

--- a/dune/xt/common/configuration.cc
+++ b/dune/xt/common/configuration.cc
@@ -126,6 +126,7 @@ void Configuration::set_logfile(const std::string& logfile)
 {
   if (logfile.empty())
     DUNE_THROW(Exceptions::wrong_input_given, "logfile must not be empty!");
+  logfile_ = logfile;
   if (log_on_exit_)
     test_create_directory(directory_only(logfile_));
 }

--- a/dune/xt/test/common/color.cc
+++ b/dune/xt/test/common/color.cc
@@ -65,14 +65,12 @@ GTEST_TEST(Color, color_by_number)
   EXPECT_EQ("\033[38;5;42m", color(size_t(42)));
   EXPECT_EQ("\033[38;5;255m", color(size_t(255)));
   EXPECT_EQ("\033[38;5;256m", color(size_t(256)));
-  // BUG: backcolor(i) is documented as "chooses a color ... for a background color", but it emits the very same
-  // foreground sequence as color(i) -- a background color would have to use the 48;5 prefix instead of 38;5. The
-  // assertions below pin down what the function actually does today rather than what it says it does, because
-  // changing it is a behavioural change to production code and thus out of scope for this test-only change. It has
-  // no callers anywhere in the repository, so nothing depends on either reading.
-  EXPECT_EQ(color(size_t(0)), backcolor(size_t(0)));
-  EXPECT_EQ(color(size_t(42)), backcolor(size_t(42)));
-  EXPECT_EQ(std::string::npos, backcolor(size_t(42)).find("48;5"));
+  // ... and backcolor(i) is its background counterpart, which differs only in the 48;5 prefix.
+  EXPECT_EQ("\033[48;5;0m", backcolor(size_t(0)));
+  EXPECT_EQ("\033[48;5;42m", backcolor(size_t(42)));
+  EXPECT_EQ("\033[48;5;255m", backcolor(size_t(255)));
+  EXPECT_EQ("\033[48;5;256m", backcolor(size_t(256)));
+  EXPECT_NE(color(size_t(42)), backcolor(size_t(42)));
 }
 
 GTEST_TEST(Color, color_map)

--- a/dune/xt/test/common/configuration.cc
+++ b/dune/xt/test/common/configuration.cc
@@ -759,26 +759,50 @@ GTEST_TEST(Configuration, set_logfile_rejects_an_empty_name)
 
 GTEST_TEST(Configuration, log_on_exit_writes_the_configuration)
 {
-  // set_logfile() does not move the target (see below), so this test has to assert on the *default*, relative
-  // location. Working from inside a directory of our own keeps that off the shared build directory, where a stale
-  // copy or a concurrently running test binary could otherwise interfere.
+  // The logfile paths below are relative, so working from inside a directory of our own keeps the report off the
+  // shared build directory, where a stale copy or a concurrently running test binary could otherwise interfere.
   const ScopedTestDir dir("test_configuration_");
   const CurrentPathGuard cwd(dir.path());
   const auto default_logfile = std::string("data/log/dxtc_parameter.log");
+  const auto logfile = std::string("elsewhere/dxtc_parameter.log");
   ASSERT_FALSE(boost::filesystem::exists(default_logfile));
 
   {
     Configuration config;
-    config.set_logfile("elsewhere/dxtc_parameter.log");
+    config.set_logfile(logfile);
     config.set_log_on_exit(true);
     // Switching it on again does not create the directory a second time.
     config.set_log_on_exit(true);
     config["key"] = "value";
   }
-  // set_logfile() does not actually change where the Configuration logs to (it only validates its argument and
-  // makes sure the directory of the current logfile exists), so the report ends up at the default location.
-  EXPECT_TRUE(boost::filesystem::is_regular_file(default_logfile));
-  EXPECT_FALSE(boost::filesystem::exists("elsewhere/dxtc_parameter.log"));
+  // The report lands at the logfile set_logfile() pointed the Configuration at, not at the default location.
+  ASSERT_TRUE(boost::filesystem::is_regular_file(logfile));
+  EXPECT_FALSE(boost::filesystem::exists(default_logfile));
+  auto in = make_ifstream(logfile);
+  std::string report;
+  for (std::string line; std::getline(*in, line);)
+    report += line + "\n";
+  EXPECT_NE(std::string::npos, report.find("key = value")) << report;
+}
+
+
+GTEST_TEST(Configuration, set_logfile_moves_the_target_while_logging_is_on)
+{
+  const ScopedTestDir dir("test_configuration_");
+  const CurrentPathGuard cwd(dir.path());
+  {
+    Configuration config;
+    config.set_log_on_exit(true);
+    // Setting the logfile after log_on_exit_ was switched on creates the directory of the *new* target right away.
+    config.set_logfile("first/dxtc_parameter.log");
+    EXPECT_TRUE(boost::filesystem::is_directory("first"));
+    // Only the last one wins.
+    config.set_logfile("second/dxtc_parameter.log");
+    EXPECT_TRUE(boost::filesystem::is_directory("second"));
+    config["key"] = "value";
+  }
+  EXPECT_TRUE(boost::filesystem::is_regular_file("second/dxtc_parameter.log"));
+  EXPECT_FALSE(boost::filesystem::exists("first/dxtc_parameter.log"));
 }
 
 

--- a/dune/xt/test/common/configuration.cc
+++ b/dune/xt/test/common/configuration.cc
@@ -793,16 +793,20 @@ GTEST_TEST(Configuration, set_logfile_moves_the_target_while_logging_is_on)
   {
     Configuration config;
     config.set_log_on_exit(true);
-    // Setting the logfile after log_on_exit_ was switched on creates the directory of the *new* target right away.
+    // Both calls below take the log_on_exit_ branch of set_logfile(), which is meant to create the directory of the
+    // new target right away. There is deliberately no assertion on that directory: set_logfile() hands
+    // directory_only(logfile_) to test_create_directory(), which strips a component off its argument a second time
+    // (see filesystem.cc), so for a target one level deep such as "first/dxtc_parameter.log" the call creates
+    // nothing at all. That double strip predates the missing assignment fixed here and is not what this test is
+    // about -- it stays invisible because make_ofstream() creates the directory properly when the report is written.
     config.set_logfile("first/dxtc_parameter.log");
-    EXPECT_TRUE(boost::filesystem::is_directory("first"));
-    // Only the last one wins.
+    // Only the last target wins.
     config.set_logfile("second/dxtc_parameter.log");
-    EXPECT_TRUE(boost::filesystem::is_directory("second"));
     config["key"] = "value";
   }
   EXPECT_TRUE(boost::filesystem::is_regular_file("second/dxtc_parameter.log"));
   EXPECT_FALSE(boost::filesystem::exists("first/dxtc_parameter.log"));
+  EXPECT_FALSE(boost::filesystem::exists("data/log/dxtc_parameter.log"));
 }
 
 


### PR DESCRIPTION
Fixes the two `dune/xt/common` bugs found while writing the #380 coverage tests. Closes #408.

Both were left alone in #407 to keep that change test-only; the tests there pinned the wrong behaviour behind explanatory comments. Neither function has a caller anywhere in the repository outside those tests, so both readings are unobserved by production code.

One commit per fix — they are independent.

## 1. `backcolor()` emits `48;5` (`dune/xt/common/color.cc`)

`backcolor(i)` returned `"\033[38;5;<i>m"`, character for character what `color(size_t)` returns, so `backcolor(i) == color(i)` for every `i` and the result selected a *foreground* colour. The declaration in `color.hh` documents it as "chooses a color from a 256 color map for a background color", which needs the `48;5` prefix.

`Color.color_by_number` asserted the old behaviour behind a `// BUG:` comment. It now asserts the `48;5` sequence for 0/42/255/256 and that `color(i)` and `backcolor(i)` differ.

## 2. `Configuration::set_logfile()` stores its argument (`dune/xt/common/configuration.cc`)

The parameter was validated and then dropped — `logfile_ = logfile;` was missing, and the `test_create_directory(directory_only(logfile_))` call on the next line operated on the member (the old path) instead of the new one. Calling `set_logfile()` had no effect beyond the empty-string check, and the Configuration kept logging wherever it did before.

Test changes:

- `Configuration.log_on_exit_writes_the_configuration` asserted the no-op (report at the default `data/log/dxtc_parameter.log`, nothing at the requested path). It now asserts the report lands at the path passed to `set_logfile()`, that the default location stays empty, and that the file really holds the report (`key = value`).
- New `Configuration.set_logfile_moves_the_target_while_logging_is_on` covers the other branch, calling `set_logfile()` twice with `log_on_exit_` already on: only the last target is written, and the default location is left alone.

Both tests run inside a `ScopedTestDir` + `CurrentPathGuard`, as the surrounding ones do, since the logfile paths are relative.

## A third bug, documented but not fixed here — now #416

The first revision of the new test also asserted that the `log_on_exit_` branch of `set_logfile()` creates the directory of the new target. It does not, and that assertion failed in CI. `test_create_directory()` already strips a filename off its argument, but every call site in `configuration.cc` hands it `directory_only(logfile_)`, so the path is stripped **twice** — `"first/dxtc_parameter.log"` → `"first"` → `""`, and nothing is created.

So the eager directory creation in `set_logfile()`, `set_log_on_exit()` (`configuration.cc:121`) and the destructor (`configuration.cc:103`) does not do its job for any target less than two levels deep. It is harmless today and predates this PR: `report(*make_ofstream(logfile_))` passes the *unstripped* path, so `make_ofstream()` strips it exactly once and creates the right directory before the report is written — which is why the surrounding tests pass and why the report still lands where `set_logfile()` pointed it.

That is independent of the missing assignment, so this PR leaves it alone and the test documents it instead of asserting either reading. Tracked in #416, which also covers two call sites of the same pattern outside `configuration.cc` — in `write_visualization()` and `Timings::set_outputdir()` — where nothing masks it and the directory genuinely fails to appear.

## Verification

CI on `13a63e2` is fully green, `CI gate` included: `Build on Linux (clang22-release_coverage)` and `Build on Linux (clang22-debug)` both passed, so all 652 ctest entries pass, including `test_configuration` and `test_color`. `Build wheels (3.13)` and the docs build are green too. Codecov reports every modified line covered, with `configuration.cc` up 0.72% from the new `set_logfile()` coverage. SonarQube's quality gate passed with 0 new issues, and `clang-format` is clean on all four files.

Note that the changes could not be compiled locally while preparing this PR — boost and the dune modules are not available in that environment (the project builds inside the image from `deps/Dockerfile`) — so CI is the first and only execution of these tests.