### PR TITLE
Fix test_create_directory() double-stripping the directory it is given

### DIFF
--- a/dune/xt/common/configuration.cc
+++ b/dune/xt/common/configuration.cc
@@ -100,7 +100,7 @@ Configuration::~Configuration()
   // std::terminate). Writing the configuration to the logfile on exit is best-effort.
   try {
     if (log_on_exit_ && !empty()) {
-      test_create_directory(directory_only(logfile_));
+      create_directory_of(logfile_);
       report(*make_ofstream(logfile_));
     }
   } catch (const std::exception& e) {
@@ -118,7 +118,7 @@ void Configuration::set_warn_on_default_access(const bool value)
 void Configuration::set_log_on_exit(const bool value)
 {
   if (!log_on_exit_ && value)
-    test_create_directory(directory_only(logfile_));
+    create_directory_of(logfile_);
   log_on_exit_ = value;
 }
 
@@ -128,7 +128,7 @@ void Configuration::set_logfile(const std::string& logfile)
     DUNE_THROW(Exceptions::wrong_input_given, "logfile must not be empty!");
   logfile_ = logfile;
   if (log_on_exit_)
-    test_create_directory(directory_only(logfile_));
+    create_directory_of(logfile_);
 }
 
 // method definitions for Configuration

--- a/dune/xt/common/filesystem.cc
+++ b/dune/xt/common/filesystem.cc
@@ -29,12 +29,15 @@ std::string filename_only(const std::string& _path)
   return boost::filesystem::path(_path).filename().string();
 } // filename_only
 
-//! may include filename, will be stripped
-void test_create_directory(const std::string& _path)
+void create_directory(const std::string& dir_path)
 {
-  std::string pathonly = directory_only(_path);
-  if (!pathonly.empty())
-    boost::filesystem::create_directories(pathonly);
+  if (!dir_path.empty())
+    boost::filesystem::create_directories(dir_path);
+}
+
+void create_directory_of(const std::string& file_path)
+{
+  create_directory(directory_only(file_path));
 }
 
 //! pure c++ emulation of system's touch binary
@@ -46,14 +49,14 @@ bool touch(const std::string& _path)
 std::unique_ptr<boost::filesystem::ofstream> make_ofstream(const boost::filesystem::path& path,
                                                            const std::ios_base::openmode mode)
 {
-  test_create_directory(path.string());
+  create_directory_of(path.string());
   return std::make_unique<boost::filesystem::ofstream>(path, mode);
 }
 
 std::unique_ptr<boost::filesystem::ifstream> make_ifstream(const boost::filesystem::path& path,
                                                            const std::ios_base::openmode mode)
 {
-  test_create_directory(path.string());
+  create_directory_of(path.string());
   return std::make_unique<boost::filesystem::ifstream>(path, mode);
 }
 

--- a/dune/xt/common/filesystem.hh
+++ b/dune/xt/common/filesystem.hh
@@ -35,8 +35,11 @@ std::string directory_only(std::string _path);
 //! return everything after the last slash
 std::string filename_only(const std::string& _path);
 
-//! may include filename, will be stripped
-void test_create_directory(const std::string& _path);
+//! creates \a dir_path itself (must not include a filename component)
+void create_directory(const std::string& dir_path);
+
+//! creates the directory containing \a file_path (which may include a filename, will be stripped)
+void create_directory_of(const std::string& file_path);
 
 //! pure c++ emulation of system's touch binary
 bool touch(const std::string& _path);

--- a/dune/xt/common/logging.cc
+++ b/dune/xt/common/logging.cc
@@ -56,7 +56,7 @@ void Logging::create(int logflags, const std::string& logfile, const std::string
   logflags_ = logflags;
   path logdir = path(datadir) / _logdir;
   filename_ = logdir / (log_fn % logfile % ".log").str();
-  test_create_directory(filename_.string());
+  create_directory_of(filename_.string());
   const bool file_logging = ((logflags_ & LOG_FILE) != 0);
   if (file_logging) {
     logfile_.open(filename_);

--- a/dune/xt/common/timings.cc
+++ b/dune/xt/common/timings.cc
@@ -149,7 +149,7 @@ void Timings::reset()
 void Timings::set_outputdir(std::string dir)
 {
   output_dir_ = std::move(dir);
-  test_create_directory(output_dir_);
+  create_directory(output_dir_);
 }
 
 void Timings::output_per_rank(std::string csv_base) const

--- a/dune/xt/functions/visualization.hh
+++ b/dune/xt/functions/visualization.hh
@@ -97,7 +97,7 @@ auto write_visualization(VTKWriter<GridViewType>& vtk_writer,
   if (path.empty())
     DUNE_THROW(Exceptions::wrong_input_given, "path must not be empty!");
   const auto directory = Common::directory_only(path);
-  Common::test_create_directory(directory);
+  Common::create_directory(directory);
   if (MPIHelper::getCommunication().size() == 1)
     vtk_writer.write(path, vtk_output_type);
   else

--- a/dune/xt/grid/output/entity_visualization.hh
+++ b/dune/xt/grid/output/entity_visualization.hh
@@ -55,7 +55,7 @@ struct ElementVisualization
     vtkwriter.addCellData(values, "data");
     const std::string piecefilesFolderName = "piecefiles";
     const std::string piecefilesPath = f.dir() + "/" + piecefilesFolderName + "/";
-    Common::test_create_directory(piecefilesPath);
+    Common::create_directory(piecefilesPath);
     vtkwriter.pwrite(f.filename(), f.dir(), piecefilesFolderName, Dune::VTK::appendedraw);
   }
 

--- a/dune/xt/test/common/configuration.cc
+++ b/dune/xt/test/common/configuration.cc
@@ -771,6 +771,8 @@ GTEST_TEST(Configuration, log_on_exit_writes_the_configuration)
     Configuration config;
     config.set_logfile(logfile);
     config.set_log_on_exit(true);
+    // set_log_on_exit(true) creates the logfile's directory right away, before anything is written.
+    EXPECT_TRUE(boost::filesystem::is_directory("elsewhere"));
     // Switching it on again does not create the directory a second time.
     config.set_log_on_exit(true);
     config["key"] = "value";
@@ -793,15 +795,13 @@ GTEST_TEST(Configuration, set_logfile_moves_the_target_while_logging_is_on)
   {
     Configuration config;
     config.set_log_on_exit(true);
-    // Both calls below take the log_on_exit_ branch of set_logfile(), which is meant to create the directory of the
-    // new target right away. There is deliberately no assertion on that directory: set_logfile() hands
-    // directory_only(logfile_) to test_create_directory(), which strips a component off its argument a second time
-    // (see filesystem.cc), so for a target one level deep such as "first/dxtc_parameter.log" the call creates
-    // nothing at all. That double strip predates the missing assignment fixed here and is not what this test is
-    // about -- it stays invisible because make_ofstream() creates the directory properly when the report is written.
+    // Both calls below take the log_on_exit_ branch of set_logfile(), which creates the directory of the new target
+    // right away, via create_directory_of(logfile_).
     config.set_logfile("first/dxtc_parameter.log");
+    EXPECT_TRUE(boost::filesystem::is_directory("first"));
     // Only the last target wins.
     config.set_logfile("second/dxtc_parameter.log");
+    EXPECT_TRUE(boost::filesystem::is_directory("second"));
     config["key"] = "value";
   }
   EXPECT_TRUE(boost::filesystem::is_regular_file("second/dxtc_parameter.log"));

--- a/dune/xt/test/common/filesystem.cc
+++ b/dune/xt/test/common/filesystem.cc
@@ -64,24 +64,40 @@ TEST_F(FilesystemTest, filename_only)
 }
 
 
-TEST_F(FilesystemTest, test_create_directory_strips_the_filename)
+TEST_F(FilesystemTest, create_directory_of_strips_the_filename)
 {
   const auto nested = dir.file("a/b");
   ASSERT_FALSE(boost::filesystem::exists(nested));
 
-  test_create_directory(nested + "/some_file.txt");
+  create_directory_of(nested + "/some_file.txt");
   EXPECT_TRUE(boost::filesystem::is_directory(nested));
   // The filename must not have been created as a directory of its own.
   EXPECT_FALSE(boost::filesystem::exists(nested + "/some_file.txt"));
 
   // Calling it again on an existing directory is fine ...
-  EXPECT_NO_THROW(test_create_directory(nested + "/some_file.txt"));
+  EXPECT_NO_THROW(create_directory_of(nested + "/some_file.txt"));
   // ... and a path without any directory component is a no-op. This one has to stay a bare filename (that is the
   // case under test), so it is made unique to keep it from colliding with anything else in the working directory.
   const auto bare_filename = Dune::XT::Common::Test::get_unique_test_name() + ".txt";
   ASSERT_FALSE(boost::filesystem::exists(bare_filename));
-  EXPECT_NO_THROW(test_create_directory(bare_filename));
+  EXPECT_NO_THROW(create_directory_of(bare_filename));
   EXPECT_FALSE(boost::filesystem::exists(bare_filename));
+}
+
+
+TEST_F(FilesystemTest, create_directory_creates_the_path_itself)
+{
+  const auto nested = dir.file("a/b");
+  ASSERT_FALSE(boost::filesystem::exists(nested));
+
+  // Unlike create_directory_of(), no component is stripped: the given path is the directory to create.
+  create_directory(nested);
+  EXPECT_TRUE(boost::filesystem::is_directory(nested));
+
+  // Calling it again on an existing directory is fine ...
+  EXPECT_NO_THROW(create_directory(nested));
+  // ... and an empty path is a no-op.
+  EXPECT_NO_THROW(create_directory(""));
 }
 
 

--- a/dune/xt/test/common/filesystem.cc
+++ b/dune/xt/test/common/filesystem.cc
@@ -96,6 +96,9 @@ TEST_F(FilesystemTest, create_directory_creates_the_path_itself)
 
   // Calling it again on an existing directory is fine ...
   EXPECT_NO_THROW(create_directory(nested));
+  // ... and so is a trailing slash (entity_visualization.hh relies on this).
+  EXPECT_NO_THROW(create_directory(nested + "/"));
+  EXPECT_TRUE(boost::filesystem::is_directory(nested));
   // ... and an empty path is a no-op.
   EXPECT_NO_THROW(create_directory(""));
 }

--- a/dune/xt/test/common/timings.cc
+++ b/dune/xt/test/common/timings.cc
@@ -16,6 +16,8 @@
 #include <dune/xt/common/ranges.hh>
 #include <dune/xt/common/timings.hh>
 
+#include <dune/xt/test/common/scoped_test_dir.hh>
+
 using namespace Dune::XT::Common;
 const size_t wait_ms = 142;
 
@@ -48,6 +50,23 @@ GTEST_TEST(ProfilerTest, ScopedTiming)
   for ([[maybe_unused]] auto i : dvalue_range)
     scoped_busywait("ProfilerTest.ScopedTiming", wait_ms);
   EXPECT_GE(DXTC_TIMINGS.walltime("ProfilerTest.ScopedTiming"), long(dvalue_range.size() * wait_ms));
+}
+
+GTEST_TEST(ProfilerTest, SetOutputdirCreatesTheDirectory)
+{
+  using Dune::XT::Common::Test::CurrentPathGuard;
+  using Dune::XT::Common::Test::ScopedTestDir;
+
+  const ScopedTestDir dir("test_timings_");
+  const CurrentPathGuard cwd(dir.path());
+  const auto nested = std::string("nested/output/dir");
+  ASSERT_FALSE(boost::filesystem::exists(nested));
+
+  DXTC_TIMINGS.set_outputdir(nested);
+  EXPECT_TRUE(boost::filesystem::is_directory(nested));
+
+  // Restore the default so subsequent tests in this binary are unaffected.
+  DXTC_TIMINGS.set_outputdir("");
 }
 
 GTEST_TEST(ProfilerTest, OutputConstness)

--- a/dune/xt/test/common/timings.cc
+++ b/dune/xt/test/common/timings.cc
@@ -65,8 +65,8 @@ GTEST_TEST(ProfilerTest, SetOutputdirCreatesTheDirectory)
   DXTC_TIMINGS.set_outputdir(nested);
   EXPECT_TRUE(boost::filesystem::is_directory(nested));
 
-  // Restore the default so subsequent tests in this binary are unaffected.
-  DXTC_TIMINGS.set_outputdir("");
+  // Restore the constructor default so subsequent tests in this binary are unaffected.
+  DXTC_TIMINGS.set_outputdir("profiling");
 }
 
 GTEST_TEST(ProfilerTest, OutputConstness)

--- a/dune/xt/test/functions/visualization.tpl
+++ b/dune/xt/test/functions/visualization.tpl
@@ -20,6 +20,8 @@
 #include <dune/xt/functions/generic/grid-function.hh>
 #include <dune/xt/functions/visualization.hh>
 
+#include <dune/xt/test/common/scoped_test_dir.hh>
+
 using namespace Dune::XT;
 using namespace Dune::XT::Functions;
 
@@ -76,12 +78,17 @@ TEST_F(VisualizeGenericGridFunction_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, vis
   if (r == 1)
     visualize_gradient(function, leaf_view, "gradient");
 
-  // A path nested below a directory that does not exist yet must have that directory created for it.
-  const std::string nested_dir = "nested_visualization_output_dir";
-  ASSERT_FALSE(boost::filesystem::is_directory(nested_dir));
-  visualize(function, leaf_view, nested_dir + "/default");
-  EXPECT_TRUE(boost::filesystem::is_directory(nested_dir));
-  boost::filesystem::remove_all(nested_dir);
+  // A path nested below a directory that does not exist yet must have that directory created for it. This runs
+  // inside its own directory (removed again on scope exit, even if visualize() throws), so a failure here cannot
+  // leave anything behind that would confuse another instantiation of this template.
+  {
+    const Dune::XT::Common::Test::ScopedTestDir dir("test_visualization_");
+    const Dune::XT::Common::Test::CurrentPathGuard cwd(dir.path());
+    const std::string nested_dir = "nested_visualization_output_dir";
+    ASSERT_FALSE(boost::filesystem::is_directory(nested_dir));
+    visualize(function, leaf_view, nested_dir + "/default");
+    EXPECT_TRUE(boost::filesystem::is_directory(nested_dir));
+  }
 }
 
 {% endfor  %}

--- a/dune/xt/test/functions/visualization.tpl
+++ b/dune/xt/test/functions/visualization.tpl
@@ -11,6 +11,8 @@
 
 #include <dune/xt/test/main.hxx>
 
+#include <boost/filesystem.hpp>
+
 #include <dune/xt/grid/grids.hh>
 #include <dune/geometry/quadraturerules.hh>
 #include <dune/xt/grid/gridprovider/cube.hh>
@@ -73,6 +75,13 @@ TEST_F(VisualizeGenericGridFunction_from_{{GRIDNAME}}_to_{{r}}_times_{{rC}}, vis
 
   if (r == 1)
     visualize_gradient(function, leaf_view, "gradient");
+
+  // A path nested below a directory that does not exist yet must have that directory created for it.
+  const std::string nested_dir = "nested_visualization_output_dir";
+  ASSERT_FALSE(boost::filesystem::is_directory(nested_dir));
+  visualize(function, leaf_view, nested_dir + "/default");
+  EXPECT_TRUE(boost::filesystem::is_directory(nested_dir));
+  boost::filesystem::remove_all(nested_dir);
 }
 
 {% endfor  %}


### PR DESCRIPTION
Fixes #416.

## Summary

`Common::test_create_directory()` takes a path that **may include a filename** and strips it before creating the parent directory. Three call sites already passed a directory (not a file path), so the strip removed one component too many:

- `dune/xt/functions/visualization.hh` — `write_visualization()` pre-stripped the path with `directory_only()` and then handed the *already-stripped* directory to `test_create_directory()`, which stripped it again. A nested output path such as `"vis/field"` never got its `vis` directory created, so the VTK write failed.
- `dune/xt/common/timings.cc` — `Timings::set_outputdir()` was given a directory directly, so a single-level directory such as `"timings"` was stripped down to nothing.
- `dune/xt/common/configuration.cc` — all three call sites (destructor, `set_log_on_exit()`, `set_logfile()`) had the same bug, though it stayed invisible in practice because `make_ofstream()` later strips the *unstripped* logfile path correctly when the report is actually written.

## Fix

Per the issue's suggestion, `test_create_directory()` is split into two unambiguous functions so the two intents can no longer be confused:

- `create_directory(dir_path)` — creates `dir_path` itself, no stripping.
- `create_directory_of(file_path)` — strips the filename and creates the parent directory.

Every call site now uses whichever one matches what it actually has:
- `write_visualization()` now calls `create_directory()` on the already-computed directory.
- `Timings::set_outputdir()` now calls `create_directory()` directly on the directory it was given.
- `Configuration`'s three call sites now call `create_directory_of(logfile_)` directly (no pre-stripping).
- `entity_visualization.hh`'s `piecefilesPath` (already a directory, with trailing slash) now uses `create_directory()` instead of relying on the stray-trailing-slash behavior of the old stripping function.
- The remaining call sites (`make_ofstream`/`make_ifstream`, `logging.cc`) already passed full file paths, so they switch to `create_directory_of()` with no behavior change.

## Tests

Added coverage for the directory-creation side effect at each of the three previously-affected call sites (there was none before):
- `dune/xt/test/common/filesystem.cc`: split test now covers both `create_directory()` and `create_directory_of()`.
- `dune/xt/test/common/configuration.cc`: asserts the logfile's directory is created eagerly by `set_log_on_exit()` and `set_logfile()`.
- `dune/xt/test/common/timings.cc`: new test asserting `set_outputdir()` creates a nested directory.
- `dune/xt/test/functions/visualization.tpl`: new assertion that `visualize()` creates a directory nested one level deep.

## Test plan

- [ ] CI build and test suite pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01818PRAy52VLfspdgbHPvVq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic creation of directories for log files, timing outputs, visualization files, and stream-based file operations.
  * Logfile directories are now created immediately when configuring logging.
  * Directory handling now correctly distinguishes between creating a directory itself and creating a file’s parent directory.

* **Tests**
  * Added coverage for nested output paths, repeated directory creation, bare filenames, and visualization output directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->