### PR TITLE
build: make Eigen3 and TBB required, drop their feature guards

### DIFF
--- a/cmake/modules/DuneGdtMacros.cmake
+++ b/cmake/modules/DuneGdtMacros.cmake
@@ -55,15 +55,8 @@ foreach(
   endif()
 endforeach()
 
-find_package(Eigen3 3.4.0)
-
-if(EIGEN3_FOUND)
-  dune_register_package_flags(INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR} COMPILE_DEFINITIONS "ENABLE_EIGEN=1")
-  set(HAVE_EIGEN 1)
-else(EIGEN3_FOUND)
-  dune_register_package_flags(COMPILE_DEFINITIONS "ENABLE_EIGEN=0")
-  set(HAVE_EIGEN 0)
-endif(EIGEN3_FOUND)
+find_package(Eigen3 3.4.0 REQUIRED)
+dune_register_package_flags(INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 
 find_package(MKL)
 

--- a/cmake/modules/DuneTBB.cmake
+++ b/cmake/modules/DuneTBB.cmake
@@ -20,18 +20,12 @@
 # tries to link _debug libraries if cmake build mode matches DEBUG
 # ~~~
 
-find_package(TBB)
+find_package(TBB REQUIRED)
 
 # add all TBB related flags to ALL_PKG_FLAGS, this must happen regardless of a target using add_dune_tbb_flags
-if(TBB_FOUND)
-  set_property(GLOBAL APPEND PROPERTY ALL_PKG_FLAGS "-DENABLE_TBB=1")
-  foreach(dir ${TBB_INCLUDE_DIRS})
-    set_property(GLOBAL APPEND PROPERTY ALL_PKG_FLAGS "-I${dir}")
-  endforeach()
-  set(HAVE_TBB 1)
-else(TBB_FOUND)
-  set(HAVE_TBB 0)
-endif(TBB_FOUND)
+foreach(dir ${TBB_INCLUDE_DIRS})
+  set_property(GLOBAL APPEND PROPERTY ALL_PKG_FLAGS "-I${dir}")
+endforeach()
 
 function(add_dune_tbb_flags targets)
   include_sys_dir("${TBB_INCLUDE_DIRS}")

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -27,20 +27,12 @@
 /* Define to the revision of dune-gdt */
 #define DUNE_GDT_VERSION_REVISION ${DUNE_GDT_GIT_VERSION_REVISION}
 
-#ifndef HAVE_EIGEN
-#define HAVE_EIGEN ENABLE_EIGEN
-#endif
-
 #ifndef HAVE_LAPACKE
 #cmakedefine01 HAVE_LAPACKE
 #endif
 
 #ifndef HAVE_MKL
 #cmakedefine01 HAVE_MKL
-#endif
-
-#ifndef HAVE_TBB
-#cmakedefine01 HAVE_TBB
 #endif
 
 #ifndef DXT_DISABLE_LARGE_TESTS
@@ -139,7 +131,7 @@
 
 #define TBB_PREVIEW_GLOBAL_CONTROL 1
 #include <boost/config.hpp>
-#if HAVE_TBB && defined(BOOST_CLANG)
+#if defined(BOOST_CLANG)
   // Hack to fix compilation with clang as tbb does not detect C++11 feature correctly for clang. Recent versions of TBB
   // allow to set the macro TBB_USE_GLIBCXX_VERSION to the proper version of libstdc++ to fix this issue, see
   // https://www.threadingbuildingblocks.org/docs/help/reference/appendices/known_issues/linux_os.html. For older versions
@@ -162,7 +154,7 @@
     #define __TBB_CPP11_DECLTYPE_PRESENT 1
     #define __TBB_CPP11_LAMBDAS_PRESENT 1
   #endif // TBB_INTERFACE_VERSION < 4400
-#endif // HAVE_TBB
+#endif // BOOST_CLANG
 
 // This is an unfortunate hack, see the header for an explanation.
 #include <dune/xt/common/fix-ambiguous-std-math-overloads.hh>

--- a/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
+++ b/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
@@ -25,7 +25,7 @@
 
 #include "interface.hh"
 
-#if HAVE_TBB && __has_include(<tbb/tbb_exception.h>)
+#if __has_include(<tbb/tbb_exception.h>)
 #  include <tbb/tbb_exception.h>
 #endif
 
@@ -316,7 +316,7 @@ public:
           skip_error_computation = true;
           time_step_scale_factor = 0.5;
           break;
-#if HAVE_TBB && __has_include(<tbb/tbb_exception.h>)
+#if __has_include(<tbb/tbb_exception.h>)
         } catch (const tbb::captured_exception&) {
           mixed_error = 1e10;
           skip_error_computation = true;

--- a/dune/xt/common/exceptions.cc
+++ b/dune/xt/common/exceptions.cc
@@ -13,7 +13,7 @@
 
 #include <iostream>
 
-#if HAVE_TBB && __has_include(<tbb/tbb_exception.h>)
+#if __has_include(<tbb/tbb_exception.h>)
 #  include <tbb/tbb_exception.h>
 #endif
 

--- a/dune/xt/common/parallel/threadmanager.cc
+++ b/dune/xt/common/parallel/threadmanager.cc
@@ -14,18 +14,14 @@
 #include <atomic>
 #include <thread>
 
-#if HAVE_TBB
-#  include <tbb/concurrent_unordered_map.h>
-#endif
+#include <tbb/concurrent_unordered_map.h>
 
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/config.hpp>
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/Core>
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/Core>
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/common/exceptions.hh>
 
@@ -33,8 +29,6 @@
 
 #include "threadmanager.hh"
 
-
-#if HAVE_TBB
 
 struct ThreadIdHashCompare
 {
@@ -70,11 +64,11 @@ size_t Dune::XT::Common::ThreadManager::current_threads()
 template <typename Key, typename T, typename MapType>
 std::pair<typename MapType::iterator, bool> tbb_map_emplace(MapType& map_in, Key key, T value)
 {
-#  if defined(BOOST_CLANG) && BOOST_CLANG
+#if defined(BOOST_CLANG) && BOOST_CLANG
   return map_in.insert(typename MapType::value_type(key, value));
-#  else
+#else
   return map_in.emplace(key, value);
-#  endif
+#endif
 }
 
 size_t Dune::XT::Common::ThreadManager::thread()
@@ -91,62 +85,23 @@ size_t Dune::XT::Common::ThreadManager::thread()
 //! both std::hw_concur and intel's default_thread_count fail for mic
 size_t Dune::XT::Common::ThreadManager::default_max_threads()
 {
-#  ifndef __MIC__
+#ifndef __MIC__
   return std::thread::hardware_concurrency();
-#  else
+#else
   return DS_MAX_MIC_THREADS;
-#  endif
+#endif
 }
 
 void Dune::XT::Common::ThreadManager::set_max_threads(const size_t count)
 {
   DXTC_CONFIG.set("threading.max_count", count, true);
   max_threads_ = count;
-#  if HAVE_EIGEN
   Eigen::setNbThreads(boost::numeric_cast<int>(count));
-#  endif
 }
 
 Dune::XT::Common::ThreadManager::ThreadManager()
   : max_threads_(default_max_threads())
 {
-#  if HAVE_EIGEN
   Eigen::initParallel();
   Eigen::setNbThreads(1);
-#  endif
 }
-
-#else // if HAVE_TBB
-
-size_t Dune::XT::Common::ThreadManager::max_threads()
-{
-  return max_threads_;
-}
-
-size_t Dune::XT::Common::ThreadManager::current_threads()
-{
-  return 1;
-}
-
-size_t Dune::XT::Common::ThreadManager::thread()
-{
-  return 0;
-}
-
-void Dune::XT::Common::ThreadManager::set_max_threads(const size_t count)
-{
-  if (count > 1)
-    DUNE_THROW(InvalidStateException, "Trying to use more than one thread w/o TBB");
-}
-
-size_t Dune::XT::Common::ThreadManager::default_max_threads()
-{
-  return 1;
-}
-
-Dune::XT::Common::ThreadManager::ThreadManager()
-  : max_threads_(1)
-{
-}
-
-#endif // HAVE_TBB

--- a/dune/xt/common/parallel/threadstorage.hh
+++ b/dune/xt/common/parallel/threadstorage.hh
@@ -15,9 +15,7 @@
 #ifndef DUNE_XT_COMMON_PARALLEL_THREADSTORAGE_HH
 #define DUNE_XT_COMMON_PARALLEL_THREADSTORAGE_HH
 
-#if HAVE_TBB
-#  include <tbb/enumerable_thread_specific.h>
-#endif
+#include <tbb/enumerable_thread_specific.h>
 
 #include <algorithm>
 #include <list>
@@ -38,8 +36,6 @@
 namespace Dune::XT::Common {
 namespace internal {
 
-
-#if HAVE_TBB
 
 template <class ValueImp>
 class EnumerableThreadSpecificWrapper
@@ -100,74 +96,6 @@ public:
 private:
   mutable BackendType values_;
 }; // class EnumerableThreadSpecificWrapper<ValueImp>
-
-#else // HAVE_TBB
-
-template <class ValueImp>
-class EnumerableThreadSpecificWrapper
-{
-  using BackendType = std::unique_ptr<std::remove_const_t<ValueImp>>;
-
-public:
-  using ValueType = ValueImp;
-  using ConstValueType = std::add_const_t<ValueType>;
-  using iterator = ValueType*;
-  using const_iterator = const ValueType*;
-
-  //! Initialization by copy construction of ValueType
-  explicit EnumerableThreadSpecificWrapper(ConstValueType& value)
-    : values_(std::make_unique<std::remove_const_t<ValueType>>(value))
-  {
-  }
-
-  //! Initialization by in-place construction ValueType with \param ctor_args
-  template <class... InitTypes, typename = require_not_self_t<EnumerableThreadSpecificWrapper, InitTypes...>>
-  explicit EnumerableThreadSpecificWrapper(InitTypes&&... ctor_args)
-    : values_(std::make_unique<std::remove_const_t<ValueType>>(std::forward<InitTypes>(ctor_args)...))
-  {
-  }
-
-  ValueType& local()
-  {
-    return *values_;
-  }
-
-  const ValueType& local() const
-  {
-    return *values_;
-  }
-
-  iterator begin()
-  {
-    return values_.get();
-  }
-
-  iterator end()
-  {
-    return values_.get() + 1;
-  }
-
-  const_iterator begin() const
-  {
-    return values_.get();
-  }
-
-  const_iterator end() const
-  {
-    return values_.get() + 1;
-  }
-
-  template <class BinaryOperation>
-  ValueType combine(BinaryOperation /*op*/) const
-  {
-    return *values_;
-  }
-
-private:
-  BackendType values_;
-}; // class EnumerableThreadSpecificWrapper<ValueImp>
-
-#endif // HAVE_TBB
 
 
 } // namespace internal

--- a/dune/xt/functions/ESV2007.hh
+++ b/dune/xt/functions/ESV2007.hh
@@ -20,11 +20,9 @@
 
 #include <dune/geometry/quadraturerules.hh>
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/Eigenvalues>
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/Eigenvalues>
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/xt/common/configuration.hh>
 #include <dune/xt/la/eigen-solver.hh>

--- a/dune/xt/grid/parallel/partitioning/ranged-internal.hh
+++ b/dune/xt/grid/parallel/partitioning/ranged-internal.hh
@@ -26,13 +26,11 @@
 #include <iterator>
 #include <vector>
 
-#if HAVE_TBB
 // The new TBB oneAPI does not have this file anymore
 #if __has_include(<tbb/tbb_stddef.h>)
 #  include <tbb/tbb_stddef.h>
-#  else
+#else
 #  include <tbb/blocked_range.h>
-#  endif
 #endif
 
 #include <dune/xt/grid/type_traits.hh>
@@ -139,7 +137,6 @@ namespace Dune::XT::Grid {
                   : 0);
       }
 
-#if HAVE_TBB
       //! Splitting Constructor
       /**
        * Construct second half of set, update \c other to represent first half.
@@ -167,7 +164,6 @@ namespace Dune::XT::Grid {
       {
         return lastPartition_ - firstPartition_ > 1;
       }
-#endif // HAVE_TBB
 
     private:
       const RangedPartitioning &partitioning_;

--- a/dune/xt/grid/walker.hh
+++ b/dune/xt/grid/walker.hh
@@ -20,17 +20,13 @@
 #include <type_traits>
 #include <vector>
 
-#if HAVE_TBB
-#  include <tbb/blocked_range.h>
-#  include <tbb/parallel_for.h>
-#endif
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
 
 #include <dune/common/version.hh>
 
 #include <dune/grid/common/rangegenerators.hh>
-#if HAVE_TBB
-#  include <dune/xt/grid/parallel/partitioning/ranged.hh>
-#endif
+#include <dune/xt/grid/parallel/partitioning/ranged.hh>
 
 #include <dune/xt/common/memory.hh>
 #include <dune/xt/common/parallel/threadmanager.hh>
@@ -591,7 +587,6 @@ public:
 
   void walk([[maybe_unused]] const bool use_tbb = false, const bool clear_functors = true)
   {
-#if HAVE_TBB
     if (use_tbb) {
       const auto num_partitions =
           DXTC_CONFIG_GET("threading.partition_factor", 1u) * XT::Common::threadManager().current_threads();
@@ -599,7 +594,6 @@ public:
       this->walk(partitioning, clear_functors);
       return;
     }
-#endif
     // prepare functors
     prepare();
 
@@ -631,7 +625,6 @@ public:
   }
 
 
-#if HAVE_TBB
 protected:
   template <class PartioningType, class WalkerType>
   struct Body
@@ -683,27 +676,6 @@ public:
     if (clear_functors)
       clear();
   } // ... tbb_walk(...)
-#else
-public:
-  template <class PartioningType>
-  void walk(PartioningType& partitioning)
-  {
-    // prepare functors
-    prepare();
-
-    // only do something, if we have to
-    if ((element_functor_wrappers_->size() + intersection_functor_wrappers_->size()
-         + element_and_intersection_functor_wrappers_->size())
-        > 0) {
-      // no actual SMP walk, use range as is
-      walk_range(partitioning.everything());
-    }
-
-    // finalize functors
-    finalize();
-    clear();
-  } // ... tbb_walk(...)
-#endif // HAVE_TBB
 
   template <class ElementRange>
   void walk_range(const ElementRange& element_range)

--- a/dune/xt/grid/walker.hh
+++ b/dune/xt/grid/walker.hh
@@ -585,7 +585,7 @@ public:
    * \}
    */
 
-  void walk([[maybe_unused]] const bool use_tbb = false, const bool clear_functors = true)
+  void walk(const bool use_tbb = false, const bool clear_functors = true)
   {
     if (use_tbb) {
       const auto num_partitions =

--- a/dune/xt/la/container.hh
+++ b/dune/xt/la/container.hh
@@ -79,34 +79,18 @@ struct Container<ScalarType, Backends::istl_sparse>
 
 /// \brief Tuple of all available vector container types (depending on enabled backends).
 template <class S>
-using AvailableVectorTypes = std::tuple<CommonDenseVector<S>,
-                                        IstlDenseVector<S>
-#if HAVE_EIGEN
-                                        ,
-                                        EigenDenseVector<S>
-#endif
-                                        >;
+using AvailableVectorTypes = std::tuple<CommonDenseVector<S>, IstlDenseVector<S>, EigenDenseVector<S>>;
 
 
 /// \brief Tuple of all available dense matrix container types (depending on enabled backends).
 template <class S>
-using AvailableDenseMatrixTypes = std::tuple<CommonDenseMatrix<S>
-#if HAVE_EIGEN
-                                             ,
-                                             EigenDenseMatrix<S>
-#endif
-                                             >;
+using AvailableDenseMatrixTypes = std::tuple<CommonDenseMatrix<S>, EigenDenseMatrix<S>>;
 
 
 /// \brief Tuple of all available sparse matrix container types (depending on enabled backends).
 template <class S>
-using AvailableSparseMatrixTypes = std::tuple<CommonSparseMatrix<S>,
-                                              IstlRowMajorSparseMatrix<S>
-#if HAVE_EIGEN
-                                              ,
-                                              EigenRowMajorSparseMatrix<S>
-#endif
-                                              >;
+using AvailableSparseMatrixTypes =
+    std::tuple<CommonSparseMatrix<S>, IstlRowMajorSparseMatrix<S>, EigenRowMajorSparseMatrix<S>>;
 
 
 } // namespace Dune::XT::LA

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -24,11 +24,9 @@
 
 #include "config.h"
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/Core>
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/Core>
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/common/typetraits.hh>
 #include <dune/common/ftraits.hh>
@@ -47,8 +45,6 @@ class EigenDenseMatrix;
 
 template <class ScalarType>
 class EigenRowMajorSparseMatrix;
-
-#if HAVE_EIGEN
 
 
 /**
@@ -296,10 +292,10 @@ public:
   using InterfaceType::as_imp;
 
 private:
-#  ifndef NDEBUG
+#ifndef NDEBUG
   //! disambiguation necessary since it exists in multiple bases
   using InterfaceType::crtp_mutex_;
-#  endif
+#endif
 
   friend class VectorInterface<Traits, ScalarType>;
   friend class EigenDenseMatrix<ScalarType>;
@@ -309,16 +305,6 @@ protected:
   std::shared_ptr<BackendType> backend_;
   std::unique_ptr<MutexesType> mutexes_;
 }; // class EigenBaseVector
-
-#else // HAVE_EIGEN
-
-template <class Traits, class ScalarImp>
-class EigenBaseVector
-{
-  static_assert(Dune::AlwaysFalse<ScalarImp>::value, "You are missing Eigen!");
-};
-
-#endif // HAVE_EIGEN
 
 } // namespace Dune::XT::LA
 

--- a/dune/xt/la/container/eigen/dense.cc
+++ b/dune/xt/la/container/eigen/dense.cc
@@ -11,9 +11,7 @@
 
 #include <config.h>
 
-#if HAVE_EIGEN
-
-#  include "dense.hh"
+#include "dense.hh"
 
 
 template class Dune::XT::LA::EigenDenseVector<double>;
@@ -27,6 +25,3 @@ template class Dune::XT::LA::EigenDenseMatrix<double>;
 //                                                         Dune::XT::LA::EigenMappedDenseVector<double>&) const;
 // template void Dune::XT::LA::EigenDenseMatrix<double>::mv(const Dune::XT::LA::EigenMappedDenseVector<double>&,
 //                                                         Dune::XT::LA::EigenDenseVector<double>&) const;
-
-
-#endif // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -27,11 +27,9 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/Core>
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/Core>
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/common/typetraits.hh>
 #include <dune/common/densematrix.hh>
@@ -60,8 +58,6 @@ class EigenMappedDenseVector;
 template <class ScalarImp>
 class EigenDenseMatrix;
 
-
-#if HAVE_EIGEN
 
 namespace internal {
 
@@ -729,32 +725,8 @@ private:
 }; // class EigenDenseMatrix
 
 
-#else // HAVE_EIGEN
-
-template <class ScalarImp>
-class EigenDenseVector
-{
-  static_assert(Dune::AlwaysFalse<ScalarImp>::value, "You are missing Eigen!");
-};
-
-template <class ScalarImp>
-class EigenMappedDenseVector
-{
-  static_assert(Dune::AlwaysFalse<ScalarImp>::value, "You are missing Eigen!");
-};
-
-template <class ScalarImp>
-class EigenDenseMatrix
-{
-  static_assert(Dune::AlwaysFalse<ScalarImp>::value, "You are missing Eigen!");
-};
-
-#endif // HAVE_EIGEN
-
 } // namespace LA
 namespace Common {
-
-#if HAVE_EIGEN
 
 template <class T>
 struct VectorAbstraction<LA::EigenDenseVector<T>> : public LA::internal::VectorAbstractionBase<LA::EigenDenseVector<T>>
@@ -786,14 +758,12 @@ struct MatrixAbstraction<LA::EigenDenseMatrix<T>> : public LA::internal::MatrixA
   }
 };
 
-#endif // HAVE_EIGEN
-
 } // namespace Common
 } // namespace Dune::XT
 
 
 // begin: this is what we need for the lib
-#if DUNE_XT_WITH_PYTHON_BINDINGS && HAVE_EIGEN
+#if DUNE_XT_WITH_PYTHON_BINDINGS
 
 
 extern template class Dune::XT::LA::EigenDenseVector<double>;
@@ -809,7 +779,7 @@ extern template class Dune::XT::LA::EigenDenseMatrix<double>;
 //                                                                Dune::XT::LA::EigenDenseVector<double>&) const;
 
 
-#endif // DUNE_XT_WITH_PYTHON_BINDINGS && HAVE_EIGEN
+#endif // DUNE_XT_WITH_PYTHON_BINDINGS
 // end: this is what we need for the lib
 
 

--- a/dune/xt/la/container/eigen/sparse.cc
+++ b/dune/xt/la/container/eigen/sparse.cc
@@ -11,9 +11,7 @@
 
 #include <config.h>
 
-#if HAVE_EIGEN
-
-#  include "sparse.hh"
+#include "sparse.hh"
 
 
 template class Dune::XT::LA::EigenRowMajorSparseMatrix<double>;
@@ -29,6 +27,3 @@ template class Dune::XT::LA::EigenRowMajorSparseMatrix<double>;
 // template void Dune::XT::LA::EigenRowMajorSparseMatrix<double>::mv(const
 // Dune::XT::LA::EigenMappedDenseVector<double>&,
 //                                                                  Dune::XT::LA::EigenDenseVector<double>&) const;
-
-
-#endif // HAVE_EIGEN

--- a/dune/xt/la/container/eigen/sparse.hh
+++ b/dune/xt/la/container/eigen/sparse.hh
@@ -25,11 +25,9 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/SparseCore>
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/SparseCore>
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/common/typetraits.hh>
 #include <dune/common/ftraits.hh>
@@ -57,8 +55,6 @@ class EigenRowMajorSparseMatrix;
 class EigenMatrixInterfaceDynamic
 {};
 
-
-#if HAVE_EIGEN
 
 namespace internal {
 
@@ -123,12 +119,12 @@ public:
         backend_->startVec(static_cast<EIGEN_size_t>(row));
         const auto& columns = pattern_in.inner(row);
         for (const auto& column : columns) {
-#  ifndef NDEBUG
+#ifndef NDEBUG
           if (column >= cc)
             DUNE_THROW(Common::Exceptions::shapes_do_not_match,
                        "The size of row " << row << " of the pattern does not match the number of columns of this ("
                                           << cc << ")!");
-#  endif // NDEBUG
+#endif // NDEBUG
           backend_->insertBackByOuterInner(static_cast<EIGEN_size_t>(row), static_cast<EIGEN_size_t>(column));
         }
         // create entry (insertBackByOuterInner() can not handle empty rows)
@@ -543,22 +539,9 @@ private:
 }; // class EigenRowMajorSparseMatrix
 
 
-#else // HAVE_EIGEN
-
-template <class ScalarImp>
-class EigenRowMajorSparseMatrix
-{
-  static_assert(AlwaysFalse<ScalarImp>::value, "You are missing Eigen!");
-};
-
-#endif // HAVE_EIGEN
-
-
 } // namespace LA
 namespace Common {
 
-
-#if HAVE_EIGEN
 
 template <class T>
 struct MatrixAbstraction<LA::EigenRowMajorSparseMatrix<T>>
@@ -572,14 +555,12 @@ struct MatrixAbstraction<LA::EigenRowMajorSparseMatrix<T>>
   using MatrixTypeTemplate = LA::EigenRowMajorSparseMatrix<FieldType>;
 };
 
-#endif // HAVE_EIGEN
-
 } // namespace Common
 } // namespace Dune::XT
 
 
 // begin: this is what we need for the lib
-#if DUNE_XT_WITH_PYTHON_BINDINGS && HAVE_EIGEN
+#if DUNE_XT_WITH_PYTHON_BINDINGS
 
 
 extern template class Dune::XT::LA::EigenRowMajorSparseMatrix<double>;
@@ -598,7 +579,7 @@ extern template class Dune::XT::LA::EigenRowMajorSparseMatrix<double>;
 //                                                    Dune::XT::LA::EigenDenseVector<double>&) const;
 
 
-#endif // DUNE_XT_WITH_PYTHON_BINDINGS && HAVE_EIGEN
+#endif // DUNE_XT_WITH_PYTHON_BINDINGS
 // end: this is what we need for the lib
 
 

--- a/dune/xt/la/eigen-solver/eigen.hh
+++ b/dune/xt/la/eigen-solver/eigen.hh
@@ -30,9 +30,6 @@
 
 namespace Dune::XT::LA {
 
-#if HAVE_EIGEN
-
-
 /// \brief Available types and default options for the EigenDenseMatrix eigensolver (eigen, lapack, shifted_qr).
 template <class S>
 class EigenSolverOptions<EigenDenseMatrix<S>, true>
@@ -99,7 +96,7 @@ protected:
       else if (compute_eigenvectors)
         eigenvectors_ = std::make_unique<EigenDenseMatrix<XT::Common::complex_t<S>>>(
             internal::compute_right_eigenvectors_using_eigen(matrix_.backend()));
-#  if HAVE_LAPACKE || HAVE_MKL
+#if HAVE_LAPACKE || HAVE_MKL
     } else if (type == "lapack") {
       if (!compute_eigenvectors)
         eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<RealType>>>(
@@ -109,7 +106,7 @@ protected:
         eigenvectors_ = std::make_unique<EigenDenseMatrix<XT::Common::complex_t<S>>>(N, N);
         internal::compute_eigenvalues_and_right_eigenvectors_using_lapack(matrix_, *eigenvalues_, *eigenvectors_);
       }
-#  endif // HAVE_LAPACKE || HAVE_MKL
+#endif // HAVE_LAPACKE || HAVE_MKL
     } else if (type == "shifted_qr") {
       if (!compute_eigenvectors) {
         eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<RealType>>>(N);
@@ -144,26 +141,6 @@ protected:
   using BaseType::matrix_;
   using BaseType::options_;
 }; // class EigenSolver<EigenDenseMatrix<...>>
-
-
-#else // HAVE_EIGEN
-
-
-template <class S>
-class EigenSolverOptions<EigenDenseMatrix<S>, true>
-{
-  static_assert(AlwaysFalse<S>::value, "You are missing eigen!");
-};
-
-
-template <class S>
-class EigenSolver<EigenDenseMatrix<S>, true>
-{
-  static_assert(AlwaysFalse<S>::value, "You are missing eigen!");
-};
-
-
-#endif // HAVE_EIGEN
 
 
 } // namespace Dune::XT::LA

--- a/dune/xt/la/eigen-solver/fmatrix.hh
+++ b/dune/xt/la/eigen-solver/fmatrix.hh
@@ -51,9 +51,7 @@ public:
     std::vector<std::string> tps;
     if (Common::Lapacke::available())
       tps.emplace_back("lapack");
-#if HAVE_EIGEN
     tps.emplace_back("eigen");
-#endif
     if (internal::numpy_eigensolver_available())
       tps.emplace_back("numpy");
     tps.emplace_back("shifted_qr");
@@ -133,30 +131,28 @@ protected:
       }
     } else
 #endif // HAVE_LAPACKE || HAVE_MKL
-#if HAVE_EIGEN
-        if (type == "eigen") {
-      if (options_->template get<bool>("compute_eigenvalues") && options_->template get<bool>("compute_eigenvectors")) {
-        eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<K>>>(SIZE);
-        EigenDenseMatrix<K> tmp_matrix(matrix_);
-        EigenDenseMatrix<Common::complex_t<K>> tmp_eigenvectors(matrix_);
-        internal::compute_eigenvalues_and_right_eigenvectors_using_eigen(
-            tmp_matrix.backend(), *eigenvalues_, tmp_eigenvectors.backend());
-        eigenvectors_ = std::make_unique<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>(
-            convert_to<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>(tmp_eigenvectors));
-      } else {
-        if (options_->template get<bool>("compute_eigenvalues"))
-          eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<K>>>(
-              internal::compute_eigenvalues_using_eigen(EigenDenseMatrix<K>(matrix_).backend()));
-        if (options_->template get<bool>("compute_eigenvectors")) {
+      if (type == "eigen") {
+        if (options_->template get<bool>("compute_eigenvalues")
+            && options_->template get<bool>("compute_eigenvectors")) {
+          eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<K>>>(SIZE);
+          EigenDenseMatrix<K> tmp_matrix(matrix_);
+          EigenDenseMatrix<Common::complex_t<K>> tmp_eigenvectors(matrix_);
+          internal::compute_eigenvalues_and_right_eigenvectors_using_eigen(
+              tmp_matrix.backend(), *eigenvalues_, tmp_eigenvectors.backend());
           eigenvectors_ = std::make_unique<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>(
-              convert_to<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>(
-                  EigenDenseMatrix<XT::Common::complex_t<K>>(
-                      internal::compute_right_eigenvectors_using_eigen(EigenDenseMatrix<K>(matrix_).backend()))));
+              convert_to<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>(tmp_eigenvectors));
+        } else {
+          if (options_->template get<bool>("compute_eigenvalues"))
+            eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<K>>>(
+                internal::compute_eigenvalues_using_eigen(EigenDenseMatrix<K>(matrix_).backend()));
+          if (options_->template get<bool>("compute_eigenvectors")) {
+            eigenvectors_ = std::make_unique<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>(
+                convert_to<Dune::FieldMatrix<XT::Common::complex_t<K>, SIZE, SIZE>>(
+                    EigenDenseMatrix<XT::Common::complex_t<K>>(
+                        internal::compute_right_eigenvectors_using_eigen(EigenDenseMatrix<K>(matrix_).backend()))));
+          }
         }
-      }
-    } else
-#endif // HAVE_EIGEN
-      if (type == "numpy") {
+      } else if (type == "numpy") {
         if (options_->template get<bool>("compute_eigenvalues")
             || options_->template get<bool>("compute_eigenvectors")) {
           eigenvalues_ = std::make_unique<std::vector<XT::Common::complex_t<K>>>(SIZE);

--- a/dune/xt/la/eigen-solver/internal/eigen.hh
+++ b/dune/xt/la/eigen-solver/internal/eigen.hh
@@ -17,12 +17,10 @@
 
 #include <vector>
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/Core>
-#  include <Eigen/Eigenvalues>
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/common/typetraits.hh>
 
@@ -31,9 +29,6 @@
 
 
 namespace Dune::XT::LA::internal {
-
-
-#if HAVE_EIGEN
 
 
 template <class S>
@@ -83,38 +78,6 @@ compute_right_eigenvectors_using_eigen(const ::Eigen::Matrix<S, ::Eigen::Dynamic
   return eigen_solver.eigenvectors();
 } // ... compute_right_eigenvectors_using_eigen(...)
 
-
-#else // HAVE_EIGEN
-
-
-template <class S, class MatrixType, class ComplexMatrixType>
-void compute_eigenvalues_and_right_eigenvectors_using_eigen(
-    const MatrixType& /*::Eigen::Matrix<S, ::Eigen::Dynamic, ::Eigen::Dynamic>& matrix*/,
-    std::vector<XT::Common::complex_t<S>>& /*eigenvalues*/,
-    ComplexMatrixType& /*::Eigen::Matrix<XT::Common::complex_t<S>, ::Eigen::Dynamic, ::Eigen::Dynamic>& eigenvectors*/)
-{
-  static_assert(AlwaysFalse<S>::value, "You are missing eigen!");
-}
-
-
-template <class S, class MatrixType>
-std::vector<XT::Common::complex_t<S>>
-compute_eigenvalues_using_eigen(const MatrixType& /*::Eigen::Matrix<S, ::Eigen::Dynamic, ::Eigen::Dynamic>& matrix*/)
-{
-  static_assert(AlwaysFalse<S>::value, "You are missing eigen!");
-}
-
-
-template <class S, class MatrixType, class ComplexMatrixType>
-ComplexMatrixType /*::Eigen::Matrix<XT::Common::complex_t<S>, ::Eigen::Dynamic, ::Eigen::Dynamic>*/
-compute_right_eigenvectors_using_eigen(
-    const MatrixType& /*::Eigen::Matrix<S, ::Eigen::Dynamic, ::Eigen::Dynamic>& matrix*/)
-{
-  static_assert(AlwaysFalse<S>::value, "You are missing eigen!");
-}
-
-
-#endif // HAVE_EIGEN
 
 } // namespace Dune::XT::LA::internal
 

--- a/dune/xt/la/matrix-inverter/eigen.hh
+++ b/dune/xt/la/matrix-inverter/eigen.hh
@@ -26,9 +26,6 @@
 
 namespace Dune::XT::LA {
 
-#if HAVE_EIGEN
-
-
 /// \brief Matrix-inverter options for an EigenDenseMatrix.
 template <class S>
 class MatrixInverterOptions<EigenDenseMatrix<S>, true>
@@ -99,27 +96,6 @@ protected:
   using BaseType::options_;
 }; // class MatrixInverter<EigenDenseMatrix<...>>
 
-
-#else // HAVE_EIGEN
-
-
-/// \brief Matrix-inverter options for an EigenDenseMatrix (unavailable without Eigen).
-template <class S>
-class MatrixInverterOptions<EigenDenseMatrix<S>, true>
-{
-  static_assert(AlwaysFalse<S>::value, "You are missing eigen!");
-};
-
-
-/// \brief Matrix-inverter for an EigenDenseMatrix (unavailable without Eigen).
-template <class S>
-class MatrixInverter<EigenDenseMatrix<S>, true>
-{
-  static_assert(AlwaysFalse<S>::value, "You are missing eigen!");
-};
-
-
-#endif // HAVE_EIGEN
 
 } // namespace Dune::XT::LA
 

--- a/dune/xt/la/matrix-inverter/fmatrix.hh
+++ b/dune/xt/la/matrix-inverter/fmatrix.hh
@@ -38,12 +38,7 @@ class MatrixInverterOptions<FieldMatrix<K, ROWS, COLS>, true>
 public:
   static std::vector<std::string> types()
   {
-    return {"direct"
-#if HAVE_EIGEN
-            ,
-            "moore_penrose"
-#endif
-    };
+    return {"direct", "moore_penrose"};
   }
 
   static Common::Configuration options(const std::string& type = "")
@@ -97,14 +92,10 @@ public:
                          << ee.what());
         DUNE_THROW(Exceptions::matrix_invert_failed, "This was the original error:\n\n" << ee.what());
       }
-    }
-#if HAVE_EIGEN
-    else if (type == "moore_penrose") {
+    } else if (type == "moore_penrose") {
       inverse_ = std::make_unique<MatrixType>(convert_to<MatrixType>(EigenDenseMatrix<K>(
           internal::compute_moore_penrose_inverse_using_eigen(convert_to<EigenDenseMatrix<K>>(matrix_).backend()))));
-    }
-#endif
-    else
+    } else
       DUNE_THROW(Common::Exceptions::internal_error,
                  "Given type '" << type
                                 << "' is none of MatrixInverterOptions<FieldMatrix<K, ROWS, COLS>>::types(), and "

--- a/dune/xt/la/matrix-inverter/internal/eigen.hh
+++ b/dune/xt/la/matrix-inverter/internal/eigen.hh
@@ -17,20 +17,16 @@
 
 #include <limits>
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/Core>
-#  include <Eigen/SVD>
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/Core>
+#include <Eigen/SVD>
 // needed for the inverse method of Eigen::Matrix, see http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1089
-#  include <Eigen/LU>
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif
+#include <Eigen/LU>
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/common/typetraits.hh>
 
 namespace Dune::XT::LA::internal {
-
-#if HAVE_EIGEN
 
 
 /**
@@ -55,20 +51,6 @@ compute_moore_penrose_inverse_using_eigen(const ::Eigen::Matrix<S, ::Eigen::Dyna
          * svd.matrixU().adjoint();
 }
 
-
-#else // HAVE_EIGEN
-
-
-template <class M>
-M compute_moore_penrose_inverse_using_eigen(const M& matrix,
-                                            const double& /*epsilon*/ = std::numeric_limits<double>::epsilon())
-{
-  static_assert(AlwaysFalse<M>::value, "You are missing eigen!");
-  return matrix;
-}
-
-
-#endif // HAVE_EIGEN
 
 } // namespace Dune::XT::LA::internal
 

--- a/dune/xt/la/solver/eigen.cc
+++ b/dune/xt/la/solver/eigen.cc
@@ -11,9 +11,7 @@
 
 #include <config.h>
 
-#if HAVE_EIGEN
-
-#  include "eigen.hh"
+#include "eigen.hh"
 
 
 template class Dune::XT::LA::Solver<Dune::XT::LA::EigenDenseMatrix<double>>;
@@ -36,6 +34,3 @@ template class Dune::XT::LA::Solver<Dune::XT::LA::EigenRowMajorSparseMatrix<doub
 //    const Dune::XT::LA::EigenDenseVector<double>&,
 //    Dune::XT::LA::EigenDenseVector<double>&,
 //    const Dune::XT::Common::Configuration&) const;
-
-
-#endif // HAVE_EIGEN

--- a/dune/xt/la/solver/eigen.hh
+++ b/dune/xt/la/solver/eigen.hh
@@ -23,24 +23,22 @@
 #include <cmath>
 #include <complex>
 
-#if HAVE_EIGEN
-#  include <dune/xt/common/disable_warnings.hh>
-#  include <Eigen/Dense>
-#  include <Eigen/SparseCore>
-#  include <Eigen/IterativeLinearSolvers>
-#  include <Eigen/SparseCholesky>
-#  include <Eigen/SparseLU>
-#  include <Eigen/SparseQR>
-// #   if HAVE_UMFPACK
-// #     include <Eigen/UmfPackSupport>
-// #   endif
-// #   include <Eigen/SPQRSupport>
-// #   include <Eigen/CholmodSupport>
-// #   if HAVE_SUPERLU
-// #     include <Eigen/SuperLUSupport>
-// #   endif
-#  include <dune/xt/common/reenable_warnings.hh>
-#endif // HAVE_EIGEN
+#include <dune/xt/common/disable_warnings.hh>
+#include <Eigen/Dense>
+#include <Eigen/SparseCore>
+#include <Eigen/IterativeLinearSolvers>
+#include <Eigen/SparseCholesky>
+#include <Eigen/SparseLU>
+#include <Eigen/SparseQR>
+// #if HAVE_UMFPACK
+// #  include <Eigen/UmfPackSupport>
+// #endif
+// #include <Eigen/SPQRSupport>
+// #include <Eigen/CholmodSupport>
+// #if HAVE_SUPERLU
+// #  include <Eigen/SuperLUSupport>
+// #endif
+#include <dune/xt/common/reenable_warnings.hh>
 
 #include <dune/xt/common/exceptions.hh>
 #include <dune/xt/common/configuration.hh>
@@ -49,8 +47,6 @@
 #include "../solver.hh"
 
 namespace Dune::XT::LA {
-
-#if HAVE_EIGEN
 
 /// \brief Available solver options for EigenDenseMatrix (direct LU, QR and Cholesky factorizations).
 template <class S, class CommunicatorType>
@@ -211,8 +207,7 @@ public:
         const S val = solution.get_entry(ii);
         if (Common::isnan(val) || Common::isinf(val)) {
           std::stringstream msg;
-          msg << "The computed solution contains inf or nan and you requested checking (see options "
-              << "below)!\n"
+          msg << "The computed solution contains inf or nan and you requested checking (see options " << "below)!\n"
               << "If you want to disable this check, set 'check_for_inf_nan = 0' in the options.\n\n"
               << "Those were the given options:\n\n"
               << opts;
@@ -234,8 +229,7 @@ public:
         std::stringstream msg;
         msg << "The computed solution does not solve the system (although the eigen backend reported "
             << "'Success') and you requested checking (see options below)!\n"
-            << "If you want to disable this check, set 'post_check_solves_system = 0' in the options."
-            << "\n\n"
+            << "If you want to disable this check, set 'post_check_solves_system = 0' in the options." << "\n\n"
             << "  (A * x - b).sup_norm() = " << tmp.sup_norm() << "\n\n"
             << "Those were the given options:\n\n"
             << opts;
@@ -629,27 +623,11 @@ private:
 }; // class Solver
 
 
-#else // HAVE_EIGEN
-
-template <class S>
-class Solver<EigenDenseMatrix<S>>
-{
-  static_assert(Dune::AlwaysFalse<S>::value, "You are missing Eigen!");
-};
-
-template <class S>
-class Solver<EigenRowMajorSparseMatrix<S>>
-{
-  static_assert(Dune::AlwaysFalse<S>::value, "You are missing Eigen!");
-};
-
-#endif // HAVE_EIGEN
-
 } // namespace Dune::XT::LA
 
 
 // begin: this is what we need for the lib
-#if DUNE_XT_WITH_PYTHON_BINDINGS && HAVE_EIGEN
+#if DUNE_XT_WITH_PYTHON_BINDINGS
 
 extern template class Dune::XT::LA::Solver<Dune::XT::LA::EigenDenseMatrix<double>>;
 // extern template void
@@ -672,7 +650,7 @@ extern template class Dune::XT::LA::Solver<Dune::XT::LA::EigenRowMajorSparseMatr
 //    Dune::XT::LA::EigenDenseVector<double>&,
 //    const Dune::XT::Common::Configuration&) const;
 
-#endif // DUNE_XT_WITH_PYTHON_BINDINGS && HAVE_EIGEN
+#endif // DUNE_XT_WITH_PYTHON_BINDINGS
 // end: this is what we need for the lib
 
 

--- a/dune/xt/la/solver/fasp.hh
+++ b/dune/xt/la/solver/fasp.hh
@@ -16,16 +16,15 @@
 #define DUNE_XT_LA_SOLVER_FASP_HH
 
 #if HAVE_FASP
-#  if HAVE_EIGEN
 
 extern "C"
 {
-#    include "fasp_functs.h"
+#  include "fasp_functs.h"
 }
 
-#    include <dune/xt/la/container/eigen.hh>
+#  include <dune/xt/la/container/eigen.hh>
 
-#    include "interface.hh"
+#  include "interface.hh"
 
 namespace Dune {
 namespace XT {
@@ -375,7 +374,6 @@ private:
 } // namespace XT
 } // namespace Dune
 
-#  endif // HAVE_EIGEN
 #endif // HAVE_FASP
 
 #endif // DUNE_XT_LA_SOLVER_FASP_HH

--- a/dune/xt/test/grid/walker.cc
+++ b/dune/xt/test/grid/walker.cc
@@ -11,7 +11,7 @@
 
 #include <dune/xt/test/main.hxx>
 
-#if DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) && HAVE_TBB // EXADUNE
+#if DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) // EXADUNE
 #  include <dune/grid/utility/partitioning/seedlist.hh>
 #endif
 
@@ -73,7 +73,7 @@ struct GridWalkerTest : public ::testing::Test
 
     list<function<void()>> element_tests({test1, test2, test3});
     list<function<void()>> intersection_tests({test4, test5});
-#if DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) && HAVE_TBB // EXADUNE
+#if DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) // EXADUNE
     // exadune guard for SeedListPartitioning
     auto test0 = [&] {
       const auto& set = gv.grid().leafIndexSet();
@@ -84,7 +84,7 @@ struct GridWalkerTest : public ::testing::Test
       walker.walk(partitioning);
     };
     tests.push_back(test0);
-#endif // DUNE_VERSION_GTE(DUNE_COMMON, 3, 9) && HAVE_TBB
+#endif // DUNE_VERSION_GTE(DUNE_COMMON, 3, 9)
 
     for (const auto& test : element_tests) {
       count = 0;

--- a/dune/xt/test/la/container.hh
+++ b/dune/xt/test/la/container.hh
@@ -189,7 +189,6 @@ public:
 };
 
 
-#if HAVE_EIGEN
 template <class S>
 class ContainerFactory<Dune::XT::LA::EigenDenseVector<S>>
 {
@@ -238,7 +237,6 @@ public:
     return matrix;
   }
 };
-#endif // HAVE_EIGEN
 
 #define EXPECT_DOUBLE_OR_COMPLEX_EQ(expected, actual)                                                                  \
   {                                                                                                                    \

--- a/dune/xt/test/la/convert.cc
+++ b/dune/xt/test/la/convert.cc
@@ -26,7 +26,6 @@ GTEST_TEST(invert, main)
 {
   using K = double;
   constexpr int ROWS = 2, COLS = 2;
-#if HAVE_EIGEN
   {
     using ToType = Dune::FieldMatrix<K, ROWS, COLS>;
     using FromType = Dune::XT::LA::EigenDenseMatrix<K>;
@@ -45,7 +44,6 @@ GTEST_TEST(invert, main)
     Dune::XT::LA::convert_to<ToType>(FromType{ROWS, COLS});
     Dune::XT::LA::convert_to<ToType>(ToType{ROWS, COLS});
   }
-#endif // #if HAVE_EIGEN
   {
     using ToType = Dune::FieldMatrix<K, ROWS, COLS>;
     using FromType = ToType;

--- a/dune/xt/test/la/generalized-eigensolver_internals.cc
+++ b/dune/xt/test/la/generalized-eigensolver_internals.cc
@@ -169,7 +169,6 @@ GTEST_TEST(GeneralizedEigenSolverInternals, field_matrix)
   check_backend_failure_is_reported<MatrixType>();
 }
 
-#if HAVE_EIGEN
 GTEST_TEST(GeneralizedEigenSolverInternals, eigen_dense_matrix)
 {
   using MatrixType = EigenDenseMatrix<double>; // <- column-major and contiguous
@@ -178,4 +177,3 @@ GTEST_TEST(GeneralizedEigenSolverInternals, eigen_dense_matrix)
   check_backend_failure_is_reported<MatrixType>();
   check_varying_problem_sizes<MatrixType>();
 }
-#endif // HAVE_EIGEN

--- a/dune/xt/test/la/saddlepoint.cc
+++ b/dune/xt/test/la/saddlepoint.cc
@@ -154,7 +154,6 @@ struct SaddlePointTestData
 };
 
 #if HAVE_DUNE_ISTL
-#  if HAVE_EIGEN
 
 GTEST_TEST(SaddlePointSolver, test_direct_eigen)
 {
@@ -180,5 +179,4 @@ GTEST_TEST(SaddlePointSolver, test_cg_direct_schurcomplement_eigen)
   DXTC_EXPECT_FLOAT_EQ(0., (p - data.expected_p_).l2_norm(), 1e-12, 1e-12);
 }
 
-#  endif // HAVE_EIGEN
 #endif // HAVE_DUNE_ISTL

--- a/dune/xt/test/main.hxx
+++ b/dune/xt/test/main.hxx
@@ -51,12 +51,10 @@
 #include <dune/xt/common/parallel/threadmanager.hh>
 
 
-#if HAVE_TBB
-#  if __has_include(<tbb/global_control.h>)
-#    include <tbb/global_control.h>
-#  else
-#    include <tbb/task_scheduler_init.h>
-#  endif
+#if __has_include(<tbb/global_control.h>)
+#  include <tbb/global_control.h>
+#else
+#  include <tbb/task_scheduler_init.h>
 #endif
 
 #include <dune/xt/test/common.hh>
@@ -107,12 +105,10 @@ int main(int argc, char** argv)
     const size_t threads = DXTC_CONFIG.has_key("threading.max_count") // <- doing this so complicated to
                                ? DXTC_CONFIG.get<size_t>("threading.max_count") //    silence the WARNING: ...
                                : 1;
-#if HAVE_TBB
-#  if __has_include(<tbb/global_control.h>)
+#if __has_include(<tbb/global_control.h>)
     tbb::global_control tbb_control(tbb::global_control::max_allowed_parallelism, boost::numeric_cast<int>(threads));
-#  else
-    tbb::task_scheduler_init tbb_init(boost::numeric_cast<int>(threads));
-#  endif
+#else
+  tbb::task_scheduler_init tbb_init(boost::numeric_cast<int>(threads));
 #endif
     threadManager().set_max_threads(threads);
 

--- a/python/gdt/dune/gdt/discretefunction/bochner.cc
+++ b/python/gdt/dune/gdt/discretefunction/bochner.cc
@@ -229,11 +229,9 @@ PYBIND11_MODULE(_discretefunction_bochner, m)
   DiscreteBochnerFunction_for_all_grids<LA::CommonDenseVector<double>,
                                         LA::bindings::Common,
                                         XT::Grid::bindings::AvailableGridTypes>::bind(m);
-#if HAVE_EIGEN
   DiscreteBochnerFunction_for_all_grids<LA::EigenDenseVector<double>,
                                         LA::bindings::Eigen,
                                         XT::Grid::bindings::AvailableGridTypes>::bind(m);
-#endif
   DiscreteBochnerFunction_for_all_grids<LA::IstlDenseVector<double>,
                                         LA::bindings::Istl,
                                         XT::Grid::bindings::AvailableGridTypes>::bind(m);

--- a/python/gdt/dune/gdt/discretefunction/discretefunction_for_all_grids.hh
+++ b/python/gdt/dune/gdt/discretefunction/discretefunction_for_all_grids.hh
@@ -69,14 +69,10 @@ struct DiscreteFunction_for_all_grids<V, VT, Dune::XT::Common::tuple_null_type>
                                  XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);                             \
   m.attr("__all__") = py::make_tuple()
 
-#if HAVE_EIGEN
-#  define DUNE_GDT_BIND_DISCRETEFUNCTION_EIGEN(dim)                                                                    \
-    DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,                                                       \
-                                   LA::bindings::Eigen,                                                                \
-                                   XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);
-#else
-#  define DUNE_GDT_BIND_DISCRETEFUNCTION_EIGEN(dim)
-#endif
+#define DUNE_GDT_BIND_DISCRETEFUNCTION_EIGEN(dim)                                                                      \
+  DiscreteFunction_for_all_grids<LA::EigenDenseVector<double>,                                                         \
+                                 LA::bindings::Eigen,                                                                  \
+                                 XT::Grid::bindings::Available##dim##dGridTypes>::bind(m);
 
 
 #endif // PYTHON_DUNE_GDT_DISCRETEFUNCTION_DISCRETEFUNCTION_FOR_ALL_GRIDS_HH

--- a/python/gdt/dune/gdt/discretefunction/dof-vector.cc
+++ b/python/gdt/dune/gdt/discretefunction/dof-vector.cc
@@ -110,8 +110,6 @@ PYBIND11_MODULE(_discretefunction_dof_vector, m)
   py::module::import("dune.xt.functions");
 
   DofVector_for_all_grids<LA::CommonDenseVector<double>>::bind(m);
-#if HAVE_EIGEN
   DofVector_for_all_grids<LA::EigenDenseVector<double>>::bind(m);
-#endif
   DofVector_for_all_grids<LA::IstlDenseVector<double>>::bind(m);
 }

--- a/python/xt/dune/xt/la/bindings.cc
+++ b/python/xt/dune/xt/la/bindings.cc
@@ -56,10 +56,8 @@ PYBIND11_MODULE(_la, m)
   auto istl_dense_vector_double = LA::bind_Vector<LA::IstlDenseVector<double>>(m);
   auto istl_dense_vector_complex = LA::bind_Vector<LA::IstlDenseVector<std::complex<double>>>(m);
 #endif
-#if HAVE_EIGEN
   auto eigen_dense_vector_double = LA::bind_Vector<LA::EigenDenseVector<double>>(m);
   auto eigen_dense_vector_complex = LA::bind_Vector<LA::EigenDenseVector<std::complex<double>>>(m);
-#endif
 
   LA::bind_SparsityPatternDefault(m);
 
@@ -79,12 +77,10 @@ PYBIND11_MODULE(_la, m)
   BIND_MATRIX(LA::IstlRowMajorSparseMatrix<double>, true, istl_row_major_sparse_matrix_double);
   BIND_MATRIX(LA::IstlRowMajorSparseMatrix<std::complex<double>>, true, istl_row_major_sparse_matrix_complex);
 #endif
-#if HAVE_EIGEN
   BIND_MATRIX(LA::EigenDenseMatrix<double>, false, eigen_dense_matrix_double);
   BIND_MATRIX(LA::EigenDenseMatrix<std::complex<double>>, false, eigen_dense_matrix_complex);
   BIND_MATRIX(LA::EigenRowMajorSparseMatrix<double>, true, eigen_row_major_sparse_matrix_double);
   BIND_MATRIX(LA::EigenRowMajorSparseMatrix<std::complex<double>>, true, eigen_row_major_sparse_matrix_complex);
-#endif
 #undef BIND_MATRIX
   LA::addbind_Matrix_Vector_interaction(common_dense_matrix_double, common_dense_vector_double);
   LA::addbind_Matrix_Vector_interaction(common_dense_matrix_complex, common_dense_vector_complex);
@@ -96,12 +92,10 @@ PYBIND11_MODULE(_la, m)
   LA::addbind_Matrix_Vector_interaction(istl_row_major_sparse_matrix_double, istl_dense_vector_double);
   LA::addbind_Matrix_Vector_interaction(istl_row_major_sparse_matrix_complex, istl_dense_vector_complex);
 #endif
-#if HAVE_EIGEN
   LA::addbind_Matrix_Vector_interaction(eigen_dense_matrix_double, eigen_dense_vector_double);
   LA::addbind_Matrix_Vector_interaction(eigen_dense_matrix_complex, eigen_dense_vector_complex);
   LA::addbind_Matrix_Vector_interaction(eigen_row_major_sparse_matrix_double, eigen_dense_vector_double);
   LA::addbind_Matrix_Vector_interaction(eigen_row_major_sparse_matrix_complex, eigen_dense_vector_complex);
-#endif
 
   // The plain linear Solver (Ax = b, used throughout the FEM/operator solving pipeline) stays
   // double-only real-valued: extending it to complex fields is out of scope for WP5, which closes
@@ -111,10 +105,8 @@ PYBIND11_MODULE(_la, m)
 #if HAVE_DUNE_ISTL
   LA::bind_Solver<LA::IstlRowMajorSparseMatrix<double>>(m);
 #endif
-#if HAVE_EIGEN
   LA::bind_Solver<LA::EigenDenseMatrix<double>>(m);
   LA::bind_Solver<LA::EigenRowMajorSparseMatrix<double>>(m);
-#endif
 
   // Eigen-solver, generalized eigen-solver and matrix-inverter (WP5, #320): bound exactly for the
   // matrix/field combinations the C++ .tpl test suite already exercises (see
@@ -128,10 +120,8 @@ PYBIND11_MODULE(_la, m)
   LA::bind_MatrixInverter<LA::CommonDenseMatrix<std::complex<double>>>(m);
   LA::bind_MatrixInverter<LA::CommonSparseMatrixCsr<double>>(m);
   LA::bind_MatrixInverter<LA::CommonSparseMatrixCsr<std::complex<double>>>(m);
-#if HAVE_EIGEN
   LA::bind_EigenSolver<LA::EigenDenseMatrix<double>>(m);
   LA::bind_GeneralizedEigenSolver<LA::EigenDenseMatrix<double>>(m);
   LA::bind_MatrixInverter<LA::EigenDenseMatrix<double>>(m);
   LA::bind_MatrixInverter<LA::EigenDenseMatrix<std::complex<double>>>(m);
-#endif
 } // PYBIND11_MODULE(...)

--- a/python/xt/dune/xt/la/container.bindings.hh
+++ b/python/xt/dune/xt/la/container.bindings.hh
@@ -24,11 +24,9 @@ using COMMON_SPARSE_MATRIX_CSR = Dune::XT::LA::CommonSparseMatrixCsr<double>;
 using COMMON_SPARSE_MATRIX_CSC = Dune::XT::LA::CommonSparseMatrixCsc<double>;
 // kept for backwards compatibility, identical to COMMON_SPARSE_MATRIX_CSR (csr is the default storage layout)
 using COMMON_SPARSE_MATRIX = Dune::XT::LA::CommonSparseMatrix<double>;
-#if HAVE_EIGEN
 using EIGEN_DENSE_VECTOR = Dune::XT::LA::EigenDenseVector<double>;
 using EIGEN_DENSE_MATRIX = Dune::XT::LA::EigenDenseMatrix<double>;
 using EIGEN_SPARSE_MATRIX = Dune::XT::LA::EigenRowMajorSparseMatrix<double>;
-#endif
 using ISTL_DENSE_VECTOR = Dune::XT::LA::IstlDenseVector<double>;
 using ISTL_SPARSE_MATRIX = Dune::XT::LA::IstlRowMajorSparseMatrix<double>;
 
@@ -38,11 +36,9 @@ using COMMON_DENSE_VECTOR_COMPLEX = Dune::XT::LA::CommonDenseVector<std::complex
 using COMMON_DENSE_MATRIX_COMPLEX = Dune::XT::LA::CommonDenseMatrix<std::complex<double>>;
 using COMMON_SPARSE_MATRIX_CSR_COMPLEX = Dune::XT::LA::CommonSparseMatrixCsr<std::complex<double>>;
 using COMMON_SPARSE_MATRIX_CSC_COMPLEX = Dune::XT::LA::CommonSparseMatrixCsc<std::complex<double>>;
-#if HAVE_EIGEN
 using EIGEN_DENSE_VECTOR_COMPLEX = Dune::XT::LA::EigenDenseVector<std::complex<double>>;
 using EIGEN_DENSE_MATRIX_COMPLEX = Dune::XT::LA::EigenDenseMatrix<std::complex<double>>;
 using EIGEN_SPARSE_MATRIX_COMPLEX = Dune::XT::LA::EigenRowMajorSparseMatrix<std::complex<double>>;
-#endif
 using ISTL_DENSE_VECTOR_COMPLEX = Dune::XT::LA::IstlDenseVector<std::complex<double>>;
 using ISTL_SPARSE_MATRIX_COMPLEX = Dune::XT::LA::IstlRowMajorSparseMatrix<std::complex<double>>;
 
@@ -216,8 +212,6 @@ struct container_name<CommonSparseMatrix<std::complex<double>, Dune::XT::Common:
   }
 };
 
-#if HAVE_EIGEN
-
 template <>
 struct container_name<EigenDenseVector<double>>
 {
@@ -271,8 +265,6 @@ struct container_name<EigenRowMajorSparseMatrix<std::complex<double>>>
     return "eigen_complex_sparse_matrix";
   }
 };
-
-#endif // HAVE_EIGEN
 
 template <>
 struct container_name<IstlDenseVector<double>>


### PR DESCRIPTION
## Summary

Eigen3 and TBB are already de-facto mandatory (both are in `vcpkg.json`, and Eigen3 is pinned hard via `overrides`), so the `HAVE_EIGEN`/`ENABLE_EIGEN` and `HAVE_TBB`/`ENABLE_TBB` guard machinery around them was dead weight. This closes #386.

- `cmake/modules/DuneGdtMacros.cmake`: `find_package(Eigen3 3.4.0 REQUIRED)`, dropped the `ENABLE_EIGEN`/`HAVE_EIGEN` indirection.
- `cmake/modules/DuneTBB.cmake`: `find_package(TBB REQUIRED)`, dropped `HAVE_TBB`/`ENABLE_TBB`.
- `config.h.cmake`: removed the `HAVE_EIGEN`/`HAVE_TBB` `#cmakedefine`/fallback plumbing.
- Removed all `#if HAVE_EIGEN` / `#if HAVE_TBB` conditionals (and the no-Eigen/no-TBB fallback stubs, e.g. `static_assert(AlwaysFalse<...>::value, "You are missing eigen!")`) throughout `dune/` and `python/`, keeping the code path that was previously the "enabled" branch unconditional.
- Reformatted the touched files with `clang-format` to fix indentation left over from unwrapping the preprocessor guards.

## Out of scope (left untouched)

- Guards inside already-dead code: `#if 0` blocks in the Python interpolation/prolongation bindings, and commented-out `// #if HAVE_EIGEN` lines.
- The pre-existing `HAVE_FASP`, `HAVE_DUNE_ISTL`, and `DUNE_VERSION_GTE(DUNE_COMMON, 3, 9)` guards, which are tracked by separate issues (only stripped the now-redundant `&& HAVE_TBB` from the latter).
- The module-vs-config `find_package(Eigen3)` resolution-mode question the issue flags as a separate decision — `cmake/modules/FindEigen3.cmake` still shadows vcpkg's config in module mode, unchanged by this PR.

## Test plan

- [ ] CI build (no local build environment available to compile against vcpkg-provided Eigen3/TBB in this session)
- [x] Verified no remaining active `HAVE_EIGEN`/`ENABLE_EIGEN`/`HAVE_TBB`/`ENABLE_TBB` references outside of already-dead/out-of-scope code (`grep -rn` sweep)
- [x] Verified preprocessor `#if`/`#endif` balance across all touched files
- [x] `clang-format --dry-run -Werror` clean on all touched files

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2jWj8iJvWHvkTJhtD1fXV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Eigen 3.4.0 and Intel TBB are now required dependencies.

* **New Features**
  * Eigen-based linear algebra, solvers, matrix inversion, eigensolvers, and Python bindings are now consistently available.
  * Parallel execution and thread management now use TBB by default.
  * Partitioned walker execution supports optional functor clearing.

* **Compatibility**
  * Removed fallback behavior for builds without Eigen or TBB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->