### PR TITLE
test(coverage): cover newton_solve, reinterpret, bochner and the DoF data handle

### DIFF
--- a/dune/gdt/discretefunction/bochner.hh
+++ b/dune/gdt/discretefunction/bochner.hh
@@ -174,8 +174,10 @@ void visualize(
       filename_prefix.empty(), XT::Common::Exceptions::wrong_input_given, "filename_prefix must not be empty!");
   bool use_counter = false;
   size_t counter = 0;
+  // an annotated vector without a (non-empty) time note cannot contribute a time to the filename below, so a single
+  // one of those makes us number all snapshots consecutively instead
   for (const auto& annotated_vector : discrete_bochner_function.dof_vectors())
-    if (!annotated_vector.note().has_key("_t"))
+    if (!annotated_vector.note().has_key("_t") || annotated_vector.note().get("_t").empty())
       use_counter = true;
   for (const auto& annotated_vector : discrete_bochner_function.dof_vectors()) {
     auto df = make_discrete_function(

--- a/dune/gdt/discretefunction/bochner.hh
+++ b/dune/gdt/discretefunction/bochner.hh
@@ -181,7 +181,9 @@ void visualize(
     auto df = make_discrete_function(
         discrete_bochner_function.space().spatial_space(), annotated_vector.vector(), discrete_bochner_function.name());
     GDT::visualize(df,
-                   filename_prefix + "_" + (use_counter ? XT::Common::to_string(counter) : XT::Common::to_string(time)),
+                   filename_prefix + "_"
+                       + (use_counter ? XT::Common::to_string(counter)
+                                      : XT::Common::to_string(annotated_vector.note().get("_t").at(0))),
                    subsampling,
                    vtk_output_type,
                    param,

--- a/dune/gdt/test/discretefunction/discretefunction_bochner.cc
+++ b/dune/gdt/test/discretefunction/discretefunction_bochner.cc
@@ -20,6 +20,7 @@
 #include <boost/filesystem.hpp>
 
 #include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/parameter.hh>
 #include <dune/xt/common/string.hh>
 #include <dune/xt/grid/grids.hh>
 #include <dune/xt/grid/gridprovider/cube.hh>
@@ -239,6 +240,41 @@ GTEST_TEST(discretefunction_bochner, visualize_uses_a_counter_without_time_notes
     EXPECT_TRUE(boost::filesystem::exists(expected_file)) << "missing " << expected_file;
 
   EXPECT_THROW(visualize(u, ""), XT::Common::Exceptions::wrong_input_given);
+}
+
+
+// A time note which carries no value cannot name a file, so it has to fall back to the counter just like a missing
+// one does (a single such vector switches the whole sequence over).
+GTEST_TEST(discretefunction_bochner, visualize_uses_a_counter_for_an_empty_time_note)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  XT::LA::ListVectorArray<V> dof_vectors(spatial_space.mapper().size(), 0);
+  const auto time_points = bochner_space.time_points();
+  const XT::Common::Parameter valueless_note("_t", std::vector<double>{});
+  ASSERT_TRUE(valueless_note.has_key("_t"));
+  ASSERT_TRUE(valueless_note.get("_t").empty());
+  for (size_t kk = 0; kk < time_points.size(); ++kk)
+    dof_vectors.append(V(spatial_space.mapper().size(), time_points[kk] + 1.),
+                       kk == 1 ? valueless_note : XT::Common::Parameter("_t", time_points[kk]));
+  auto u = make_discrete_bochner_function(bochner_space, dof_vectors);
+
+  const std::string prefix = "discretefunction_bochner__visualize_empty_note";
+  // only in a serial run do we know the file names the VTKWriter produces
+  std::vector<std::string> expected_files;
+  if (grid_view.comm().size() == 1)
+    for (const std::string& suffix : {"0", "1", "2"})
+      expected_files.push_back(prefix + "_" + suffix + ".vtu");
+  // a leftover file from an earlier run would let the assertions below pass without visualize() writing anything
+  for (const auto& expected_file : expected_files)
+    boost::filesystem::remove(expected_file);
+
+  EXPECT_NO_THROW(visualize(u, prefix, /*subsampling=*/false));
+  for (const auto& expected_file : expected_files)
+    EXPECT_TRUE(boost::filesystem::exists(expected_file)) << "missing " << expected_file;
 }
 
 

--- a/dune/gdt/test/discretefunction/discretefunction_bochner.cc
+++ b/dune/gdt/test/discretefunction/discretefunction_bochner.cc
@@ -1,0 +1,259 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-gdt developers
+
+#ifndef DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS
+#  define DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS 1
+#endif
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/string.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/la/container/istl.hh>
+#include <dune/xt/la/container/vector-array/list.hh>
+
+#include <dune/gdt/discretefunction/bochner.hh>
+#include <dune/gdt/exceptions.hh>
+#include <dune/gdt/spaces/bochner.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+static constexpr size_t d = G::dimension;
+using GV = typename G::LeafGridView;
+using V = XT::LA::IstlDenseVector<double>;
+using BS = BochnerSpace<GV>;
+
+
+namespace {
+
+
+XT::Grid::GridProvider<G> make_grid()
+{
+  return XT::Grid::make_cube_grid<G>(XT::Common::from_string<FieldVector<double, d>>("[0 0]"),
+                                     XT::Common::from_string<FieldVector<double, d>>("[1 1]"),
+                                     XT::Common::from_string<std::array<unsigned int, d>>("[2 2]"));
+}
+
+
+// The temporal grid of the Bochner space below, two intervals of a P1 Lagrange discretization of [0, 1].
+std::vector<double> time_grid()
+{
+  return {0., 0.5, 1.};
+}
+
+
+/**
+ * \brief Fills the DoF vectors such that the function is the constant time_point + 1 at each temporal node.
+ *
+ * Since the temporal space is P1 and these values depend linearly on time, the resulting Bochner function equals
+ * t \mapsto t + 1 exactly, for every t in [0, 1] - which makes evaluate() checkable by hand.
+ */
+template <class DiscreteBochnerFunctionType>
+void fill_dofs(const BS& bochner_space, DiscreteBochnerFunctionType& u)
+{
+  const auto time_points = bochner_space.time_points();
+  for (size_t kk = 0; kk < time_points.size(); ++kk) {
+    auto& vec = u.dof_vectors()[kk].vector();
+    for (size_t ii = 0; ii < vec.size(); ++ii)
+      vec.set_entry(ii, time_points[kk] + 1.);
+  }
+}
+
+
+} // namespace
+
+
+// The freshly allocating factory has to hand out one DoF vector per temporal DoF, each of spatial size.
+GTEST_TEST(discretefunction_bochner, freshly_allocated_dof_vectors_match_the_space)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  const auto u = make_discrete_bochner_function<V>(bochner_space);
+
+  EXPECT_EQ(&bochner_space, &u.space());
+  EXPECT_EQ("DiscreteBochnerFunction", u.name());
+  ASSERT_EQ(bochner_space.temporal_space().mapper().size(), u.dof_vectors().length());
+  ASSERT_EQ(3u, u.dof_vectors().length());
+  for (const auto& annotated_vector : u.dof_vectors()) {
+    EXPECT_EQ(spatial_space.mapper().size(), annotated_vector.vector().size());
+    EXPECT_DOUBLE_EQ(0., annotated_vector.vector().sup_norm());
+  }
+}
+
+
+// A given name has to be kept, an empty one has to be replaced by the documented default.
+GTEST_TEST(discretefunction_bochner, keeps_a_given_name)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  EXPECT_EQ("u", make_discrete_bochner_function<V>(bochner_space, "u").name());
+  EXPECT_EQ("DiscreteBochnerFunction", make_discrete_bochner_function<V>(bochner_space, "").name());
+}
+
+
+// Wrapping existing DoF vectors must not copy them: writing through the function has to be visible in the original.
+GTEST_TEST(discretefunction_bochner, wraps_existing_dof_vectors)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  XT::LA::ListVectorArray<V> dof_vectors(spatial_space.mapper().size(), bochner_space.temporal_space().mapper().size());
+  auto u = make_discrete_bochner_function(bochner_space, dof_vectors, "u");
+  EXPECT_EQ("u", u.name());
+  ASSERT_EQ(dof_vectors.length(), u.dof_vectors().length());
+
+  u.dof_vectors()[0].vector().set_entry(0, 42.);
+  EXPECT_DOUBLE_EQ(42., dof_vectors[0].vector().get_entry(0));
+}
+
+
+// DoF vectors which do not match the Bochner space have to be rejected on construction.
+GTEST_TEST(discretefunction_bochner, rejects_mismatching_dof_vectors)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+  const size_t spatial_size = spatial_space.mapper().size();
+  const size_t temporal_size = bochner_space.temporal_space().mapper().size();
+
+  XT::LA::ListVectorArray<V> too_few_vectors(spatial_size, temporal_size - 1);
+  EXPECT_THROW(make_discrete_bochner_function(bochner_space, too_few_vectors), Exceptions::space_error);
+
+  XT::LA::ListVectorArray<V> too_large_vectors(spatial_size + 1, temporal_size);
+  EXPECT_THROW(make_discrete_bochner_function(bochner_space, too_large_vectors), Exceptions::space_error);
+}
+
+
+// Evaluating in time has to reproduce the DoF vectors at the temporal nodes ...
+GTEST_TEST(discretefunction_bochner, evaluate_reproduces_the_temporal_nodes)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  auto u = make_discrete_bochner_function<V>(bochner_space);
+  fill_dofs(bochner_space, u);
+
+  const auto time_points = bochner_space.time_points();
+  ASSERT_EQ(3u, time_points.size());
+  for (size_t kk = 0; kk < time_points.size(); ++kk) {
+    const auto u_t = u.evaluate(time_points[kk]);
+    ASSERT_EQ(spatial_space.mapper().size(), u_t.dofs().vector().size());
+    for (size_t ii = 0; ii < u_t.dofs().vector().size(); ++ii)
+      EXPECT_NEAR(time_points[kk] + 1., u_t.dofs().vector().get_entry(ii), 1e-12);
+  }
+}
+
+
+// ... and, since the data is linear in time and the temporal space is P1, in between them as well.
+GTEST_TEST(discretefunction_bochner, evaluate_interpolates_between_the_temporal_nodes)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  auto u = make_discrete_bochner_function<V>(bochner_space);
+  fill_dofs(bochner_space, u);
+
+  for (const double t : {0.125, 0.25, 0.5, 0.75, 0.9}) {
+    const auto u_t = u.evaluate(t);
+    for (size_t ii = 0; ii < u_t.dofs().vector().size(); ++ii)
+      EXPECT_NEAR(t + 1., u_t.dofs().vector().get_entry(ii), 1e-12);
+  }
+}
+
+
+// Times outside of the temporal interval are documented to be clamped to it.
+GTEST_TEST(discretefunction_bochner, evaluate_clamps_times_outside_of_the_time_interval)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+  EXPECT_DOUBLE_EQ(0., bochner_space.time_interval().first);
+  EXPECT_DOUBLE_EQ(1., bochner_space.time_interval().second);
+
+  auto u = make_discrete_bochner_function<V>(bochner_space);
+  fill_dofs(bochner_space, u);
+
+  const auto before = u.evaluate(-1.);
+  const auto after = u.evaluate(2.);
+  for (size_t ii = 0; ii < before.dofs().vector().size(); ++ii) {
+    EXPECT_NEAR(1., before.dofs().vector().get_entry(ii), 1e-12);
+    EXPECT_NEAR(2., after.dofs().vector().get_entry(ii), 1e-12);
+  }
+}
+
+
+// visualize() writes one file per temporal snapshot, numbered consecutively if the DoF vectors carry no time note.
+GTEST_TEST(discretefunction_bochner, visualize_uses_a_counter_without_time_notes)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  auto u = make_discrete_bochner_function<V>(bochner_space);
+  fill_dofs(bochner_space, u);
+
+  const std::string prefix = "discretefunction_bochner__visualize_counter";
+  EXPECT_NO_THROW(visualize(u, prefix, /*subsampling=*/false));
+  if (grid_view.comm().size() == 1) // <- only then do we know the file names the VTKWriter produces
+    for (const std::string& suffix : {"0", "1", "2"})
+      EXPECT_TRUE(boost::filesystem::exists(prefix + "_" + suffix + ".vtu"))
+          << "missing " << prefix + "_" + suffix + ".vtu";
+
+  EXPECT_THROW(visualize(u, ""), XT::Common::Exceptions::wrong_input_given);
+}
+
+
+// If every DoF vector is annotated with its time, that time is used in the file name instead of the counter.
+GTEST_TEST(discretefunction_bochner, visualize_uses_the_time_note_if_present)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto spatial_space = make_finite_volume_space(grid_view);
+  const BS bochner_space(spatial_space, time_grid());
+
+  XT::LA::ListVectorArray<V> dof_vectors(spatial_space.mapper().size(), 0);
+  const auto time_points = bochner_space.time_points();
+  for (const auto& time_point : time_points)
+    dof_vectors.append(V(spatial_space.mapper().size(), time_point + 1.), {"_t", time_point});
+  auto u = make_discrete_bochner_function(bochner_space, dof_vectors);
+
+  const std::string prefix = "discretefunction_bochner__visualize_time";
+  EXPECT_NO_THROW(visualize(u, prefix, /*subsampling=*/false));
+  if (grid_view.comm().size() == 1) // <- only then do we know the file names the VTKWriter produces
+    for (const auto& time_point : time_points) {
+      const auto expected_file = prefix + "_" + XT::Common::to_string(time_point) + ".vtu";
+      EXPECT_TRUE(boost::filesystem::exists(expected_file)) << "missing " << expected_file;
+    }
+}

--- a/dune/gdt/test/discretefunction/discretefunction_bochner.cc
+++ b/dune/gdt/test/discretefunction/discretefunction_bochner.cc
@@ -225,11 +225,18 @@ GTEST_TEST(discretefunction_bochner, visualize_uses_a_counter_without_time_notes
   fill_dofs(bochner_space, u);
 
   const std::string prefix = "discretefunction_bochner__visualize_counter";
-  EXPECT_NO_THROW(visualize(u, prefix, /*subsampling=*/false));
-  if (grid_view.comm().size() == 1) // <- only then do we know the file names the VTKWriter produces
+  // only in a serial run do we know the file names the VTKWriter produces
+  std::vector<std::string> expected_files;
+  if (grid_view.comm().size() == 1)
     for (const std::string& suffix : {"0", "1", "2"})
-      EXPECT_TRUE(boost::filesystem::exists(prefix + "_" + suffix + ".vtu"))
-          << "missing " << prefix + "_" + suffix + ".vtu";
+      expected_files.push_back(prefix + "_" + suffix + ".vtu");
+  // a leftover file from an earlier run would let the assertions below pass without visualize() writing anything
+  for (const auto& expected_file : expected_files)
+    boost::filesystem::remove(expected_file);
+
+  EXPECT_NO_THROW(visualize(u, prefix, /*subsampling=*/false));
+  for (const auto& expected_file : expected_files)
+    EXPECT_TRUE(boost::filesystem::exists(expected_file)) << "missing " << expected_file;
 
   EXPECT_THROW(visualize(u, ""), XT::Common::Exceptions::wrong_input_given);
 }
@@ -250,10 +257,16 @@ GTEST_TEST(discretefunction_bochner, visualize_uses_the_time_note_if_present)
   auto u = make_discrete_bochner_function(bochner_space, dof_vectors);
 
   const std::string prefix = "discretefunction_bochner__visualize_time";
+  // only in a serial run do we know the file names the VTKWriter produces
+  std::vector<std::string> expected_files;
+  if (grid_view.comm().size() == 1)
+    for (const auto& time_point : time_points)
+      expected_files.push_back(prefix + "_" + XT::Common::to_string(time_point) + ".vtu");
+  // a leftover file from an earlier run would let the assertions below pass without visualize() writing anything
+  for (const auto& expected_file : expected_files)
+    boost::filesystem::remove(expected_file);
+
   EXPECT_NO_THROW(visualize(u, prefix, /*subsampling=*/false));
-  if (grid_view.comm().size() == 1) // <- only then do we know the file names the VTKWriter produces
-    for (const auto& time_point : time_points) {
-      const auto expected_file = prefix + "_" + XT::Common::to_string(time_point) + ".vtu";
-      EXPECT_TRUE(boost::filesystem::exists(expected_file)) << "missing " << expected_file;
-    }
+  for (const auto& expected_file : expected_files)
+    EXPECT_TRUE(boost::filesystem::exists(expected_file)) << "missing " << expected_file;
 }

--- a/dune/gdt/test/discretefunction/discretefunction_default_datahandle.cc
+++ b/dune/gdt/test/discretefunction/discretefunction_default_datahandle.cc
@@ -1,0 +1,160 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-gdt developers
+
+#ifndef DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS
+#  define DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS 1
+#endif
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <array>
+#include <vector>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/string.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/la/container/istl.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/discretefunction/default-datahandle.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+static constexpr size_t d = G::dimension;
+using GV = typename G::LeafGridView;
+using V = XT::LA::IstlDenseVector<double>;
+using DF = DiscreteFunction<V, GV>;
+
+
+namespace {
+
+
+XT::Grid::GridProvider<G> make_grid()
+{
+  return XT::Grid::make_cube_grid<G>(XT::Common::from_string<FieldVector<double, d>>("[0 0]"),
+                                     XT::Common::from_string<FieldVector<double, d>>("[1 1]"),
+                                     XT::Common::from_string<std::array<unsigned int, d>>("[2 2]"));
+}
+
+
+// Minimal stand-in for the message buffer the grid hands to gather()/scatter() when communicating.
+struct TestMessageBuffer
+{
+  void write(const double& value)
+  {
+    data.push_back(value);
+  }
+
+  void read(double& value)
+  {
+    value = data.at(read_index);
+    ++read_index;
+  }
+
+  std::vector<double> data;
+  size_t read_index{0};
+}; // struct TestMessageBuffer
+
+
+} // namespace
+
+
+// Only the DoFs attached to elements are communicated, and the size is constant unless stated otherwise.
+GTEST_TEST(discretefunction_default_datahandle, contains_only_codim_zero)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  auto u = make_discrete_function<V>(space);
+
+  DiscreteFunctionDataHandle<DF> handle(u);
+  EXPECT_TRUE(handle.contains(int(d), 0));
+  EXPECT_FALSE(handle.contains(int(d), 1));
+  EXPECT_FALSE(handle.contains(int(d), int(d)));
+  EXPECT_TRUE(handle.fixedSize(int(d), 0));
+
+  DiscreteFunctionDataHandle<DF> non_fixed_size_handle(u, /*fixed_size=*/false);
+  EXPECT_FALSE(non_fixed_size_handle.fixedSize(int(d), 0));
+}
+
+
+// The announced size has to match the number of local DoFs for elements, and be zero for anything else.
+GTEST_TEST(discretefunction_default_datahandle, announces_the_local_size_for_elements)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  auto u = make_discrete_function<V>(space);
+
+  const DiscreteFunctionDataHandle<DF> handle(u);
+  size_t num_elements = 0;
+  for (auto&& element : elements(grid_view)) {
+    EXPECT_EQ(space.mapper().local_size(element), handle.size(element));
+    ++num_elements;
+  }
+  EXPECT_EQ(4u, num_elements);
+
+  const auto vertex = *grid_view.begin<GV::dimension>();
+  EXPECT_EQ(0u, handle.size(vertex));
+}
+
+
+// Gathering the DoFs of a function and scattering them into another one has to reproduce them exactly.
+GTEST_TEST(discretefunction_default_datahandle, gather_and_scatter_round_trip)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  const size_t n = space.mapper().size();
+
+  auto u = make_discrete_function<V>(space);
+  for (size_t ii = 0; ii < n; ++ii)
+    u.dofs().vector().set_entry(ii, double(ii) + 1.);
+
+  const DiscreteFunctionDataHandle<DF> handle(u);
+  TestMessageBuffer buffer;
+  for (auto&& element : elements(grid_view))
+    handle.gather(buffer, element);
+  ASSERT_EQ(n, buffer.data.size());
+
+  auto v = make_discrete_function<V>(space); // <- default constructed: all DoFs zero
+  DiscreteFunctionDataHandle<DF> other_handle(v);
+  for (auto&& element : elements(grid_view))
+    other_handle.scatter(buffer, element, space.mapper().local_size(element));
+
+  for (size_t ii = 0; ii < n; ++ii)
+    EXPECT_DOUBLE_EQ(u.dofs().vector().get_entry(ii), v.dofs().vector().get_entry(ii));
+}
+
+
+// Entities of codimension other than zero carry no data, so gather()/scatter() have to be no-ops for them.
+GTEST_TEST(discretefunction_default_datahandle, gather_and_scatter_ignore_higher_codimensions)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  auto u = make_discrete_function<V>(space);
+  u.dofs().vector().set_entry(0, 42.);
+
+  DiscreteFunctionDataHandle<DF> handle(u);
+  const auto vertex = *grid_view.begin<GV::dimension>();
+
+  TestMessageBuffer buffer;
+  handle.gather(buffer, vertex);
+  EXPECT_TRUE(buffer.data.empty());
+
+  handle.scatter(buffer, vertex, 0);
+  EXPECT_DOUBLE_EQ(42., u.dofs().vector().get_entry(0));
+}

--- a/dune/gdt/test/discretefunction/discretefunction_reinterpret.cc
+++ b/dune/gdt/test/discretefunction/discretefunction_reinterpret.cc
@@ -1,0 +1,183 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-gdt developers
+
+#ifndef DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS
+#  define DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS 1
+#endif
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <array>
+#include <cmath>
+
+#include <dune/grid/common/rangegenerators.hh>
+
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/string.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/la/container/istl.hh>
+
+#include <dune/gdt/discretefunction/default.hh>
+#include <dune/gdt/discretefunction/reinterpret.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+static constexpr size_t d = G::dimension;
+using GV = typename G::LeafGridView;
+using E = XT::Grid::extract_entity_t<GV>;
+using V = XT::LA::IstlDenseVector<double>;
+
+
+namespace {
+
+
+XT::Grid::GridProvider<G> make_grid(const std::string& num_elements, const std::string& upper_right = "[1 1]")
+{
+  return XT::Grid::make_cube_grid<G>(XT::Common::from_string<FieldVector<double, d>>("[0 0]"),
+                                     XT::Common::from_string<FieldVector<double, d>>(upper_right),
+                                     XT::Common::from_string<std::array<unsigned int, d>>(num_elements));
+}
+
+
+// A function which is easy to reproduce by hand, evaluated at the center of the element x lies in.
+double reference_value(const FieldVector<double, d>& x)
+{
+  return 1. + x[0] + 10. * x[1];
+}
+
+
+// Fills the DoFs of a finite volume function such that it equals reference_value(element_center) on each element.
+template <class SpaceType>
+void fill_dofs(const SpaceType& space, DiscreteFunction<V, GV>& u)
+{
+  auto local_dofs = u.dofs().localize();
+  for (auto&& element : elements(space.grid_view())) {
+    local_dofs.bind(element);
+    local_dofs.set_entry(0, reference_value(element.geometry().center()));
+  }
+}
+
+
+} // namespace
+
+
+// Reinterpreting onto the very grid view the source lives on has to reproduce the source exactly.
+GTEST_TEST(discretefunction_reinterpret, round_trips_on_the_source_grid_view)
+{
+  auto grid = make_grid("[2 2]");
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  auto u = make_discrete_function<V>(space);
+  fill_dofs(space, u);
+
+  const auto reinterpreted = reinterpret(u, grid_view);
+  auto local_u = u.local_function();
+  auto local_reinterpreted = reinterpreted.local_function();
+  size_t num_elements = 0;
+  for (auto&& element : elements(grid_view)) {
+    local_u->bind(element);
+    local_reinterpreted->bind(element);
+    const auto x_in_reference_element = element.geometry().local(element.geometry().center());
+    EXPECT_DOUBLE_EQ(local_u->evaluate(x_in_reference_element)[0],
+                     local_reinterpreted->evaluate(x_in_reference_element)[0]);
+    ++num_elements;
+  }
+  EXPECT_EQ(4u, num_elements);
+}
+
+
+// The same, but using the overload where the target element type is given explicitly instead of being deduced.
+GTEST_TEST(discretefunction_reinterpret, round_trips_with_an_explicitly_given_target_element)
+{
+  auto grid = make_grid("[2 2]");
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  auto u = make_discrete_function<V>(space);
+  fill_dofs(space, u);
+
+  const auto reinterpreted = reinterpret<E>(u);
+  auto local_u = u.local_function();
+  auto local_reinterpreted = reinterpreted.local_function();
+  for (auto&& element : elements(grid_view)) {
+    local_u->bind(element);
+    local_reinterpreted->bind(element);
+    const auto x_in_reference_element = element.geometry().local(element.geometry().center());
+    EXPECT_DOUBLE_EQ(local_u->evaluate(x_in_reference_element)[0],
+                     local_reinterpreted->evaluate(x_in_reference_element)[0]);
+  }
+}
+
+
+// Reinterpreting a piecewise constant function onto a finer grid has to yield the value of the coarse element which
+// contains the respective fine element.
+GTEST_TEST(discretefunction_reinterpret, evaluates_the_source_on_a_finer_target_grid)
+{
+  auto coarse_grid = make_grid("[2 2]");
+  auto coarse_grid_view = coarse_grid.leaf_view();
+  const auto coarse_space = make_finite_volume_space(coarse_grid_view);
+  auto u = make_discrete_function<V>(coarse_space);
+  fill_dofs(coarse_space, u);
+
+  auto fine_grid = make_grid("[4 4]");
+  auto fine_grid_view = fine_grid.leaf_view();
+
+  const auto reinterpreted = reinterpret(u, fine_grid_view);
+  auto local_reinterpreted = reinterpreted.local_function();
+  size_t num_elements = 0;
+  for (auto&& fine_element : elements(fine_grid_view)) {
+    local_reinterpreted->bind(fine_element);
+    const auto center = fine_element.geometry().center();
+    // the coarse grid has two elements per direction over [0, 1], so this is the center of the containing one
+    FieldVector<double, d> coarse_center(0.);
+    for (size_t dd = 0; dd < d; ++dd)
+      coarse_center[dd] = (std::floor(center[dd] * 2.) + 0.5) / 2.;
+    EXPECT_NEAR(
+        reference_value(coarse_center), local_reinterpreted->evaluate(fine_element.geometry().local(center))[0], 1e-12);
+    ++num_elements;
+  }
+  EXPECT_EQ(16u, num_elements);
+}
+
+
+// Where the target grid is not covered by the source grid, the reinterpreted function is documented to be zero.
+GTEST_TEST(discretefunction_reinterpret, is_zero_outside_of_the_source_grid)
+{
+  auto source_grid = make_grid("[2 2]", "[0.5 0.5]"); // <- covers only the lower left quarter of the target grid
+  auto source_grid_view = source_grid.leaf_view();
+  const auto source_space = make_finite_volume_space(source_grid_view);
+  auto u = make_discrete_function<V>(source_space);
+  fill_dofs(source_space, u);
+
+  // the target elements are of the same size as the source ones, so their centers coincide where they overlap
+  auto target_grid = make_grid("[4 4]");
+  auto target_grid_view = target_grid.leaf_view();
+
+  const auto reinterpreted = reinterpret(u, target_grid_view);
+  auto local_reinterpreted = reinterpreted.local_function();
+  size_t num_zero_elements = 0;
+  size_t num_nonzero_elements = 0;
+  for (auto&& element : elements(target_grid_view)) {
+    local_reinterpreted->bind(element);
+    const auto center = element.geometry().center();
+    const auto value = local_reinterpreted->evaluate(element.geometry().local(center))[0];
+    if (center[0] < 0.5 && center[1] < 0.5) {
+      EXPECT_NEAR(reference_value(center), value, 1e-12);
+      ++num_nonzero_elements;
+    } else {
+      EXPECT_DOUBLE_EQ(0., value);
+      ++num_zero_elements;
+    }
+  }
+  EXPECT_EQ(4u, num_nonzero_elements);
+  EXPECT_EQ(12u, num_zero_elements);
+}

--- a/dune/gdt/test/misc/algorithms_newton.cc
+++ b/dune/gdt/test/misc/algorithms_newton.cc
@@ -13,12 +13,142 @@
 
 #include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
 
+#include <array>
+#include <cmath>
+#include <vector>
+
 #include <dune/xt/common/configuration.hh>
+#include <dune/xt/common/fvector.hh>
+#include <dune/xt/common/string.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+#include <dune/xt/la/container/istl.hh>
 
 #include <dune/gdt/algorithms/newton.hh>
+#include <dune/gdt/exceptions.hh>
+#include <dune/gdt/operators/interfaces.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
 
 using namespace Dune;
 using namespace Dune::GDT;
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+static constexpr size_t d = G::dimension;
+using GV = typename G::LeafGridView;
+using M = XT::LA::IstlRowMajorSparseMatrix<double>;
+using V = XT::LA::IstlDenseVector<double>;
+
+
+namespace {
+
+
+/**
+ * \brief The smallest nonlinear operator we can hand to newton_solve: the DoF-wise square u \mapsto u^2.
+ *
+ * Solving u^2 = c for c > 0 from a positive initial guess has the known root sqrt(c), and the jacobian diag(2 u) is
+ * trivially invertible as long as no DoF is zero. Both counters allow the tests below to check that newton_solve
+ * actually iterates (and how often).
+ */
+class SquareOperator : public OperatorInterface<GV, 1, 1, 1, 1, double, M, GV, GV>
+{
+  using BaseType = OperatorInterface<GV, 1, 1, 1, 1, double, M, GV, GV>;
+
+public:
+  using typename BaseType::AssemblyGridViewType;
+  using typename BaseType::MatrixOperatorType;
+  using typename BaseType::RangeSpaceType;
+  using typename BaseType::SourceSpaceType;
+  using typename BaseType::VectorType;
+
+  explicit SquareOperator(const SourceSpaceType& spc)
+    : BaseType()
+    , space_(spc)
+    , num_applications_(0)
+    , num_jacobians_(0)
+  {
+  }
+
+  // pull in methods from various base classes
+  using BaseType::apply;
+  using BaseType::jacobian;
+
+  const RangeSpaceType& range_space() const override final
+  {
+    return space_;
+  }
+
+  const SourceSpaceType& source_space() const override final
+  {
+    return space_;
+  }
+
+  const AssemblyGridViewType& assembly_grid_view() const override final
+  {
+    return space_.grid_view();
+  }
+
+  bool linear() const override final
+  {
+    return false;
+  }
+
+  void apply(const VectorType& source_vector,
+             VectorType& range_vector,
+             const XT::Common::Parameter& /*param*/ = {}) const override final
+  {
+    this->assert_matching_source(source_vector);
+    this->assert_matching_range(range_vector);
+    for (size_t ii = 0; ii < source_vector.size(); ++ii)
+      range_vector.set_entry(ii, source_vector.get_entry(ii) * source_vector.get_entry(ii));
+    ++num_applications_;
+  } // ... apply(...)
+
+protected:
+  std::vector<XT::Common::Configuration> all_jacobian_options() const override final
+  {
+    return {{{"type", "diagonal"}}};
+  }
+
+public:
+  void jacobian(const VectorType& source_vector,
+                MatrixOperatorType& jacobian_op,
+                const XT::Common::Configuration& opts,
+                const XT::Common::Parameter& /*param*/ = {}) const override final
+  {
+    this->assert_matching_source(source_vector);
+    this->assert_jacobian_opts(opts); // ensures that type diagonal is requested
+    for (size_t ii = 0; ii < source_vector.size(); ++ii)
+      jacobian_op.matrix().add_to_entry(ii, ii, jacobian_op.scaling * 2. * source_vector.get_entry(ii));
+    ++num_jacobians_;
+  } // ... jacobian(...)
+
+  size_t num_applications() const
+  {
+    return num_applications_;
+  }
+
+  size_t num_jacobians() const
+  {
+    return num_jacobians_;
+  }
+
+private:
+  const SourceSpaceType& space_;
+  mutable size_t num_applications_;
+  mutable size_t num_jacobians_;
+}; // class SquareOperator
+
+
+// A four element grid keeps the linear systems tiny while still exercising more than a single DoF.
+XT::Grid::GridProvider<G> make_grid()
+{
+  return XT::Grid::make_cube_grid<G>(XT::Common::from_string<FieldVector<double, d>>("[0 0]"),
+                                     XT::Common::from_string<FieldVector<double, d>>("[1 1]"),
+                                     XT::Common::from_string<std::array<unsigned int, d>>("[2 2]"));
+}
+
+
+} // namespace
 
 
 // default_newton_solve_options() has to provide the documented precision / iteration keys with their default values.
@@ -31,4 +161,113 @@ GTEST_TEST(algorithms_newton, default_options_have_documented_keys)
   EXPECT_DOUBLE_EQ(1e-7, opts.get<double>("precision"));
   EXPECT_EQ(100u, opts.get<size_t>("max_iter"));
   EXPECT_EQ(1000u, opts.get<size_t>("max_dampening_iter"));
+}
+
+
+// Solving u^2 = 2 from the initial guess 1 has to yield sqrt(2) in every DoF, within a handful of iterations.
+GTEST_TEST(algorithms_newton, converges_to_the_known_root)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  const SquareOperator op(space);
+
+  const size_t n = space.mapper().size();
+  ASSERT_EQ(4u, n);
+  const V rhs(n, 2.);
+  V u(n, 1.);
+
+  newton_solve(op, rhs, u);
+
+  for (size_t ii = 0; ii < n; ++ii)
+    EXPECT_NEAR(std::sqrt(2.), u.get_entry(ii), 1e-6);
+  // newton has to have iterated, but the quadratic convergence of this problem must not require many iterations
+  EXPECT_GE(op.num_jacobians(), 1u);
+  EXPECT_LE(op.num_jacobians(), 10u);
+  EXPECT_GT(op.num_applications(), op.num_jacobians());
+}
+
+
+// The initial guess is used as such: starting at the root, newton has to succeed without computing a single jacobian.
+GTEST_TEST(algorithms_newton, accepts_an_initial_guess_which_already_solves_the_problem)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  const SquareOperator op(space);
+
+  const size_t n = space.mapper().size();
+  const V rhs(n, 2.);
+  V u(n, std::sqrt(2.));
+
+  newton_solve(op, rhs, u);
+
+  for (size_t ii = 0; ii < n; ++ii)
+    EXPECT_NEAR(std::sqrt(2.), u.get_entry(ii), 1e-12);
+  EXPECT_EQ(0u, op.num_jacobians());
+  EXPECT_EQ(1u, op.num_applications());
+}
+
+
+// A non-default precision has to be honoured: a very coarse one has to stop the iteration earlier.
+GTEST_TEST(algorithms_newton, honours_a_given_precision)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  const SquareOperator accurate_op(space);
+  const SquareOperator coarse_op(space);
+
+  const size_t n = space.mapper().size();
+  const V rhs(n, 2.);
+
+  V accurate_u(n, 1.);
+  newton_solve(accurate_op, rhs, accurate_u);
+
+  auto coarse_opts = default_newton_solve_options();
+  coarse_opts["precision"] = "1e-1";
+  V coarse_u(n, 1.);
+  newton_solve(coarse_op, rhs, coarse_u, {}, coarse_opts);
+
+  EXPECT_LT(coarse_op.num_jacobians(), accurate_op.num_jacobians());
+  for (size_t ii = 0; ii < n; ++ii)
+    EXPECT_NEAR(std::sqrt(2.), coarse_u.get_entry(ii), 1e-1);
+}
+
+
+// The documented failure behaviour of the non-convergence path is an Exceptions::newton_error ...
+GTEST_TEST(algorithms_newton, throws_if_the_maximum_number_of_iterations_is_reached)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  const SquareOperator op(space);
+
+  const size_t n = space.mapper().size();
+  const V rhs(n, 2.);
+  V u(n, 1.);
+
+  auto opts = default_newton_solve_options();
+  opts["max_iter"] = "0"; // <- the initial guess is not a root, so this can never succeed
+  EXPECT_THROW(newton_solve(op, rhs, u, {}, opts), Exceptions::newton_error);
+}
+
+
+// ... which is also thrown if the automatic dampening does not manage to reduce the residual.
+GTEST_TEST(algorithms_newton, throws_if_the_dampening_does_not_converge)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  const SquareOperator op(space);
+
+  const size_t n = space.mapper().size();
+  const V rhs(n, 2.);
+  V u(n, 1.);
+
+  auto opts = default_newton_solve_options();
+  opts["max_dampening_iter"] = "0"; // <- not even the undampened candidate may be tried
+  EXPECT_THROW(newton_solve(op, rhs, u, {}, opts), Exceptions::newton_error);
+  // the jacobian was required to obtain the update whose dampening then failed
+  EXPECT_EQ(1u, op.num_jacobians());
 }

--- a/dune/gdt/test/misc/algorithms_newton.cc
+++ b/dune/gdt/test/misc/algorithms_newton.cc
@@ -104,6 +104,9 @@ public:
   } // ... apply(...)
 
 protected:
+  // this identifier is operator-private: assert_jacobian_opts() only checks it for membership in this list. It names
+  // the shape of the contribution we add below and says nothing about the sparsity pattern empty_jacobian_op()
+  // allocates (which, for a finite volume space, also covers the neighbour couplings).
   std::vector<XT::Common::Configuration> all_jacobian_options() const override final
   {
     return {{{"type", "diagonal"}}};
@@ -161,6 +164,35 @@ GTEST_TEST(algorithms_newton, default_options_have_documented_keys)
   EXPECT_DOUBLE_EQ(1e-7, opts.get<double>("precision"));
   EXPECT_EQ(100u, opts.get<size_t>("max_iter"));
   EXPECT_EQ(1000u, opts.get<size_t>("max_dampening_iter"));
+}
+
+
+// newton_solve() does not differentiate the operator it is given, but the residual operator lhs - rhs. That composed
+// operator therefore has to report jacobian options (newton_solve takes the first one, unconditionally) and has to
+// delegate the actual assembly to its summands.
+GTEST_TEST(algorithms_newton, the_residual_operator_delegates_its_jacobian)
+{
+  auto grid = make_grid();
+  auto grid_view = grid.leaf_view();
+  const auto space = make_finite_volume_space(grid_view);
+  const SquareOperator op(space);
+
+  const size_t n = space.mapper().size();
+  const V rhs(n, 2.);
+  const auto residual_op = op - rhs;
+
+  const auto types = residual_op.jacobian_options();
+  ASSERT_FALSE(types.empty()); // <- newton_solve calls .at(0) on this
+  EXPECT_EQ("lincomb", types.at(0));
+
+  const V u(n, 3.);
+  auto jacobian_op = residual_op.jacobian(u, types.at(0));
+  jacobian_op.assemble();
+
+  EXPECT_EQ(1u, op.num_jacobians()); // <- the composed operator delegated to us
+  // the constant summand contributes a zero jacobian, so this is exactly our diag(2 u)
+  for (size_t ii = 0; ii < n; ++ii)
+    EXPECT_DOUBLE_EQ(6., jacobian_op.matrix().get_entry(ii, ii));
 }
 
 


### PR DESCRIPTION
Finishes the remainder of #289 — the scope PR #316 explicitly deferred because it could not compile-verify the template-instantiation-only paths.

## New unit tests

**`dune/gdt/test/misc/algorithms_newton.cc`** (extends the existing options test)

`newton_solve` needs an `OperatorInterface`, so the test adds the smallest nonlinear one that will do: the DoF-wise square `u ↦ u²` on a four element finite volume space, whose jacobian is `diag(2u)`. Solving `u² = 2` therefore has the known root `√2`. Covered:

- convergence to `√2` in every DoF (`EXPECT_NEAR(..., 1e-6)`), with an iteration count bounded via a counter on the operator;
- an initial guess which already solves the problem is used as such (no jacobian is computed);
- a non-default `precision` is honoured (a coarse one stops the iteration earlier);
- both documented non-convergence paths throw `Exceptions::newton_error`: `max_iter` reached, and the automatic dampening exceeding `max_dampening_iter`.

**`dune/gdt/test/discretefunction/discretefunction_reinterpret.cc`**

- round trip on the source grid view, for both the deduced-target and the explicit-`TargetElement` overload;
- a piecewise constant function reinterpreted onto a four times finer grid reproduces the value of the containing coarse element (hand-computed);
- the documented zero where the target grid is not covered by the source grid.

**`dune/gdt/test/discretefunction/discretefunction_bochner.cc`**

- both factories (freshly allocated DoF vectors and wrapping existing ones, verifying that the latter does not copy), the name default, and the size checks rejecting mismatching DoF vectors with `Exceptions::space_error`;
- `evaluate()` at the temporal nodes and, since the data is linear in time over a P1 temporal space, exactly in between them; plus the clamping outside of the time interval;
- both file naming branches of `visualize()`.

**`dune/gdt/test/discretefunction/discretefunction_default_datahandle.cc`**

- `contains` / `fixedSize` / `size` for codimension zero and above;
- a gather/scatter round trip through a stand-in message buffer.

No CMake changes are needed: `misc` and `discretefunction` are already in `GDT_TEST_SUBDIRS` and `add_subdir_tests` globs `*.cc`.

## Drive-by fix

`visualize(DiscreteBochnerFunction, ...)` in `dune/gdt/discretefunction/bochner.hh` referenced an undeclared `time` in its non-counter branch (it resolved to `std::time`), so the template could not be instantiated at all. It now formats the `_t` note of the annotated vector, which is exactly what the surrounding `use_counter` logic tests for.

## Verification

The tests were written against the headers but not compiled locally — this sandbox has no dune dependency stack — so CI is the first build. Anything that does not compile or fails will be fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRKddJMBaBMSxxoqP9o5Xr


---
_Generated by [Claude Code](https://claude.ai/code/session_01KRKddJMBaBMSxxoqP9o5Xr)_