### PR TITLE
Remove the always-true HAVE_DUNE_ALUGRID guards

### DIFF
--- a/benchmarks/assembly_kernels__sipdg.cpp
+++ b/benchmarks/assembly_kernels__sipdg.cpp
@@ -45,8 +45,6 @@
 using namespace Dune;
 using namespace Dune::GDT;
 
-#if HAVE_DUNE_ALUGRID
-
 int main(int argc, char** argv)
 {
   MPIHelper::instance(argc, argv);
@@ -110,13 +108,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-
-#else // HAVE_DUNE_ALUGRID
-
-int main()
-{
-  // The ESV2007 benchmark requires a simplex grid (dune-alugrid); nothing to do otherwise.
-  return 0;
-}
-
-#endif // HAVE_DUNE_ALUGRID

--- a/benchmarks/stationary_heat_equation__ESV2007.cpp
+++ b/benchmarks/stationary_heat_equation__ESV2007.cpp
@@ -42,8 +42,6 @@
 using namespace Dune;
 using namespace Dune::GDT;
 
-#if HAVE_DUNE_ALUGRID
-
 int main(int argc, char** argv)
 {
   MPIHelper::instance(argc, argv);
@@ -109,13 +107,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-
-#else // HAVE_DUNE_ALUGRID
-
-int main()
-{
-  // The ESV2007 benchmark requires a simplex grid (dune-alugrid); nothing to do otherwise.
-  return 0;
-}
-
-#endif // HAVE_DUNE_ALUGRID

--- a/dune/gdt/data/stationary_heat_equation.hh
+++ b/dune/gdt/data/stationary_heat_equation.hh
@@ -65,7 +65,6 @@ struct ESV2007DiffusionProblem
   {
     if (std::is_same<G, YASP_2D_EQUIDISTANT_OFFSET>::value) {
       return XT::Grid::make_cube_grid<G>(-1, 1, 8);
-#if HAVE_DUNE_ALUGRID
     } else if (std::is_same<G, ALU_2D_SIMPLEX_CONFORMING>::value) {
       auto grid = XT::Grid::make_cube_grid<G>(-1, 1, 4);
       grid.global_refine(2);
@@ -76,7 +75,6 @@ struct ESV2007DiffusionProblem
       auto grid = XT::Grid::make_cube_grid<G>(-1, 1, 8);
       grid.global_refine(1);
       return grid;
-#endif // HAVE_DUNE_ALUGRID
     } else
       DUNE_THROW(XT::Common::Exceptions::wrong_input_given,
                  "Please add a specialization for '" << XT::Common::Typename<G>::value() << "'!");

--- a/dune/gdt/test/integrands/integrands.hh
+++ b/dune/gdt/test/integrands/integrands.hh
@@ -261,13 +261,10 @@ struct IntegrandTest : public ::testing::Test
 } // namespace Dune
 
 
-using Grids2D = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                 ,
+using Grids2D = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET,
                                  ALU_2D_SIMPLEX_CONFORMING,
                                  ALU_2D_SIMPLEX_NONCONFORMING,
                                  ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                  ,
                                  UG_2D
@@ -279,11 +276,9 @@ using Grids2D = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
                                  >;
 
 DUNE_XT_COMMON_TYPENAME(YASP_2D_EQUIDISTANT_OFFSET)
-#if HAVE_DUNE_ALUGRID
 DUNE_XT_COMMON_TYPENAME(ALU_2D_SIMPLEX_CONFORMING)
 DUNE_XT_COMMON_TYPENAME(ALU_2D_SIMPLEX_NONCONFORMING)
 DUNE_XT_COMMON_TYPENAME(ALU_2D_CUBE)
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
 DUNE_XT_COMMON_TYPENAME(UG_2D)
 #endif

--- a/dune/gdt/test/interpolations/interpolations_boundary__cubic_2d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_boundary__cubic_2d_grids.cc
@@ -14,11 +14,8 @@
 #include "boundary.hh"
 
 
-using Cubic2dGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                      ,
+using Cubic2dGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET,
                                       ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID
                                       ,
                                       UG_2D

--- a/dune/gdt/test/interpolations/interpolations_boundary__cubic_3d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_boundary__cubic_3d_grids.cc
@@ -14,11 +14,8 @@
 #include "boundary.hh"
 
 
-using Cubic3dGrids = ::testing::Types<YASP_3D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                      ,
+using Cubic3dGrids = ::testing::Types<YASP_3D_EQUIDISTANT_OFFSET,
                                       ALU_3D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID
                                       ,
                                       UG_3D

--- a/dune/gdt/test/interpolations/interpolations_boundary__simplicial_2d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_boundary__simplicial_2d_grids.cc
@@ -14,20 +14,14 @@
 #include "boundary.hh"
 
 
-using Simplicial2dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_2D_SIMPLEX_CONFORMING,
-    ALU_2D_SIMPLEX_NONCONFORMING
-#endif
-#if HAVE_DUNE_ALUGRID && HAVE_DUNE_UGGRID
-    ,
-#endif
+using Simplicial2dGrids = ::testing::Types<ALU_2D_SIMPLEX_CONFORMING,
+                                           ALU_2D_SIMPLEX_NONCONFORMING
 #if HAVE_DUNE_UGGRID
-    UG_2D
+                                           ,
+                                           UG_2D
 #endif
-    >;
+                                           >;
 
-#if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using BoundaryInterpolation = Dune::GDT::Test::BoundaryInterpolationOnLeafViewTest<G>;
 TYPED_TEST_SUITE(BoundaryInterpolation, Simplicial2dGrids);
@@ -35,4 +29,3 @@ TYPED_TEST(BoundaryInterpolation, interpolates_correctly)
 {
   this->interpolates_correctly();
 }
-#endif // HAVE_DUNE_UGGRID || HAVE_UG || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/interpolations/interpolations_boundary__simplicial_3d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_boundary__simplicial_3d_grids.cc
@@ -14,20 +14,14 @@
 #include "boundary.hh"
 
 
-using Simplicial3dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_3D_SIMPLEX_CONFORMING,
-    ALU_3D_SIMPLEX_NONCONFORMING
-#endif
-#if HAVE_DUNE_ALUGRID && HAVE_DUNE_UGGRID
-    ,
-#endif
+using Simplicial3dGrids = ::testing::Types<ALU_3D_SIMPLEX_CONFORMING,
+                                           ALU_3D_SIMPLEX_NONCONFORMING
 #if HAVE_DUNE_UGGRID
-    UG_3D
+                                           ,
+                                           UG_3D
 #endif
-    >;
+                                           >;
 
-#if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using BoundaryInterpolation = Dune::GDT::Test::BoundaryInterpolationOnLeafViewTest<G>;
 TYPED_TEST_SUITE(BoundaryInterpolation, Simplicial3dGrids);
@@ -35,4 +29,3 @@ TYPED_TEST(BoundaryInterpolation, interpolates_correctly)
 {
   this->interpolates_correctly();
 }
-#endif // HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/interpolations/interpolations_default__cubic_2d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_default__cubic_2d_grids.cc
@@ -17,19 +17,13 @@
 // YASP_2D_EQUIDISTANT_OFFSET is covered at runtime by the hypothesis property tests driving
 // the bindings (python/gdt/test/test_hypothesis_interpolation.py); only the grids the
 // bindings do not instantiate remain here.
-using Cubic2dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_2D_CUBE
-#endif
-#if HAVE_DUNE_ALUGRID && HAVE_DUNE_UGGRID
-    ,
-#endif
+using Cubic2dGrids = ::testing::Types<ALU_2D_CUBE
 #if HAVE_DUNE_UGGRID
-    UG_2D
+                                      ,
+                                      UG_2D
 #endif
-    >;
+                                      >;
 
-#if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using InterpolationTest = Dune::GDT::Test::DefaultInterpolationOnLeafViewTest<G>;
 TYPED_TEST_SUITE(InterpolationTest, Cubic2dGrids);
@@ -37,4 +31,3 @@ TYPED_TEST(InterpolationTest, interpolates_correctly)
 {
   this->interpolates_correctly(4e-14);
 }
-#endif // HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/interpolations/interpolations_default__cubic_3d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_default__cubic_3d_grids.cc
@@ -17,19 +17,13 @@
 // YASP_3D_EQUIDISTANT_OFFSET is covered at runtime by the hypothesis property tests driving
 // the bindings (python/gdt/test/test_hypothesis_interpolation.py); only the grids the
 // bindings do not instantiate remain here.
-using Cubic3dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_3D_CUBE
-#endif
-#if HAVE_DUNE_ALUGRID && HAVE_DUNE_UGGRID
-    ,
-#endif
+using Cubic3dGrids = ::testing::Types<ALU_3D_CUBE
 #if HAVE_DUNE_UGGRID
-    UG_3D
+                                      ,
+                                      UG_3D
 #endif
-    >;
+                                      >;
 
-#if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using InterpolationTest = Dune::GDT::Test::DefaultInterpolationOnLeafViewTest<G>;
 TYPED_TEST_SUITE(InterpolationTest, Cubic3dGrids);
@@ -37,4 +31,3 @@ TYPED_TEST(InterpolationTest, interpolates_correctly)
 {
   this->interpolates_correctly(2e-13);
 }
-#endif // HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/interpolations/interpolations_default__simplicial_2d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_default__simplicial_2d_grids.cc
@@ -17,19 +17,13 @@
 // ALU_2D_SIMPLEX_CONFORMING is covered at runtime by the hypothesis property tests driving
 // the bindings (python/gdt/test/test_hypothesis_interpolation.py); only the grids the
 // bindings do not instantiate remain here.
-using Simplicial2dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_2D_SIMPLEX_NONCONFORMING
-#endif
-#if HAVE_DUNE_ALUGRID && HAVE_DUNE_UGGRID
-    ,
-#endif
+using Simplicial2dGrids = ::testing::Types<ALU_2D_SIMPLEX_NONCONFORMING
 #if HAVE_DUNE_UGGRID
-    UG_2D
+                                           ,
+                                           UG_2D
 #endif
-    >;
+                                           >;
 
-#if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using InterpolationTest = Dune::GDT::Test::DefaultInterpolationOnLeafViewTest<G>;
 TYPED_TEST_SUITE(InterpolationTest, Simplicial2dGrids);
@@ -37,4 +31,3 @@ TYPED_TEST(InterpolationTest, interpolates_correctly)
 {
   this->interpolates_correctly();
 }
-#endif // HAVE_DUNE_UGGRID  || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/interpolations/interpolations_default__simplicial_3d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_default__simplicial_3d_grids.cc
@@ -17,20 +17,13 @@
 // ALU_3D_SIMPLEX_CONFORMING is covered at runtime by the hypothesis property tests driving
 // the bindings (python/gdt/test/test_hypothesis_interpolation.py); only the grids the
 // bindings do not instantiate remain here.
-using Simplicial3dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_3D_SIMPLEX_NONCONFORMING
-#endif
-#if HAVE_DUNE_ALUGRID && HAVE_DUNE_UGGRID
-    ,
-#endif
+using Simplicial3dGrids = ::testing::Types<ALU_3D_SIMPLEX_NONCONFORMING
 #if HAVE_DUNE_UGGRID
-    UG_3D
+                                           ,
+                                           UG_3D
 #endif
-    >;
+                                           >;
 
-
-#if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using InterpolationTest = Dune::GDT::Test::DefaultInterpolationOnLeafViewTest<G>;
 TYPED_TEST_SUITE(InterpolationTest, Simplicial3dGrids);
@@ -38,4 +31,3 @@ TYPED_TEST(InterpolationTest, interpolates_correctly)
 {
   this->interpolates_correctly(3e-14);
 }
-#endif // HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/interpolations/interpolations_raviart_thomas__cubic_2d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_raviart_thomas__cubic_2d_grids.cc
@@ -14,11 +14,8 @@
 #include "raviart-thomas.hh"
 
 
-using Cubic2dGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                      ,
+using Cubic2dGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET,
                                       ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID
                                       ,
                                       UG_2D

--- a/dune/gdt/test/interpolations/interpolations_raviart_thomas__simplicial_2d_grids.cc
+++ b/dune/gdt/test/interpolations/interpolations_raviart_thomas__simplicial_2d_grids.cc
@@ -14,20 +14,14 @@
 #include "raviart-thomas.hh"
 
 
-using Simplicial2dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_2D_SIMPLEX_CONFORMING,
-    ALU_2D_SIMPLEX_NONCONFORMING
-#endif
-#if HAVE_DUNE_ALUGRID && HAVE_DUNE_UGGRID
-    ,
-#endif
+using Simplicial2dGrids = ::testing::Types<ALU_2D_SIMPLEX_CONFORMING,
+                                           ALU_2D_SIMPLEX_NONCONFORMING
 #if HAVE_DUNE_UGGRID
-    UG_2D
+                                           ,
+                                           UG_2D
 #endif
-    >;
+                                           >;
 
-#if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using RaviartThomasInterpolationTest = Dune::GDT::Test::RaviartThomasInterpolationOnLeafViewTest<G>;
 TYPED_TEST_SUITE(RaviartThomasInterpolationTest, Simplicial2dGrids);
@@ -43,4 +37,3 @@ TYPED_TEST(RaviartThomasInterpolationTest, interpolant_has_continuous_normal_com
 {
   this->interpolant_has_continuous_normal_components();
 }
-#endif // HAVE_DUNE_UGGRID  || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/misc/tools_grid_quality_estimates.cc
+++ b/dune/gdt/test/misc/tools_grid_quality_estimates.cc
@@ -165,8 +165,6 @@ GTEST_TEST(grid_quality_estimates, inverse_inequality_constants_on_3d_cube_grid)
 }
 
 
-#if HAVE_DUNE_ALUGRID
-
 // #378: the bindings' hypothesis property test segfaulted the whole pytest process in the combined estimate on a 3d
 // ALUGrid cube. The cause turned out to be a dangling grid on the python side rather than anything in the estimator
 // (see the py::keep_alive in python/gdt/dune/gdt/spaces/), but until now this was the only grid this estimator had
@@ -211,5 +209,3 @@ GTEST_TEST(grid_quality_estimates, inverse_inequality_constants_on_simplicial_gr
     check_mesh_width_independence<ALU_3D_SIMPLEX_CONFORMING>(order);
   }
 }
-
-#endif // HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/operators/operators_oswald_interpolation__cubic_2d_grids.cc
+++ b/dune/gdt/test/operators/operators_oswald_interpolation__cubic_2d_grids.cc
@@ -14,11 +14,8 @@
 #include "oswald-interpolation.hh"
 
 
-using Cubic2dGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                      ,
+using Cubic2dGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET,
                                       ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                       ,
                                       UG_2D

--- a/dune/gdt/test/operators/operators_oswald_interpolation__cubic_3d_grids.cc
+++ b/dune/gdt/test/operators/operators_oswald_interpolation__cubic_3d_grids.cc
@@ -14,11 +14,8 @@
 #include "oswald-interpolation.hh"
 
 
-using Cubic3dGrids = ::testing::Types<YASP_3D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                      ,
+using Cubic3dGrids = ::testing::Types<YASP_3D_EQUIDISTANT_OFFSET,
                                       ALU_3D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                       ,
                                       UG_3D

--- a/dune/gdt/test/operators/operators_oswald_interpolation__simplicial_2d_grids.cc
+++ b/dune/gdt/test/operators/operators_oswald_interpolation__simplicial_2d_grids.cc
@@ -14,18 +14,14 @@
 #include "oswald-interpolation.hh"
 
 
-using Simplicial2dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_2D_SIMPLEX_CONFORMING,
-    ALU_2D_SIMPLEX_NONCONFORMING
-#endif
+using Simplicial2dGrids = ::testing::Types<ALU_2D_SIMPLEX_CONFORMING,
+                                           ALU_2D_SIMPLEX_NONCONFORMING
 #if HAVE_DUNE_UGGRID || HAVE_UG
-    ,
-    UG_2D
+                                           ,
+                                           UG_2D
 #endif
-    >;
+                                           >;
 
-#if HAVE_DUNE_UGGRID || HAVE_UG || HAVE_DUNE_ALUGRID
 template <class G>
 using OswaldInterpolationOperator = Dune::GDT::Test::OswaldInterpolationOperatorOnLeafViewTest<G>;
 TYPED_TEST_SUITE(OswaldInterpolationOperator, Simplicial2dGrids);
@@ -37,4 +33,3 @@ TYPED_TEST(OswaldInterpolationOperator, fulfills_h1_interpolation_estimate)
 {
   this->fulfills_h1_interpolation_estimate();
 }
-#endif // HAVE_DUNE_UGGRID || HAVE_UG || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/operators/operators_oswald_interpolation__simplicial_3d_grids.cc
+++ b/dune/gdt/test/operators/operators_oswald_interpolation__simplicial_3d_grids.cc
@@ -14,18 +14,14 @@
 #include "oswald-interpolation.hh"
 
 
-using Simplicial3dGrids = ::testing::Types<
-#if HAVE_DUNE_ALUGRID
-    ALU_3D_SIMPLEX_CONFORMING,
-    ALU_3D_SIMPLEX_NONCONFORMING
-#endif
+using Simplicial3dGrids = ::testing::Types<ALU_3D_SIMPLEX_CONFORMING,
+                                           ALU_3D_SIMPLEX_NONCONFORMING
 #if HAVE_DUNE_UGGRID || HAVE_UG
-    ,
-    UG_3D
+                                           ,
+                                           UG_3D
 #endif
-    >;
+                                           >;
 
-#if HAVE_DUNE_UGGRID || HAVE_UG || HAVE_DUNE_ALUGRID
 template <class G>
 using OswaldInterpolationOperator = Dune::GDT::Test::OswaldInterpolationOperatorOnLeafViewTest<G>;
 TYPED_TEST_SUITE(OswaldInterpolationOperator, Simplicial3dGrids);
@@ -37,4 +33,3 @@ TYPED_TEST(OswaldInterpolationOperator, fulfills_h1_interpolation_estimate)
 {
   this->fulfills_h1_interpolation_estimate();
 }
-#endif // HAVE_DUNE_UGGRID || HAVE_UG || HAVE_DUNE_ALUGRID

--- a/dune/gdt/test/spaces/base.hh
+++ b/dune/gdt/test/spaces/base.hh
@@ -260,21 +260,16 @@ XT::Grid::GridProvider<G> make_simplicial_grid()
 
 
 using SimplicialGrids = ::testing::Types<ONED_1D,
-                                         YASP_1D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                         ,
+                                         YASP_1D_EQUIDISTANT_OFFSET,
                                          ALU_2D_SIMPLEX_CONFORMING,
                                          ALU_2D_SIMPLEX_NONCONFORMING
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                          ,
                                          UG_2D
 #endif
-#if HAVE_DUNE_ALUGRID
                                          ,
                                          ALU_3D_SIMPLEX_CONFORMING,
                                          ALU_3D_SIMPLEX_NONCONFORMING
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                          ,
                                          UG_3D
@@ -296,21 +291,15 @@ XT::Grid::GridProvider<G> make_cubic_grid()
 } // ... make_cubic_grid(...)
 
 
-using CubicGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                    ,
+using CubicGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET,
                                     ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                     ,
                                     UG_2D
 #endif
                                     ,
-                                    YASP_3D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                    ,
+                                    YASP_3D_EQUIDISTANT_OFFSET,
                                     ALU_3D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                     ,
                                     UG_3D

--- a/dune/gdt/test/spaces/spaces_hdiv_raviart_thomas.cc
+++ b/dune/gdt/test/spaces/spaces_hdiv_raviart_thomas.cc
@@ -326,21 +326,16 @@ struct RtSpaceOnSimplicialLeafView : public RtSpace<typename Dune::XT::Grid::Gri
 
 
 using SimplicialGrids = ::testing::Types<ONED_1D,
-                                         YASP_1D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                         ,
+                                         YASP_1D_EQUIDISTANT_OFFSET,
                                          ALU_2D_SIMPLEX_CONFORMING,
                                          ALU_2D_SIMPLEX_NONCONFORMING
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                          ,
                                          UG_2D
 #endif
-#if HAVE_DUNE_ALUGRID
                                          ,
                                          ALU_3D_SIMPLEX_CONFORMING,
                                          ALU_3D_SIMPLEX_NONCONFORMING
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                          ,
                                          UG_3D
@@ -425,21 +420,15 @@ struct RtSpaceOnCubicLeafView : public RtSpace<typename Dune::XT::Grid::GridProv
 }; // struct RtSpaceOnCubicLeafView
 
 
-using CubicGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                    ,
+using CubicGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET,
                                     ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                     ,
                                     UG_2D
 #endif
                                     ,
-                                    YASP_3D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                    ,
+                                    YASP_3D_EQUIDISTANT_OFFSET,
                                     ALU_3D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                     ,
                                     UG_3D

--- a/dune/gdt/test/spaces/spaces_l2_finite_volume.cc
+++ b/dune/gdt/test/spaces/spaces_l2_finite_volume.cc
@@ -189,21 +189,16 @@ struct FiniteVolumeSpaceOnSimplicialLeafView
 
 
 using SimplicialGrids = ::testing::Types<ONED_1D,
-                                         YASP_1D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                         ,
+                                         YASP_1D_EQUIDISTANT_OFFSET,
                                          ALU_2D_SIMPLEX_CONFORMING,
                                          ALU_2D_SIMPLEX_NONCONFORMING
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                          ,
                                          UG_2D
 #endif
-#if HAVE_DUNE_ALUGRID
                                          ,
                                          ALU_3D_SIMPLEX_CONFORMING,
                                          ALU_3D_SIMPLEX_NONCONFORMING
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                          ,
                                          UG_3D
@@ -281,21 +276,15 @@ struct FiniteVolumeSpaceOnCubicLeafView
 }; // struct FiniteVolumeSpaceOnCubicLeafView
 
 
-using CubicGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                    ,
+using CubicGrids = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET,
                                     ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                     ,
                                     UG_2D
 #endif
                                     ,
-                                    YASP_3D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                    ,
+                                    YASP_3D_EQUIDISTANT_OFFSET,
                                     ALU_3D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                     ,
                                     UG_3D

--- a/dune/gdt/test/stationary-heat-equation/OS2015.hh
+++ b/dune/gdt/test/stationary-heat-equation/OS2015.hh
@@ -65,12 +65,10 @@ struct OS2015MultiscaleProblem
   {
     if (std::is_same<G, YASP_2D_EQUIDISTANT_OFFSET>::value) {
       return XT::Grid::make_cube_grid<G>({0., 0.}, {5., 1.}, {100u, 20u});
-#  if HAVE_DUNE_ALUGRID
     } else if (std::is_same<G, ALU_2D_SIMPLEX_CONFORMING>::value) {
       auto grid = XT::Grid::make_cube_grid<G>({0., 0.}, {5., 1.}, {100u, 20u});
       grid.global_refine(2);
       return grid;
-#  endif // HAVE_DUNE_ALUGRID
     } else
       EXPECT_TRUE(false) << "Please add a specialization for '" << XT::Common::Typename<G>::value << "'!";
   } // ... make_initial_grid(...)

--- a/dune/gdt/test/stokes/stokes.cc
+++ b/dune/gdt/test/stokes/stokes.cc
@@ -23,32 +23,20 @@
 using namespace Dune;
 using namespace Dune::GDT::Test;
 
-using SimplexGrids2D = ::testing::Types<
-#  if HAVE_DUNE_ALUGRID
-    ALU_2D_SIMPLEX_CONFORMING,
-    ALU_2D_SIMPLEX_NONCONFORMING
-#  endif
+using SimplexGrids2D = ::testing::Types<ALU_2D_SIMPLEX_CONFORMING,
+                                        ALU_2D_SIMPLEX_NONCONFORMING
 #  if HAVE_DUNE_UGGRID || HAVE_UG
-#    if HAVE_DUNE_ALUGRID
-    ,
-#    endif
-    UG_2D
+                                        ,
+                                        UG_2D
 #  endif
-    >;
+                                        >;
 
-using CubeGrids2D = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET
-#  if HAVE_DUNE_ALUGRID
-                                     ,
-                                     ALU_2D_CUBE
-#  endif
-                                     >;
+using CubeGrids2D = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET, ALU_2D_CUBE>;
 
 DUNE_XT_COMMON_TYPENAME(YASP_2D_EQUIDISTANT_OFFSET)
-#  if HAVE_DUNE_ALUGRID
 DUNE_XT_COMMON_TYPENAME(ALU_2D_SIMPLEX_CONFORMING)
 DUNE_XT_COMMON_TYPENAME(ALU_2D_SIMPLEX_NONCONFORMING)
 DUNE_XT_COMMON_TYPENAME(ALU_2D_CUBE)
-#  endif
 #  if HAVE_DUNE_UGGRID || HAVE_UG
 DUNE_XT_COMMON_TYPENAME(UG_2D)
 #  endif
@@ -56,7 +44,6 @@ DUNE_XT_COMMON_TYPENAME(UG_2D)
 DUNE_XT_COMMON_TYPENAME(ALBERTA_2D)
 #  endif
 
-#  if HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 template <class G>
 using StokesTestSimplex = StokesTestcase1<G>;
 TYPED_TEST_SUITE(StokesTestSimplex, SimplexGrids2D);
@@ -65,7 +52,6 @@ TYPED_TEST(StokesTestSimplex, order2)
 {
   this->run(2, 2e-5, 3e-3);
 }
-#  endif // HAVE_DUNE_UGGRID || HAVE_DUNE_ALUGRID
 
 template <class G>
 using StokesTestCube = StokesTestcase1<G>;

--- a/dune/xt/grid/dd/glued.hh
+++ b/dune/xt/grid/dd/glued.hh
@@ -130,7 +130,6 @@ class Glued
     static constexpr bool value = true;
   };
 
-#  if HAVE_DUNE_ALUGRID
   template <class Comm, bool anything>
   struct allowed_local_grid<ALUGrid<3, 3, simplex, conforming, Comm>, anything>
   {
@@ -142,7 +141,6 @@ class Glued
   {
     static constexpr bool value = false;
   };
-#  endif // HAVE_DUNE_ALUGRID
 
 #  if HAVE_MPI && (HAVE_DUNE_UGGRID || HAVE_UG)
   // UGGrid does not support multiple parallel instances in parallel and we have no means yet to create multiple

--- a/dune/xt/grid/gridprovider/cube.hh
+++ b/dune/xt/grid/gridprovider/cube.hh
@@ -89,8 +89,6 @@ class CubeGridProviderFactory
   };
 #endif
 
-#if HAVE_DUNE_ALUGRID
-
   template <int dimGrid, int dimWorld, class MpiCommImp>
   struct ElementVariant<Dune::ALUGrid<dimGrid, dimWorld, Dune::cube, Dune::conforming, MpiCommImp>>
   {
@@ -102,8 +100,6 @@ class CubeGridProviderFactory
   {
     static constexpr int id = 1;
   };
-
-#endif // HAVE_DUNE_ALUGRID
 
 public:
   static constexpr bool available = true;

--- a/dune/xt/grid/gridprovider/cube.lib.hh
+++ b/dune/xt/grid/gridprovider/cube.lib.hh
@@ -35,9 +35,7 @@
     _prefix Dune::XT::Grid::GridProvider<_GRID> Dune::XT::Grid::make_cube_grid<_GRID>(                                 \
         const Dune::XT::Common::Configuration&)
 
-#  if HAVE_DUNE_ALUGRID
 DUNE_XT_GRID_GRIDPROVIDER_CUBE_LIB_FACTORY_METHODS(extern template, ALU_2D_SIMPLEX_CONFORMING);
-#  endif
 DUNE_XT_GRID_GRIDPROVIDER_CUBE_LIB_FACTORY_METHODS(extern template, YASP_1D_EQUIDISTANT_OFFSET);
 DUNE_XT_GRID_GRIDPROVIDER_CUBE_LIB_FACTORY_METHODS(extern template, YASP_2D_EQUIDISTANT_OFFSET);
 DUNE_XT_GRID_GRIDPROVIDER_CUBE_LIB_FACTORY_METHODS(extern template, YASP_3D_EQUIDISTANT_OFFSET);

--- a/dune/xt/grid/gridprovider/dgf.hh
+++ b/dune/xt/grid/gridprovider/dgf.hh
@@ -21,9 +21,7 @@
 
 #include <dune/grid/io/file/dgfparser/dgfgridfactory.hh> // How convenient that GridPtr requires DGFGridFactory but ...
 #include <dune/grid/io/file/dgfparser.hh>
-#if HAVE_DUNE_ALUGRID
-#  include <dune/alugrid/dgf.hh>
-#endif
+#include <dune/alugrid/dgf.hh>
 #include <dune/grid/io/file/dgfparser/gridptr.hh> // ... does not include it!
 
 #include <dune/xt/common/configuration.hh>

--- a/dune/xt/grid/gridprovider/eoc.hh
+++ b/dune/xt/grid/gridprovider/eoc.hh
@@ -16,9 +16,7 @@
 #ifndef DUNE_XT_GRID_PROVIDER_EOC_HH
 #define DUNE_XT_GRID_PROVIDER_EOC_HH
 
-#if HAVE_DUNE_ALUGRID
-#  include <dune/alugrid/grid.hh>
-#endif
+#include <dune/alugrid/grid.hh>
 
 #include <dune/xt/grid/gridprovider/provider.hh>
 #include <dune/xt/grid/gridprovider/factory.hh>
@@ -187,8 +185,6 @@ public:
 };
 
 
-#if HAVE_DUNE_ALUGRID
-
 template <class Comm>
 class EOCGridProvider<Dune::ALUGrid<2, 2, simplex, conforming, Comm>>
   : public LeafBasedEOCGridProvider<Dune::ALUGrid<2, 2, simplex, conforming, Comm>>
@@ -200,8 +196,6 @@ public:
   {
   }
 };
-
-#endif // HAVE_DUNE_ALUGRID
 
 
 } // namespace Dune::XT::Grid

--- a/dune/xt/grid/gridprovider/gmsh.hh
+++ b/dune/xt/grid/gridprovider/gmsh.hh
@@ -93,12 +93,10 @@ public:
   static Common::Configuration default_config()
   {
     auto cfg = gmsh_gridprovider_default_config();
-#if HAVE_DUNE_ALUGRID
     if (std::is_same<ALUGrid<2, 2, simplex, conforming>, GridType>::value
         || std::is_same<ALUGrid<2, 2, simplex, nonconforming>, GridType>::value) {
       cfg["filename"] = "gmsh_2d_simplices.msh";
     }
-#endif // HAVE_DUNE_ALUGRID
     return cfg;
   }
 

--- a/dune/xt/grid/grids.hh
+++ b/dune/xt/grid/grids.hh
@@ -22,9 +22,7 @@
 #  include <dune/xt/common/reenable_warnings.hh>
 #endif
 
-#if HAVE_DUNE_ALUGRID
-#  include <dune/alugrid/grid.hh>
-#endif
+#include <dune/alugrid/grid.hh>
 
 #if HAVE_DUNE_SPGRID
 #  include <dune/grid/spgrid.hh>
@@ -45,14 +43,12 @@ using YASP_1D_EQUIDISTANT_OFFSET = Dune::YaspGrid<1, Dune::EquidistantOffsetCoor
 using YASP_2D_EQUIDISTANT_OFFSET = Dune::YaspGrid<2, Dune::EquidistantOffsetCoordinates<double, 2>>;
 using YASP_3D_EQUIDISTANT_OFFSET = Dune::YaspGrid<3, Dune::EquidistantOffsetCoordinates<double, 3>>;
 using YASP_4D_EQUIDISTANT_OFFSET = Dune::YaspGrid<4, Dune::EquidistantOffsetCoordinates<double, 4>>;
-#if HAVE_DUNE_ALUGRID
 using ALU_2D_SIMPLEX_CONFORMING = Dune::ALUGrid<2, 2, Dune::simplex, Dune::conforming>;
 using ALU_2D_SIMPLEX_NONCONFORMING = Dune::ALUGrid<2, 2, Dune::simplex, Dune::nonconforming>;
 using ALU_2D_CUBE = Dune::ALUGrid<2, 2, Dune::cube, Dune::nonconforming>;
 using ALU_3D_SIMPLEX_CONFORMING = Dune::ALUGrid<3, 3, Dune::simplex, Dune::conforming>;
 using ALU_3D_SIMPLEX_NONCONFORMING = Dune::ALUGrid<3, 3, Dune::simplex, Dune::nonconforming>;
 using ALU_3D_CUBE = Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>;
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
 using UG_2D = Dune::UGGrid<2>;
 using UG_3D = Dune::UGGrid<3>;
@@ -64,16 +60,6 @@ using ALBERTA_3D = Dune::AlbertaGrid<3, 3>;
 
 
 namespace Dune::XT::Grid {
-namespace internal {
-
-
-// To give better error messages, required below.
-template <size_t d>
-class ThereIsNoSimplexGridAvailableInDimension
-{};
-
-
-} // namespace internal
 
 
 /**
@@ -84,13 +70,10 @@ using Available1dGridTypes = std::tuple<ONED_1D, YASP_1D_EQUIDISTANT_OFFSET>;
 /**
  * \note Alberta grids are missing here on purpose, these cannot be handled automatically very well.
  */
-using Available2dGridTypes = std::tuple<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                        ,
+using Available2dGridTypes = std::tuple<YASP_2D_EQUIDISTANT_OFFSET,
                                         ALU_2D_SIMPLEX_CONFORMING,
                                         ALU_2D_SIMPLEX_NONCONFORMING,
                                         ALU_2D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                         ,
                                         UG_2D
@@ -100,13 +83,10 @@ using Available2dGridTypes = std::tuple<YASP_2D_EQUIDISTANT_OFFSET
 /**
  * \note Alberta grids are missing here on purpose, these cannot be handled automatically very well.
  */
-using Available3dGridTypes = std::tuple<YASP_3D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                        ,
+using Available3dGridTypes = std::tuple<YASP_3D_EQUIDISTANT_OFFSET,
                                         ALU_3D_SIMPLEX_CONFORMING,
                                         ALU_3D_SIMPLEX_NONCONFORMING,
                                         ALU_3D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                         ,
                                         UG_3D
@@ -122,22 +102,8 @@ using AvailableGridTypes = Common::tuple_cat_t<Available1dGridTypes, Available2d
 
 
 using SIMPLEXGRID_1D = ONED_1D;
-using SIMPLEXGRID_2D =
-#if HAVE_DUNE_ALUGRID
-    ALU_2D_SIMPLEX_CONFORMING;
-#elif HAVE_DUNE_UGGRID || HAVE_UG
-    UG_2D;
-#else
-    Dune::XT::Grid::internal::ThereIsNoSimplexGridAvailableInDimension<2>;
-#endif
-using SIMPLEXGRID_3D =
-#if HAVE_DUNE_ALUGRID
-    ALU_3D_SIMPLEX_CONFORMING;
-#elif HAVE_DUNE_UGGRID || HAVE_UG
-    UG_3D;
-#else
-    Dune::XT::Grid::internal::ThereIsNoSimplexGridAvailableInDimension<3>;
-#endif
+using SIMPLEXGRID_2D = ALU_2D_SIMPLEX_CONFORMING;
+using SIMPLEXGRID_3D = ALU_3D_SIMPLEX_CONFORMING;
 
 
 using CUBEGRID_1D = ONED_1D;
@@ -145,13 +111,8 @@ using CUBEGRID_2D = YASP_2D_EQUIDISTANT_OFFSET;
 using CUBEGRID_3D = YASP_3D_EQUIDISTANT_OFFSET;
 
 
-#if HAVE_DUNE_ALUGRID || HAVE_DUNE_UGGRID || HAVE_UG
-#  define SIMPLEXGRID_2D_AVAILABLE 1
-#  define SIMPLEXGRID_3D_AVAILABLE 1
-#else
-#  define SIMPLEXGRID_2D_AVAILABLE 0
-#  define SIMPLEXGRID_3D_AVAILABLE 0
-#endif
+#define SIMPLEXGRID_2D_AVAILABLE 1
+#define SIMPLEXGRID_3D_AVAILABLE 1
 
 
 using GRID_1D = ONED_1D;

--- a/dune/xt/grid/structuredgridfactory.hh
+++ b/dune/xt/grid/structuredgridfactory.hh
@@ -30,9 +30,7 @@
 #  include <dune/grid/albertagrid.hh>
 #endif
 
-#if HAVE_DUNE_ALUGRID
-#  include <dune/alugrid/common/structuredgridfactory.hh>
-#endif
+#include <dune/alugrid/common/structuredgridfactory.hh>
 
 #if HAVE_DUNE_UGGRID
 #  include <dune/grid/uggrid.hh>
@@ -173,7 +171,6 @@ public:
 #endif // HAVE_ALBERTA
 
 
-#if HAVE_DUNE_ALUGRID
 template <int dim_world, int dim, ALUGridRefinementType refineType, class Comm>
 class StructuredGridFactory<ALUGrid<dim, dim_world, Dune::cube, refineType, Comm>>
   : public Dune::StructuredGridFactory<ALUGrid<dim, dim_world, Dune::cube, refineType, Comm>>
@@ -191,14 +188,13 @@ public:
   {
     if (Dune::MPIHelper::isFake) // NOLINT(readability-implicit-bool-conversion)
       return Dune::StructuredGridFactory<GridType>::createCubeGrid(lowerLeft, upperRight, elements);
-#  if HAVE_MPI
+#if HAVE_MPI
     if (mpi_comm == MPI_COMM_WORLD)
       return Dune::StructuredGridFactory<GridType>::createCubeGrid(lowerLeft, upperRight, elements);
-#  endif
+#endif
     DUNE_THROW(InvalidStateException, "ALUgrid Cube construction cannot handle non-world communicators");
   }
 };
-#endif // HAVE_ALBERTA
 
 #if HAVE_DUNE_SPGRID
 template <class ct, int dim, template <int> class Refinement, class Comm>

--- a/dune/xt/grid/type_traits.hh
+++ b/dune/xt/grid/type_traits.hh
@@ -29,9 +29,7 @@
 #  include <dune/xt/common/reenable_warnings.hh>
 #endif
 
-#if HAVE_DUNE_ALUGRID
-#  include <dune/alugrid/grid.hh>
-#endif
+#include <dune/alugrid/grid.hh>
 
 #if HAVE_DUNE_SPGRID
 #  include <dune/grid/spgrid.hh>
@@ -142,7 +140,6 @@ struct is_grid<Dune::AlbertaGrid<dim, dimworld>> : public std::true_type
 {};
 
 #endif // HAVE_ALBERTA
-#if HAVE_DUNE_ALUGRID
 
 template <int dim, int dimworld, ALUGridElementType elType, ALUGridRefinementType refineType, class Comm>
 struct is_grid<Dune::ALUGrid<dim, dimworld, elType, refineType, Comm>> : public std::true_type
@@ -152,7 +149,6 @@ template <int dim, int dimworld, ALU3dGridElementType elType, class Comm>
 struct is_grid<Dune::ALU3dGrid<dim, dimworld, elType, Comm>> : public std::true_type
 {};
 
-#endif // HAVE_DUNE_ALUGRID
 #if HAVE_DUNE_UGGRID || HAVE_UG
 
 template <int dim>
@@ -248,8 +244,6 @@ struct is_cube_alugrid : public std::false_type
 {};
 
 
-#if HAVE_DUNE_ALUGRID
-
 template <int dim, int dimworld, ALUGridElementType elType, ALUGridRefinementType refineType, class Comm>
 struct is_alugrid<ALUGrid<dim, dimworld, elType, refineType, Comm>> : public std::true_type
 {};
@@ -265,8 +259,6 @@ struct is_simplex_alugrid<ALUGrid<dim, dimworld, ALUGridElementType::simplex, re
 template <int dim, int dimworld, ALUGridRefinementType refineType, class Comm>
 struct is_cube_alugrid<ALUGrid<dim, dimworld, ALUGridElementType::cube, refineType, Comm>> : public std::true_type
 {};
-
-#endif // HAVE_DUNE_ALUGRID
 
 
 /// \brief Extracts the grid type from a grid view, grid part, intersection or entity T.

--- a/dune/xt/test/grid/dd_glued_3d.cc
+++ b/dune/xt/test/grid/dd_glued_3d.cc
@@ -45,8 +45,6 @@ struct ExpectedResults<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>,
 }; // struct ExpectedResults<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>, YaspGrid<3,
 // EquidistantOffsetCoordinates<double, 3>>, anything>
 
-#  if HAVE_DUNE_ALUGRID
-
 template <class Comm>
 struct ExpectedResults<ALUGrid<3, 3, cube, nonconforming, Comm>, YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>>
 {
@@ -97,7 +95,6 @@ struct ExpectedResults<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>, ALU
 }; // ExpectedResults<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>, ALUGrid<3, 3, cube, nonconforming, Comm>,
 // anything>
 
-#  endif // HAVE_DUNE_ALUGRID
 #  if HAVE_DUNE_UGGRID || HAVE_UG
 
 template <>
@@ -164,7 +161,6 @@ using namespace Dune::XT::Grid;
 // clang-format off
 using GridTypes = ::testing::Types< std::tuple<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>,
                                      YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>>
-#if HAVE_DUNE_ALUGRID
                         , std::tuple<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>,
                                      Dune::ALUGrid<3, 3, cube, nonconforming>>
 //                      , std::tuple<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>,
@@ -179,7 +175,6 @@ using GridTypes = ::testing::Types< std::tuple<YaspGrid<3, EquidistantOffsetCoor
 //                                   ALUGrid<3, 3, simplex, nonconforming>>               // <- known to fail completely
 //                      , std::tuple<ALUGrid<3, 3, cube, nonconforming>,
 //                                   ALUGrid<3, 3, simplex, nonconforming>>               // <- known to fail completely
-#endif // HAVE_DUNE_ALUGRID
 #if !HAVE_MPI && (HAVE_DUNE_UGGRID || HAVE_UG)
                         , std::tuple<YaspGrid<3, EquidistantOffsetCoordinates<double, 3>>, UGGrid<3>>
 #endif

--- a/dune/xt/test/grid/gmsh_gridprovider.cc
+++ b/dune/xt/test/grid/gmsh_gridprovider.cc
@@ -11,9 +11,7 @@
 
 #include <dune/xt/test/main.hxx>
 
-#if HAVE_DUNE_ALUGRID
-
-#  include "provider.hh"
+#include "provider.hh"
 
 
 struct GmshGridProvider : public GridProviderBase<TESTGRIDTYPE>
@@ -40,12 +38,3 @@ TEST_F(GmshGridProvider, visualize)
 {
   this->check_visualize();
 }
-
-#else // HAVE_DUNE_ALUGRID
-
-
-TEST(DISABLED_GmshGridProvider, layers) {}
-TEST(DISABLED_GmshGridProvider, visualize) {}
-
-
-#endif // HAVE_DUNE_ALUGRID

--- a/python/gdt/dune/gdt/gamm-2019-talk-on-conservative-rb.cc
+++ b/python/gdt/dune/gdt/gamm-2019-talk-on-conservative-rb.cc
@@ -47,14 +47,7 @@
 using namespace Dune;
 using namespace Dune::GDT;
 
-#if HAVE_DUNE_ALUGRID
 using G = ALU_2D_SIMPLEX_CONFORMING;
-#elif HAVE_DUNE_UGGRID || HAVE_UG
-using G = UG_2D;
-#else
-#  warning Falling back to cubic grid, results will not be reproduced but similar!
-using G = YASP_2D_EQUIDISTANT_OFFSET;
-#endif
 
 using GP = XT::Grid::GridProvider<G>;
 using GV = typename G::LeafGridView;

--- a/python/gdt/dune/gdt/tools/adaptation-helper.cc
+++ b/python/gdt/dune/gdt/tools/adaptation-helper.cc
@@ -195,13 +195,7 @@ public:
 } // namespace Dune
 
 
-using AvailableAdaptiveGridTypes = std::tuple<ONED_1D
-#if HAVE_DUNE_ALUGRID
-                                              ,
-                                              ALU_2D_SIMPLEX_CONFORMING,
-                                              ALU_3D_SIMPLEX_CONFORMING
-#endif
-                                              >;
+using AvailableAdaptiveGridTypes = std::tuple<ONED_1D, ALU_2D_SIMPLEX_CONFORMING, ALU_3D_SIMPLEX_CONFORMING>;
 
 
 template <class V, class VT, class GridTypes = AvailableAdaptiveGridTypes>

--- a/python/xt/dune/xt/grid/dd_glued_gridprovider/cube.cc
+++ b/python/xt/dune/xt/grid/dd_glued_gridprovider/cube.cc
@@ -53,9 +53,7 @@ PYBIND11_MODULE(_grid_dd_glued_gridprovider_cube, m)
 
 #if HAVE_DUNE_GRID_GLUE
   make_cube_dd_grid<YASP_2D_EQUIDISTANT_OFFSET, Cube>::bind(m);
-#  if HAVE_DUNE_ALUGRID
   make_cube_dd_grid<ALU_2D_SIMPLEX_CONFORMING, Simplex>::bind(m);
   make_cube_dd_grid<ALU_2D_CUBE, Cube>::bind(m);
-#  endif
 #endif
 }

--- a/python/xt/dune/xt/grid/dd_glued_gridprovider/provider.cc
+++ b/python/xt/dune/xt/grid/dd_glued_gridprovider/provider.cc
@@ -264,18 +264,11 @@ struct MacroGridBasedBoundaryInfo
  * \note Available grid types for DD::Glued. So far, we only use Alugrid and Yasp
  */
 
-using AvailableGridGlueGridTypes = std::tuple<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                              ,
-                                              ALU_2D_SIMPLEX_CONFORMING,
-                                              ALU_2D_CUBE
-#endif
-                                              >;
+using AvailableGridGlueGridTypes = std::tuple<YASP_2D_EQUIDISTANT_OFFSET, ALU_2D_SIMPLEX_CONFORMING, ALU_2D_CUBE>;
 
 using GridGlue2dYaspYasp =
     Dune::XT::Grid::DD::Glued<YASP_2D_EQUIDISTANT_OFFSET, YASP_2D_EQUIDISTANT_OFFSET, Dune::XT::Grid::Layers::leaf>;
 using CouplingGridView2dYaspYasp = Dune::XT::Grid::CouplingGridView<GridGlue2dYaspYasp>;
-#if HAVE_DUNE_ALUGRID
 using GridGlue2dAluSimplexConformingAluSimplexConforming =
     Dune::XT::Grid::DD::Glued<ALU_2D_SIMPLEX_CONFORMING, ALU_2D_SIMPLEX_CONFORMING, Dune::XT::Grid::Layers::leaf>;
 using GridGlue2dAluConformingAluConforming =
@@ -284,15 +277,10 @@ using CouplingGridView2dAluSimplexConformingAluSimplexConforming =
     Dune::XT::Grid::CouplingGridView<GridGlue2dAluSimplexConformingAluSimplexConforming>;
 using CouplingGridView2dAluConformingAluConforming =
     Dune::XT::Grid::CouplingGridView<GridGlue2dAluConformingAluConforming>;
-#endif
 
-using AvailableCouplingGridViewTypes = std::tuple<CouplingGridView2dYaspYasp
-#if HAVE_DUNE_ALUGRID
-                                                  ,
+using AvailableCouplingGridViewTypes = std::tuple<CouplingGridView2dYaspYasp,
                                                   CouplingGridView2dAluSimplexConformingAluSimplexConforming,
-                                                  CouplingGridView2dAluConformingAluConforming
-#endif
-                                                  >;
+                                                  CouplingGridView2dAluConformingAluConforming>;
 
 
 template <class GridTypes = AvailableGridGlueGridTypes>

--- a/python/xt/dune/xt/grid/gridprovider/cube.cc
+++ b/python/xt/dune/xt/grid/gridprovider/cube.cc
@@ -137,7 +137,6 @@ PYBIND11_MODULE(_grid_gridprovider_cube, m)
   make_cube_grid<YASP_1D_EQUIDISTANT_OFFSET, Cube>::bind(m); // NOSONAR(cpp:S1117): m is an argument, not a decl
   make_cube_grid<YASP_2D_EQUIDISTANT_OFFSET, Cube>::bind(m);
   make_cube_grid<YASP_3D_EQUIDISTANT_OFFSET, Cube>::bind(m);
-#if HAVE_DUNE_ALUGRID
   // default (structured cube / conforming simplex) overloads
   make_cube_grid<ALU_2D_SIMPLEX_CONFORMING, Simplex>::bind(m);
   make_cube_grid<ALU_3D_SIMPLEX_CONFORMING, Simplex>::bind(m);
@@ -146,5 +145,4 @@ PYBIND11_MODULE(_grid_gridprovider_cube, m)
   // historical set that is separately bindable: the nonconforming ALU *simplex* grids share their
   // leaf-view type with the conforming ones (see grids.bindings.hh), and 2d has no cube ALUGrid.
   make_cube_grid_backend<ALU_3D_CUBE, Cube, Nonconforming>::bind(m);
-#endif
 }

--- a/python/xt/dune/xt/grid/gridprovider/gmsh.cc
+++ b/python/xt/dune/xt/grid/gridprovider/gmsh.cc
@@ -53,10 +53,8 @@ PYBIND11_MODULE(_grid_gridprovider_gmsh, m)
   py::module::import("dune.xt.grid._grid_gridprovider_provider");
   py::module::import("dune.xt.grid._grid_traits");
 
-#if HAVE_DUNE_ALUGRID
   make_gmsh_grid<ALU_2D_SIMPLEX_CONFORMING, Simplex>::bind(m);
   make_gmsh_grid<ALU_2D_CUBE, Cube>::bind(m);
   make_gmsh_grid<ALU_3D_SIMPLEX_CONFORMING, Simplex>::bind(m);
   make_gmsh_grid<ALU_3D_CUBE, Cube>::bind(m);
-#endif
 }

--- a/python/xt/dune/xt/grid/grids.bindings.hh
+++ b/python/xt/dune/xt/grid/grids.bindings.hh
@@ -106,9 +106,6 @@ struct grid_name<YaspGrid<dim, EquidistantOffsetCoordinates<double, dim>>>
   }
 };
 
-#if HAVE_DUNE_ALUGRID
-
-
 template <int dim, class Comm>
 struct grid_name<ALUGrid<dim, dim, simplex, conforming, Comm>>
 {
@@ -164,7 +161,6 @@ struct grid_name<ALU3dGrid<dim, dim, ALU3dGridElementType::hexa, Comm>>
 };
 
 
-#endif // HAVE_DUNE_ALUGRID
 #if HAVE_ALBERTA
 
 
@@ -221,23 +217,17 @@ struct grid_name<UGGrid<dim>>
 
 using Available1dGridTypes = std::tuple<ONED_1D, YASP_1D_EQUIDISTANT_OFFSET>;
 
-using Available2dGridTypes = unique_grid_tuple_t<std::tuple<YASP_2D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                                            ,
+using Available2dGridTypes = unique_grid_tuple_t<std::tuple<YASP_2D_EQUIDISTANT_OFFSET,
                                                             ALU_2D_SIMPLEX_CONFORMING
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                                             ,
                                                             UG_2D
 #endif
                                                             >>;
 
-using Available3dGridTypes = unique_grid_tuple_t<std::tuple<YASP_3D_EQUIDISTANT_OFFSET
-#if HAVE_DUNE_ALUGRID
-                                                            ,
+using Available3dGridTypes = unique_grid_tuple_t<std::tuple<YASP_3D_EQUIDISTANT_OFFSET,
                                                             ALU_3D_SIMPLEX_CONFORMING,
                                                             ALU_3D_CUBE
-#endif
 #if HAVE_DUNE_UGGRID || HAVE_UG
                                                             ,
                                                             UG_3D

--- a/python/xt/dune/xt/grid/walker/apply-on.bindings.hh
+++ b/python/xt/dune/xt/grid/walker/apply-on.bindings.hh
@@ -111,12 +111,8 @@ public:
 #define _DUNE_XT_GRID_WALKER_APPLYON_BIND_ALBERTA(_m, _W, _w, _layer, _backend, _class_name)
 // #endif
 
-#if HAVE_DUNE_ALUGRID
-#  define _DUNE_XT_GRID_WALKER_APPLYON_BIND_ALU(_m, _W, _w, _layer, _backend, _class_name)                             \
-    _DUNE_XT_GRID_WALKER_APPLYON_BIND(_m, _W, _w, ALU_2D_SIMPLEX_CONFORMING, _layer, _backend, _class_name)
-#else
-#  define _DUNE_XT_GRID_WALKER_APPLYON_BIND_ALU(_m, _W, _w, _layer, _backend, _class_name)
-#endif
+#define _DUNE_XT_GRID_WALKER_APPLYON_BIND_ALU(_m, _W, _w, _layer, _backend, _class_name)                               \
+  _DUNE_XT_GRID_WALKER_APPLYON_BIND(_m, _W, _w, ALU_2D_SIMPLEX_CONFORMING, _layer, _backend, _class_name)
 
 /*#if HAVE_DUNE_UGGRID
 #define _DUNE_XT_GRID_WALKER_APPLYON_BIND_UG(_m, _W, _w, _layer, _backend, _class_name) \


### PR DESCRIPTION
Closes #384.

## Summary

`dune-alugrid` is a hard requirement: `CMakeLists.txt` puts it in `DUNE_SUBMODULES` and calls `find_package(${module} CONFIG REQUIRED)` on it, and `vcpkg.json` lists it unconditionally (unlike `uggrid`/`alberta`, which sit behind manifest features). Since dune-common's `DuneModuleDependencies.cmake` sets `HAVE_DUNE_ALUGRID` to `dune-alugrid_FOUND`, the macro is always `1` and every `#if`/`#ifdef` guarding on it is dead code.

This PR removes those guards across the 36 affected files while keeping the previously-guarded content:

- Plain `#if HAVE_DUNE_ALUGRID ... #endif` blocks with no `#else` are stripped, keeping the body unconditional.
- Compound conditions containing `HAVE_DUNE_ALUGRID` are simplified according to their boolean semantics (`X || HAVE_DUNE_ALUGRID` → always true → guard removed; `X && HAVE_DUNE_ALUGRID` → reduces to `X`).
- `dune/xt/test/grid/gmsh_gridprovider.cc` had `#if HAVE_DUNE_ALUGRID ... #else` with unreachable `TEST(DISABLED_GmshGridProvider, ...) {}` stubs; both the guard and the dead `#else` branch are removed.
- `dune/xt/grid/grids.hh`'s now-unreachable `ThereIsNoSimplexGridAvailableInDimension` fallback (only reachable when ALUGRID was absent) is removed along with the `#elif`/`#else` branches that could select it.
- The commented-out `//#if HAVE_DUNE_ALUGRID` block in `dune/xt/test/grid/dd_glued_2d.cc` is left untouched, as noted in the issue — that file is dead code slated for removal as part of the dune-grid-glue cleanup instead.

Purely mechanical; no behavioral change. All grid types and tests that were previously compiled in (since ALUGRID has always been available) continue to be compiled in unconditionally.

## Test plan

- [ ] CI build/test suite (dune-alugrid is always available, so the guarded code paths were already being exercised)
- [x] Verified `#if`/`#endif` nesting balance in every touched file
- [x] `clang-format` applied to all touched files
- [x] Repo-wide grep confirms no remaining `HAVE_DUNE_ALUGRID` guards except the intentionally-untouched commented block in `dd_glued_2d.cc`


---
_Generated by [Claude Code](https://claude.ai/code/session_011yjFCrcyDBdLEzfGsjuPqn)_