### PR TITLE
ci: give the benchmarks job uv, and fail fast when it is missing

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,6 +45,17 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ninja-build
 
+    - name: Set up uv
+      # The configure step expands the templated test suites through `uv run` (see
+      # dxt_codegen_command in cmake/modules/DuneXTTesting.cmake), and CMakeLists.txt
+      # resolves the Python interpreter with `uv python find`. Without uv on PATH the
+      # configure dies ~30 minutes in, after vcpkg has built every dependency.
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      with:
+        # this workflow only runs on pushes to main and workflow_dispatch, so the
+        # cache is never written from an untrusted fork
+        enable-cache: true
+
     - name: Configure CMake
       id: configure_cmake
       run: cmake --preset=release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,21 @@ endforeach()
 # that active venv and breaks the configure-time system-test extraction (`dune_extract_static.py: No module named
 # dune`).
 option(DXT_USE_UV_PYTHON "Resolve the Python interpreter via uv (pinned by .python-version)" ON)
-if(DXT_USE_UV_PYTHON)
-  find_program(UV_EXECUTABLE uv)
+
+# uv is a hard build requirement independent of DXT_USE_UV_PYTHON: the configure-time expansion of the templated test
+# suites runs through `uv run` (see dxt_codegen_command in DuneXTTesting.cmake), as do the Python test and coverage
+# targets. Fail here rather than let a missing binary surface much later as an opaque "no such file or directory" from
+# the codegen -- on a from-scratch vcpkg build that is half an hour of dependency compilation further in.
+find_program(UV_EXECUTABLE uv)
+if(NOT UV_EXECUTABLE)
+  message(
+    FATAL_ERROR
+      "uv was not found on PATH. It is required to expand the templated test suites and to run the Python test suites."
+      " Install it (https://docs.astral.sh/uv/getting-started/installation/); CI jobs get it from the"
+      " astral-sh/setup-uv action.")
 endif()
-if(UV_EXECUTABLE)
+
+if(DXT_USE_UV_PYTHON)
   # `uv python find` only locates an already-available interpreter; it does not download one. On a host/runner whose
   # system Python doesn't match the pinned (.python-version) interpreter, resolve it in two steps: try to find it, and
   # if that fails install it with `uv python install` (uv downloads a managed CPython) and find it again.
@@ -116,7 +127,7 @@ if(UV_EXECUTABLE)
       CACHE FILEPATH "Python interpreter provided by uv" FORCE)
   message(STATUS "Using uv-provided Python interpreter: ${_uv_python_executable}")
 else()
-  message(STATUS "uv disabled or unavailable (DXT_USE_UV_PYTHON=${DXT_USE_UV_PYTHON}); using default FindPython")
+  message(STATUS "DXT_USE_UV_PYTHON=OFF; using default FindPython")
 endif()
 
 find_package(Python COMPONENTS Interpreter Development)

--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -139,11 +139,13 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
   #
   # * `uv run --no-project --with ...` supplies jinja2/pyparsing without a manually-managed venv, the same way the
   #   coverage targets in dxt_add_python_tests() pull gcovr/coverage.py, and `--python ${Python_EXECUTABLE}` pins the
-  #   interpreter the rest of the build resolved (see the uv block in the top-level CMakeLists.txt). Both are bounded to
-  #   their current major version: template expansion is build-critical, and both libraries have broken across a major
-  #   bump before (jinja2 2->3, pyparsing 2->3). They are deliberately *not* pinned exactly here -- python/xt/uv.lock
-  #   already resolves them (jinja2 3.1.6, pyparsing 3.3.2) and is what the dependency tooling updates, so an exact
-  #   version repeated in CMake would be a second source of truth that silently drifts from it.
+  #   interpreter the rest of the build resolved (see the uv block in the top-level CMakeLists.txt, which also resolves
+  #   ${UV_EXECUTABLE} and fails the configure outright when uv is missing -- expanding these templates is the earliest
+  #   consumer, and a bare `uv` here reported that as an opaque "no such file or directory"). Both are bounded to their
+  #   current major version: template expansion is build-critical, and both libraries have broken across a major bump
+  #   before (jinja2 2->3, pyparsing 2->3). They are deliberately *not* pinned exactly here -- python/xt/uv.lock already
+  #   resolves them (jinja2 3.1.6, pyparsing 3.3.2) and is what the dependency tooling updates, so an exact version
+  #   repeated in CMake would be a second source of truth that silently drifts from it.
   # * PYTHONPATH points at the binary-dir assembly of the `dune.xt` package -- the symlinked sources plus the configured
   #   _version.py that dune_pybindxi_install_python_package() and python/xt/dune/xt/CMakeLists.txt put there. The
   #   per-suite .py configs import dune.xt.codegen / dune.xt.test.grid_types, and the source tree on its own is not
@@ -154,8 +156,8 @@ macro(_PROCESS_SUBDIR_TESTS fullpath)
   # was dropped (its find_program is commented out in CMakeLists.txt), and the ${PROJECT_SOURCE_DIR}/python/ scripts/
   # path, which has never existed -- the script lives in python/xt/scripts/.
   set(dxt_codegen_command
-      ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_BINARY_DIR}/python/xt" uv run --no-project --with "jinja2>=3,<4"
-      --with "pyparsing>=3,<4" --python ${Python_EXECUTABLE} python
+      ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_BINARY_DIR}/python/xt" ${UV_EXECUTABLE} run --no-project --with
+      "jinja2>=3,<4" --with "pyparsing>=3,<4" --python ${Python_EXECUTABLE} python
       ${PROJECT_SOURCE_DIR}/python/xt/scripts/dxt_code_generation.py)
 
   foreach(template ${test_templates})
@@ -435,15 +437,19 @@ macro(DXT_ADD_PYTHON_TESTS)
   # from a clean source checkout with `python python/update_lockfiles.py` (no build dir required).
   add_test(
     NAME xt_test_python
-    COMMAND uv run --frozen --python ${Python_EXECUTABLE} --group test python -m pytest ${CMAKE_BINARY_DIR}/python/xt
-            --cov ${CMAKE_CURRENT_SOURCE_DIR}/ --junitxml=${CMAKE_BINARY_DIR}/pytest_results_xt.xml)
+    COMMAND
+      ${UV_EXECUTABLE} run --frozen --python ${Python_EXECUTABLE} --group test python -m pytest
+      ${CMAKE_BINARY_DIR}/python/xt --cov ${CMAKE_CURRENT_SOURCE_DIR}/
+      --junitxml=${CMAKE_BINARY_DIR}/pytest_results_xt.xml)
   set_tests_properties(
     xt_test_python PROPERTIES WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/python/xt ENVIRONMENT
                               COVERAGE_FILE=${CMAKE_BINARY_DIR}/coverage-xt LABELS "dune-gdt-test;python_test")
   add_test(
     NAME gdt_test_python
-    COMMAND uv run --frozen --python ${Python_EXECUTABLE} --group test python -m pytest ${CMAKE_BINARY_DIR}/python/gdt
-            --cov ${CMAKE_CURRENT_SOURCE_DIR}/ --junitxml=${CMAKE_BINARY_DIR}/pytest_results_gdt.xml)
+    COMMAND
+      ${UV_EXECUTABLE} run --frozen --python ${Python_EXECUTABLE} --group test python -m pytest
+      ${CMAKE_BINARY_DIR}/python/gdt --cov ${CMAKE_CURRENT_SOURCE_DIR}/
+      --junitxml=${CMAKE_BINARY_DIR}/pytest_results_gdt.xml)
   set_tests_properties(
     gdt_test_python PROPERTIES WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/python/gdt ENVIRONMENT
                                COVERAGE_FILE=${CMAKE_BINARY_DIR}/coverage-gdt LABELS "dune-gdt-test;python_test")
@@ -456,7 +462,7 @@ macro(DXT_ADD_PYTHON_TESTS)
   # future non-test file dropped into docs/ is never accidentally swept into this suite.
   add_test(
     NAME docs_test_python
-    COMMAND uv run --frozen --python ${Python_EXECUTABLE} --group docs_test python -m pytest
+    COMMAND ${UV_EXECUTABLE} run --frozen --python ${Python_EXECUTABLE} --group docs_test python -m pytest
             ${CMAKE_SOURCE_DIR}/docs/test_benchmark_plots.py --junitxml=${CMAKE_BINARY_DIR}/pytest_results_docs.xml)
   set_tests_properties(docs_test_python PROPERTIES WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/python/xt LABELS
                                                    "dune-gdt-test;python_test")
@@ -471,9 +477,9 @@ macro(DXT_ADD_PYTHON_TESTS)
     add_custom_target(
       coverage_cpp
       COMMAND
-        uv run --no-project --with gcovr gcovr --root ${CMAKE_SOURCE_DIR} --filter ${CMAKE_SOURCE_DIR}/dune/
-        --gcov-ignore-parse-errors --exclude-unreachable-branches --exclude-throw-branches --print-summary --xml-pretty
-        -o ${CMAKE_BINARY_DIR}/coverage-cpp.xml ${CMAKE_BINARY_DIR}
+        ${UV_EXECUTABLE} run --no-project --with gcovr gcovr --root ${CMAKE_SOURCE_DIR} --filter
+        ${CMAKE_SOURCE_DIR}/dune/ --gcov-ignore-parse-errors --exclude-unreachable-branches --exclude-throw-branches
+        --print-summary --xml-pretty -o ${CMAKE_BINARY_DIR}/coverage-cpp.xml ${CMAKE_BINARY_DIR}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       VERBATIM USES_TERMINAL)
   endif()
@@ -499,8 +505,9 @@ macro(DXT_ADD_PYTHON_TESTS)
     # combine the two coverage.py data files written by the pytest CTest runs and emit one XML.
     add_custom_target(
       coverage_python
-      COMMAND uv run --no-project --with coverage python -m coverage combine coverage-xt coverage-gdt
-      COMMAND uv run --no-project --with coverage python -m coverage xml -o ${CMAKE_BINARY_DIR}/coverage-python.xml
+      COMMAND ${UV_EXECUTABLE} run --no-project --with coverage python -m coverage combine coverage-xt coverage-gdt
+      COMMAND ${UV_EXECUTABLE} run --no-project --with coverage python -m coverage xml -o
+              ${CMAKE_BINARY_DIR}/coverage-python.xml
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       VERBATIM USES_TERMINAL)
   endif()


### PR DESCRIPTION
## What is broken

The **Benchmarks** workflow has failed on every push to `main` since 2026-07-25. Run 113 was the last green one; run 114 — the first push after #373 merged — is where it started, and it has been red ever since (latest: [run 135](https://github.com/dune-gdt/dune-gdt/actions/runs/30623029800/job/91131753736)).

`Configure CMake` dies ~29 minutes in, after vcpkg has built every dependency from source:

```
CMake Error at .../DuneExecuteProcess.cmake:68 (message):
  failed to expand the templated test suite
  /home/runner/work/dune-gdt/dune-gdt/dune/xt/test/common/vector.tpl

  Run command:cmake;-E;env;PYTHONPATH=...;uv;run;--no-project;--with;jinja2>=3,<4;...
  Return code: 1
  Detailed log:
  no such file or directory
```

## Root cause

`uv` is not on `PATH` in that job. The message names the template, but the template exists — it is the *exec of `uv`* that fails, and `DuneXTTesting.cmake` invoked a bare `uv`.

#373 ("actually glob, generate and register the .tpl test suites") made template expansion run at configure time through `uv run`; before it, all 49 templated suites were silently skipped, so nothing in the benchmarks job had ever needed `uv`. `non_docker_build.yml` sets up uv for its build/docs/wheel legs; `benchmarks.yml` never did.

The same run log shows the second symptom: `find_program(UV_EXECUTABLE uv)` came up empty, so `CMakeLists.txt` fell through to plain `FindPython` and built the codegen command with `--python /usr/bin/python3.14` — the system interpreter, not the 3.13 pinned in `.python-version`.

## Changes

- **`.github/workflows/benchmarks.yml`** — add the `astral-sh/setup-uv` step (same pinned SHA as `non_docker_build.yml`) before `Configure CMake`. This alone fixes the failure. `enable-cache: true` unconditionally is safe here: the workflow only triggers on pushes to `main` and `workflow_dispatch`, never on fork PRs.
- **`CMakeLists.txt`** — `uv` is a hard requirement of every configure, independent of `DXT_USE_UV_PYTHON`: the codegen needs it even when the interpreter comes from elsewhere, as in the manylinux wheel build that passes `DXT_USE_UV_PYTHON=OFF` (that build configures fine today, so uv is present in the container and the new check does not regress it). So `find_program` now runs unconditionally and a miss is a `FATAL_ERROR` with an actionable message, instead of silently degrading to the system interpreter and surfacing half an hour later as `no such file or directory` from the codegen. The `DXT_USE_UV_PYTHON` branch below it is unchanged apart from its guard.
- **`cmake/modules/DuneXTTesting.cmake`** — call `${UV_EXECUTABLE}` instead of a bare `uv` in the codegen command, the three pytest CTest entries and the coverage targets.

## Verification

- The new CMake block was exercised standalone with `cmake -P` in both directions: it resolves `uv` when present, and emits the intended fatal error when not.
- `cmake-format` / `cmake-lint` (repo config) clean on both touched CMake files; `actionlint` clean on the workflow.
- The end-to-end proof is the Benchmarks run on `main` after merge — it cannot be reproduced in a PR, since the workflow only triggers on push to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWtKrVSk9urVAAQWJbosCi)_