### PR TITLE
Remove always-true HAVE_DUNE_ISTL guards and dead EXADUNE TBB block

### DIFF
--- a/dune/gdt/test/stokes/stokes.cc
+++ b/dune/gdt/test/stokes/stokes.cc
@@ -18,8 +18,6 @@
 
 #include <dune/gdt/test/stokes/stokes-taylorhood.hh>
 
-#if HAVE_DUNE_ISTL
-
 using namespace Dune;
 using namespace Dune::GDT::Test;
 
@@ -66,5 +64,3 @@ TYPED_TEST(StokesTestCube, order3)
 {
   this->run(3, 4e-7, 7e-6);
 }
-
-#endif // HAVE_DUNE_ISTL

--- a/dune/gdt/test/stokes/stokes.cc
+++ b/dune/gdt/test/stokes/stokes.cc
@@ -23,10 +23,10 @@ using namespace Dune::GDT::Test;
 
 using SimplexGrids2D = ::testing::Types<ALU_2D_SIMPLEX_CONFORMING,
                                         ALU_2D_SIMPLEX_NONCONFORMING
-#  if HAVE_DUNE_UGGRID || HAVE_UG
+#if HAVE_DUNE_UGGRID || HAVE_UG
                                         ,
                                         UG_2D
-#  endif
+#endif
                                         >;
 
 using CubeGrids2D = ::testing::Types<YASP_2D_EQUIDISTANT_OFFSET, ALU_2D_CUBE>;
@@ -35,12 +35,12 @@ DUNE_XT_COMMON_TYPENAME(YASP_2D_EQUIDISTANT_OFFSET)
 DUNE_XT_COMMON_TYPENAME(ALU_2D_SIMPLEX_CONFORMING)
 DUNE_XT_COMMON_TYPENAME(ALU_2D_SIMPLEX_NONCONFORMING)
 DUNE_XT_COMMON_TYPENAME(ALU_2D_CUBE)
-#  if HAVE_DUNE_UGGRID || HAVE_UG
+#if HAVE_DUNE_UGGRID || HAVE_UG
 DUNE_XT_COMMON_TYPENAME(UG_2D)
-#  endif
-#  if HAVE_ALBERTA
+#endif
+#if HAVE_ALBERTA
 DUNE_XT_COMMON_TYPENAME(ALBERTA_2D)
-#  endif
+#endif
 
 template <class G>
 using StokesTestSimplex = StokesTestcase1<G>;

--- a/dune/xt/test/grid/walker.cc
+++ b/dune/xt/test/grid/walker.cc
@@ -11,12 +11,7 @@
 
 #include <dune/xt/test/main.hxx>
 
-#if DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) && HAVE_TBB // EXADUNE
-#  include <dune/grid/utility/partitioning/seedlist.hh>
-#endif
-
 #include <dune/xt/common/logstreams.hh>
-#include <dune/xt/common/parallel/partitioner.hh>
 
 #include <dune/xt/grid/gridprovider/cube.hh>
 #include <dune/xt/grid/functors/boundary-detector.hh>
@@ -73,18 +68,6 @@ struct GridWalkerTest : public ::testing::Test
 
     list<function<void()>> element_tests({test1, test2, test3});
     list<function<void()>> intersection_tests({test4, test5});
-#if DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) && HAVE_TBB // EXADUNE
-    // exadune guard for SeedListPartitioning
-    auto test0 = [&] {
-      const auto& set = gv.grid().leafIndexSet();
-      IndexSetPartitioner<GridLayerType> partitioner(set);
-      EXPECT_EQ(set.size(0), partitioner.partitions());
-      Dune::SeedListPartitioning<GridType, 0> partitioning(gv, partitioner);
-      walker.append(counter);
-      walker.walk(partitioning);
-    };
-    tests.push_back(test0);
-#endif // DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) && HAVE_TBB
 
     for (const auto& test : element_tests) {
       count = 0;

--- a/dune/xt/test/la/algorithms_cholesky_extra.cc
+++ b/dune/xt/test/la/algorithms_cholesky_extra.cc
@@ -174,10 +174,8 @@ GTEST_TEST(CholeskyExtraTest, factorizes_sparse_matrices)
   factorizes_correctly<CommonSparseMatrixCsr<double>>(large_dim);
   factorizes_correctly<CommonSparseMatrixCsc<double>>(small_dim);
   factorizes_correctly<CommonSparseMatrixCsc<double>>(large_dim);
-#if HAVE_DUNE_ISTL
   factorizes_correctly<IstlRowMajorSparseMatrix<double>>(small_dim);
   factorizes_correctly<IstlRowMajorSparseMatrix<double>>(large_dim);
-#endif
 }
 
 GTEST_TEST(CholeskyExtraTest, storage_layout_specific_implementations_agree)
@@ -232,10 +230,8 @@ GTEST_TEST(CholeskyExtraTest, throws_on_matrix_which_is_not_positive_definite)
   EXPECT_THROW(cholesky(csr), Dune::MathError);
   auto csc = indefinite_matrix<CommonSparseMatrixCsc<double>>(small_dim);
   EXPECT_THROW(cholesky(csc), Dune::MathError);
-#if HAVE_DUNE_ISTL
   auto istl = indefinite_matrix<IstlRowMajorSparseMatrix<double>>(small_dim);
   EXPECT_THROW(cholesky(istl), Dune::MathError);
-#endif
 }
 
 GTEST_TEST(CholeskyExtraTest, csr_and_csc_factorizations_throw_for_other_storage_layouts)

--- a/dune/xt/test/la/algorithms_solve_sym_tridiag_posdef_extra.cc
+++ b/dune/xt/test/la/algorithms_solve_sym_tridiag_posdef_extra.cc
@@ -86,9 +86,7 @@ GTEST_TEST(SolveSymTridiagPosdefExtraTest, solves_systems_given_by_a_matrix)
   solves_correctly<DynamicMatrix<double>, DynamicVector<double>>(12);
   solves_correctly<FieldMatrix<double, 12, 12>, FieldVector<double, 12>>(12);
   solves_correctly<CommonSparseMatrixCsr<double>, CommonDenseVector<double>>(12);
-#if HAVE_DUNE_ISTL
   solves_correctly<IstlRowMajorSparseMatrix<double>, IstlDenseVector<double>>(12);
-#endif
 }
 
 GTEST_TEST(SolveSymTridiagPosdefExtraTest, solves_systems_given_by_diagonal_and_subdiagonal)

--- a/dune/xt/test/la/algorithms_triangular_solves_extra.cc
+++ b/dune/xt/test/la/algorithms_triangular_solves_extra.cc
@@ -163,9 +163,7 @@ GTEST_TEST(TriangularSolvesExtraTest, solves_sparse_systems)
   solves_correctly<CommonSparseMatrixCsc<double>, CommonDenseVector<double>>(dim);
   solves_correctly<CommonSparseMatrixCsr<double>, CommonSparseVector<double>>(dim);
   solves_correctly<CommonSparseMatrixCsc<double>, CommonSparseVector<double>>(dim);
-#if HAVE_DUNE_ISTL
   solves_correctly<IstlRowMajorSparseMatrix<double>, IstlDenseVector<double>>(dim);
-#endif
 }
 
 // CommonSparseOrDenseMatrix decides on construction whether to store the matrix in a sparse or in a dense format, both
@@ -198,9 +196,7 @@ GTEST_TEST(TriangularSolvesExtraTest, throws_for_singular_matrices)
   throws_for_singular_matrices<DynamicMatrix<double>, DynamicVector<double>>(dim);
   throws_for_singular_matrices<CommonSparseMatrixCsr<double>, CommonDenseVector<double>>(dim);
   throws_for_singular_matrices<CommonSparseMatrixCsc<double>, CommonDenseVector<double>>(dim);
-#if HAVE_DUNE_ISTL
   throws_for_singular_matrices<IstlRowMajorSparseMatrix<double>, IstlDenseVector<double>>(dim);
-#endif
 }
 
 GTEST_TEST(TriangularSolvesExtraTest, throws_for_non_square_matrices)

--- a/dune/xt/test/la/saddlepoint.cc
+++ b/dune/xt/test/la/saddlepoint.cc
@@ -153,8 +153,7 @@ struct SaddlePointTestData
   Vector expected_p_;
 };
 
-#if HAVE_DUNE_ISTL
-#  if HAVE_EIGEN
+#if HAVE_EIGEN
 
 GTEST_TEST(SaddlePointSolver, test_direct_eigen)
 {
@@ -180,5 +179,4 @@ GTEST_TEST(SaddlePointSolver, test_cg_direct_schurcomplement_eigen)
   DXTC_EXPECT_FLOAT_EQ(0., (p - data.expected_p_).l2_norm(), 1e-12, 1e-12);
 }
 
-#  endif // HAVE_EIGEN
-#endif // HAVE_DUNE_ISTL
+#endif // HAVE_EIGEN


### PR DESCRIPTION
## Summary

Part of the guard review spun out of #376 (fixes #385).

1. **`HAVE_DUNE_ISTL` — always 1.** `dune-istl` is a required `DUNE_SUBMODULES` dependency found with `find_package(... CONFIG REQUIRED)`, so `HAVE_DUNE_ISTL` is always true. Removed the seven now-pointless `#if HAVE_DUNE_ISTL` guards (none had an `#else`), keeping the previously-guarded content unconditional, in:
   - `dune/gdt/test/stokes/stokes.cc`
   - `dune/xt/test/la/saddlepoint.cc`
   - `dune/xt/test/la/algorithms_cholesky_extra.cc` (x2)
   - `dune/xt/test/la/algorithms_solve_sym_tridiag_posdef_extra.cc`
   - `dune/xt/test/la/algorithms_triangular_solves_extra.cc` (x2)

2. **`HAVE_TBB` block in `walker.cc` — dead, and removed rather than "fixed".** The `SeedListPartitioning` sub-test was gated on `DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) && HAVE_TBB`. `dune/xt/grid/parallel/partitioning/ranged.hh` uses the identical `DUNE_VERSION_GTE(DUNE_GRID, 3, 9)` predicate deliberately (with a local fallback) to detect the point at which EXADUNE partitioning utilities were merged into dune-grid — so this is not a typo for "2.9", it correctly mirrors that real upstream gate. Since dune-common is pinned to 2.10, the block has always been dead code, and it referenced an undeclared `tests` container (`tests.push_back(test0)`), confirming it has never actually compiled. Removed the block along with its now-unused `seedlist.hh` and `partitioner.hh` includes.

## Test plan
- [ ] CI build/test suite (no dune-istl-related toolchain available locally to compile-check)
- [x] Manually verified `#if`/`#endif` balance in every touched file
- [x] Confirmed no remaining `HAVE_DUNE_ISTL` occurrences in the touched test files
- [x] Confirmed `IndexSetPartitioner`/`SeedListPartitioning`/`seedlist.hh` no longer referenced in `walker.cc`


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqsbUTBCHKS7vLcnHscDxv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded linear algebra test coverage so supported matrix and solver scenarios run consistently across configurations.
  * Improved saddle-point solver testing when Eigen is available.
  * Simplified grid and walker test coverage across optional grid backends.
  * Improved test-suite portability by reducing unnecessary dependency-specific restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->