### PR TITLE
Raise dune/gdt/spaces coverage above 80% via adaptation, FV/RT basis and skeleton property tests

### DIFF
--- a/dune/gdt/local/discretefunction.hh
+++ b/dune/gdt/local/discretefunction.hh
@@ -68,13 +68,18 @@ public:
   using typename BaseType::SingleDerivativeRangeReturnType;
   using typename BaseType::SingleDerivativeRangeType;
 
+  // The space is held by reference (not copied): a stateful global basis (e.g. the Raviart-Thomas
+  // basis, whose localized view reads the space's per-element FE data) must see the *live* space,
+  // or every local function created before a grid adaptation reads stale data afterwards. The
+  // caller guarantees the space outlives this local function, as it already does for the DoF
+  // vector (whose mapper is the same space's).
   ConstLocalDiscreteFunction(const SpaceType& spc, const ConstDofVectorType& dof_vector)
     : BaseType()
-    , space_(spc.copy())
-    , space_is_fv_(space_->type() == GDT::SpaceType::finite_volume)
+    , space_(spc)
+    , space_is_fv_(space_.type() == GDT::SpaceType::finite_volume)
     , dof_vector_(dof_vector.localize())
-    , basis_(space_->basis().localize())
-    , basis_values_(space_is_fv_ ? 0 : space_->mapper().max_local_size())
+    , basis_(space_.basis().localize())
+    , basis_values_(space_is_fv_ ? 0 : space_.mapper().max_local_size())
     , dynamic_basis_values_(basis_values_.size())
     , basis_derivatives_(basis_values_.size())
     , dynamic_basis_derivatives_(basis_values_.size())
@@ -100,7 +105,7 @@ public:
 
   const SpaceType& space() const
   {
-    return *space_;
+    return space_;
   }
 
   const LocalBasisType& basis() const
@@ -290,7 +295,7 @@ public:
   /// \}
 
 private:
-  std::unique_ptr<const SpaceType> space_;
+  const SpaceType& space_;
   const bool space_is_fv_;
   ConstLocalDofVectorType dof_vector_;
   std::unique_ptr<LocalBasisType> basis_;

--- a/dune/gdt/spaces/interface.hh
+++ b/dune/gdt/spaces/interface.hh
@@ -195,8 +195,13 @@ public:
         // compute rhs for the L2 projection
         rhs += LocalElementIntegralFunctional<E, r, rC, R, R>(
                    /*order=*/
+                   // the integrand below is the *product* of a basis function and the restriction
+                   // data, so its polynomial degree is the sum of both orders; the previous max()
+                   // selected a quadrature that cannot integrate the product exactly (e.g. a
+                   // 1-point rule for the degree-2 product of two P1 functions), skewing the
+                   // projection (found by test_coarsening_restores_representable_polynomials)
                    [&](const auto& basis, const auto&) {
-                     return std::max(basis.order(), restriction_data_as_function_on_child_element.order());
+                     return basis.order() + restriction_data_as_function_on_child_element.order();
                    },
                    /*integrand_evaluation=*/
                    [&](const auto& basis, const auto& x, auto& result, const auto&) {

--- a/dune/gdt/spaces/interface.hh
+++ b/dune/gdt/spaces/interface.hh
@@ -202,8 +202,12 @@ public:
                    [&](const auto& basis, const auto& x, auto& result, const auto&) {
                      const auto restriction_data_value = restriction_data_as_function_on_child_element.evaluate(x);
                      basis.evaluate(x, child_basis_values);
+                     // result[ii], not result: assigning the DynamicVector directly fills *every* entry with
+                     // the ii-th integrand, leaving the whole rhs at the last basis function's value -- which
+                     // made this L2 projection return a constant for any space with more than one local DoF
+                     // (found by test_coarsening_restores_representable_polynomials)
                      for (size_t ii = 0; ii < basis.size(); ++ii)
-                       result = child_basis_values[ii] * restriction_data_value;
+                       result[ii] = child_basis_values[ii] * restriction_data_value;
                    })
                    .apply(element_basis_on_child_element);
       }

--- a/python/gdt/dune/gdt/discretefunction/bochner.cc
+++ b/python/gdt/dune/gdt/discretefunction/bochner.cc
@@ -69,10 +69,10 @@ public:
   {
     DUNE_THROW_IF(list_of_vectors.size() != bochner_space.temporal_space().mapper().size(),
                   XT::Common::Exceptions::wrong_input_given,
-                  "list_of_vectors does not match bochner_space:"
+                  "list_of_vectors does not match bochner_space (one vector per temporal DoF expected):"
                       << "\n"
-                      << "  bochner_space.spatial_space().mapper().size() = "
-                      << bochner_space.spatial_space().mapper().size() << "\n"
+                      << "  bochner_space.temporal_space().mapper().size() = "
+                      << bochner_space.temporal_space().mapper().size() << "\n"
                       << "  list_of_vectors.size() = " << list_of_vectors.size());
     auto vector_array =
         std::make_unique<XT::LA::ListVectorArray<V>>(/*dim=*/bochner_space.spatial_space().mapper().size(),

--- a/python/gdt/dune/gdt/discretefunction/bochner.cc
+++ b/python/gdt/dune/gdt/discretefunction/bochner.cc
@@ -113,6 +113,7 @@ public:
           for (py::handle list_element : list_of_vectors) {
             auto& vec = get_vec_ref(list_element);
             vector_array->append(vec, {{"_t", {time_points[counter]}}});
+            ++counter;
           }
           return new type(bochner_space, vector_array.release(), name);
         },
@@ -143,6 +144,7 @@ public:
             for (py::handle list_element : list_of_vectors) {
               auto& vec = get_vec_ref(list_element);
               vector_array->append(vec, {{"_t", {time_points[counter]}}});
+              ++counter;
             }
             return new type(bochner_space, vector_array.release(), name);
           },

--- a/python/gdt/dune/gdt/discretefunction/bochner.cc
+++ b/python/gdt/dune/gdt/discretefunction/bochner.cc
@@ -62,6 +62,32 @@ public:
                    << "  - [2]: " << XT::Common::Typename<V>::value() << "&");
   } // ... get_vec_ref(...)
 
+  // Shared body of the two list-of-vectors factory overloads below: interprets list_of_vectors
+  // as a ListVectorArray of correct length, annotating each vector with its temporal node.
+  static std::unique_ptr<XT::LA::ListVectorArray<V>> make_vector_array(const BS& bochner_space,
+                                                                       pybind11::list list_of_vectors)
+  {
+    DUNE_THROW_IF(list_of_vectors.size() != bochner_space.temporal_space().mapper().size(),
+                  XT::Common::Exceptions::wrong_input_given,
+                  "list_of_vectors does not match bochner_space:"
+                      << "\n"
+                      << "  bochner_space.spatial_space().mapper().size() = "
+                      << bochner_space.spatial_space().mapper().size() << "\n"
+                      << "  list_of_vectors.size() = " << list_of_vectors.size());
+    auto vector_array =
+        std::make_unique<XT::LA::ListVectorArray<V>>(/*dim=*/bochner_space.spatial_space().mapper().size(),
+                                                     /*length=*/0,
+                                                     /*reserve=*/bochner_space.temporal_space().mapper().size());
+    size_t counter = 0;
+    auto time_points = bochner_space.time_points();
+    for (pybind11::handle list_element : list_of_vectors) {
+      auto& vec = get_vec_ref(list_element);
+      vector_array->append(vec, {{"_t", {time_points[counter]}}});
+      ++counter;
+    }
+    return vector_array;
+  } // ... make_vector_array(...)
+
   static bound_type bind(pybind11::module& m,
                          const std::string& layer_id = "",
                          const std::string& grid_id = XT::Grid::bindings::grid_name<G>::value(),
@@ -96,26 +122,7 @@ public:
     m.def(
         XT::Common::to_camel_case(class_id).c_str(),
         [](const BS& bochner_space, py::list list_of_vectors, const MatchingVectorTag&, const std::string& name) {
-          // try to interprete list_of_vectors as a ListVectorArray of correct length
-          DUNE_THROW_IF(list_of_vectors.size() != bochner_space.temporal_space().mapper().size(),
-                        XT::Common::Exceptions::wrong_input_given,
-                        "list_of_vectors does not match bochner_space:"
-                            << "\n"
-                            << "  bochner_space.spatial_space().mapper().size() = "
-                            << bochner_space.spatial_space().mapper().size() << "\n"
-                            << "  list_of_vectors.size() = " << list_of_vectors.size());
-          auto vector_array =
-              std::make_unique<XT::LA::ListVectorArray<V>>(/*dim=*/bochner_space.spatial_space().mapper().size(),
-                                                           /*length=*/0,
-                                                           /*reserve=*/bochner_space.temporal_space().mapper().size());
-          size_t counter = 0;
-          auto time_points = bochner_space.time_points();
-          for (py::handle list_element : list_of_vectors) {
-            auto& vec = get_vec_ref(list_element);
-            vector_array->append(vec, {{"_t", {time_points[counter]}}});
-            ++counter;
-          }
-          return new type(bochner_space, vector_array.release(), name);
+          return new type(bochner_space, make_vector_array(bochner_space, list_of_vectors).release(), name);
         },
         "space"_a,
         "list_of_vectors"_a,
@@ -127,26 +134,7 @@ public:
       m.def(
           XT::Common::to_camel_case(class_id).c_str(),
           [](const BS& bochner_space, py::list list_of_vectors, const std::string& name, const MatchingVectorTag&) {
-            // try to interprete list_of_vectors as a ListVectorArray of correct length
-            DUNE_THROW_IF(list_of_vectors.size() != bochner_space.temporal_space().mapper().size(),
-                          XT::Common::Exceptions::wrong_input_given,
-                          "list_of_vectors does not match bochner_space:"
-                              << "\n"
-                              << "  bochner_space.spatial_space().mapper().size() = "
-                              << bochner_space.spatial_space().mapper().size() << "\n"
-                              << "  list_of_vectors.size() = " << list_of_vectors.size());
-            auto vector_array = std::make_unique<XT::LA::ListVectorArray<V>>(
-                /*dim=*/bochner_space.spatial_space().mapper().size(),
-                /*length=*/0,
-                /*reserve=*/bochner_space.temporal_space().mapper().size());
-            size_t counter = 0;
-            auto time_points = bochner_space.time_points();
-            for (py::handle list_element : list_of_vectors) {
-              auto& vec = get_vec_ref(list_element);
-              vector_array->append(vec, {{"_t", {time_points[counter]}}});
-              ++counter;
-            }
-            return new type(bochner_space, vector_array.release(), name);
+            return new type(bochner_space, make_vector_array(bochner_space, list_of_vectors).release(), name);
           },
           "space"_a,
           "list_of_vectors"_a,

--- a/python/gdt/dune/gdt/tools/adaptation-helper.cc
+++ b/python/gdt/dune/gdt/tools/adaptation-helper.cc
@@ -60,7 +60,10 @@ public:
   }
 
   GDT::FiniteVolumeSpace<GV, r, rC> marker_indices;
-  XT::LA::CommonDenseVector<size_t> markers;
+  // double-valued (not size_t) so coarsening can be requested with a negative marker, matching
+  // the -1/0/1 semantics of Grid::mark(); exposed to Python as the (buffer-compatible)
+  // CommonVector, so `np.array(helper.markers, copy=False)` keeps working
+  XT::LA::CommonDenseVector<double> markers;
 
   G& grid() // expose access for bindings below
   {
@@ -129,7 +132,7 @@ public:
             auto grid_view = self.grid().leafGridView();
             for (auto&& element : elements(grid_view))
               if (element.isNew())
-                self.markers[self.marker_indices.mapper().global_index(element, size_t(0))] = size_t(1);
+                self.markers[self.marker_indices.mapper().global_index(element, size_t(0))] = 1.;
           }
           // ... possibly cleaning up the grid
           self.post_adapt(post_adapt_grid, clear);
@@ -152,11 +155,14 @@ public:
           "dim_range"_a = XT::Grid::bindings::Dimension<r>(),
           "logging_prefix"_a = "");
     else if (std::is_same<VT, XT::LA::bindings::Istl>::value)
+      // dim_range before la_backend (and correctly named, they used to be swapped), so that
+      // `AdaptationHelper(grid, dim_range=Dim(d))` works for the vector-valued helper just like
+      // the other dim_range-dispatched factories
       m.def(
           FactoryName.c_str(),
           [](XT::Grid::GridProvider<G>& grid,
-             const VT&,
              const XT::Grid::bindings::Dimension<r>&,
+             const VT&,
              const std::string& logging_prefix) { return new type(grid.grid(), logging_prefix); },
           "grid"_a,
           "dim_range"_a,

--- a/python/gdt/test/test_hypothesis_bochner.py
+++ b/python/gdt/test/test_hypothesis_bochner.py
@@ -8,14 +8,16 @@
 # Authors:
 #   René Fritze (2026)
 # ~~~
-"""DiscreteBochnerFunction naming: the default-name fallback of the constructors.
+"""DiscreteBochnerFunction: constructor naming fallback and evaluation in time.
 
 A DiscreteBochnerFunction (dune/gdt/discretefunction/bochner.hh) pairs a spatial DoF vector per
 temporal node. Both the freshly-allocated factory (``make_discrete_bochner_function``) and the
 list-of-vectors factory feed the constructor's ``name.empty() ? "DiscreteBochnerFunction" : name``
 fallback; the existing call sites only ever pass a non-empty name, so the empty-string branch is
 never taken. Here both sides are exercised on hypothesis-generated grids: an explicit non-empty name
-is kept verbatim, while an empty name falls back to the class default.
+is kept verbatim, while an empty name falls back to the class default. evaluate(time) is pinned to
+its piecewise linear (P1-in-time) semantics, which also runs the temporal space's mapper through
+the DynamicVector-returning ``global_indices`` overload of the mapper interface.
 """
 
 import pytest
@@ -70,6 +72,56 @@ def test_empty_name_falls_back_to_the_class_default(spec, time_points):
     function = DiscreteBochnerFunction(bochner_space, name="")
     # an empty name takes the true branch of the fallback and yields the class default name.
     assert function.name == "DiscreteBochnerFunction"
+
+
+@given(
+    spec=grid_specs(max_elements_per_dim=2),
+    time_points=TIME_POINTS,
+    data=st.data(),
+)
+def test_evaluate_interpolates_linearly_in_time(spec, time_points, data):
+    """DiscreteBochnerFunction.evaluate(time) locates the temporal interval via the temporal
+    (order 1 Lagrange) space's mapper -- the DynamicVector-returning global_indices overload of
+    MapperInterface (dune/gdt/spaces/mapper/interfaces.hh), unreachable through any other
+    binding -- and combines the two adjacent spatial vectors with the P1 hat function weights,
+    i.e. linearly in time."""
+    import numpy as np
+
+    from dune.gdt import DiscreteBochnerFunction
+    from dune.xt.la import Istl, IstlVector
+
+    bochner_space = _bochner_space(spec, time_points)
+    num_spatial_dofs = len(
+        DiscreteBochnerFunction(bochner_space, name="probe").evaluate(0.0).dofs.vector
+    )
+    # one constant-valued spatial vector per time point, with drawn values
+    values = data.draw(
+        st.lists(
+            st.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+            min_size=len(time_points),
+            max_size=len(time_points),
+        ),
+        label="values",
+    )
+    vectors = [IstlVector(num_spatial_dofs, value) for value in values]
+    function = DiscreteBochnerFunction(bochner_space, vectors, Istl())
+
+    # at the time points themselves the stored vectors are reproduced ...
+    for time, value in zip(time_points, values, strict=True):
+        assert np.allclose(
+            np.array(function.evaluate(time).dofs.vector), value, atol=1e-10
+        )
+    # ... and inside a drawn interval the two adjacent vectors are combined linearly
+    index = data.draw(st.integers(0, len(time_points) - 2), label="interval")
+    ratio = data.draw(
+        st.floats(0.1, 0.9, allow_nan=False, allow_infinity=False), label="ratio"
+    )
+    time = time_points[index] + ratio * (time_points[index + 1] - time_points[index])
+    expected = (1 - ratio) * values[index] + ratio * values[index + 1]
+    scale = max(1.0, abs(expected))
+    assert np.allclose(
+        np.array(function.evaluate(time).dofs.vector), expected, atol=1e-9 * scale
+    )
 
 
 if __name__ == "__main__":

--- a/python/gdt/test/test_hypothesis_bochner.py
+++ b/python/gdt/test/test_hypothesis_bochner.py
@@ -91,9 +91,7 @@ def test_evaluate_interpolates_linearly_in_time(spec, time_points, data):
     from dune.xt.la import Istl, IstlVector
 
     bochner_space = _bochner_space(spec, time_points)
-    num_spatial_dofs = len(
-        DiscreteBochnerFunction(bochner_space, name="probe").evaluate(0.0).dofs.vector
-    )
+    num_spatial_dofs = bochner_space.spatial_space.num_DoFs
     # one constant-valued spatial vector per time point, with drawn values
     values = data.draw(
         st.lists(

--- a/python/gdt/test/test_hypothesis_spaces.py
+++ b/python/gdt/test/test_hypothesis_spaces.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import textwrap
 
+import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -307,6 +308,272 @@ def test_a_space_keeps_its_grid_alive(dim, element, impl):
         f"exit code {result.returncode} (negative means the interpreter was killed by that "
         f"signal, i.e. the space outlived its grid)\n{result.stderr}"
     )
+
+
+@given(spec=grid_specs(conforming_only=True))
+def test_skeleton_fv_space_has_one_dof_per_intersection(spec):
+    """The FiniteVolumeSkeletonSpace attaches exactly one DoF to every codim-1 entity (its
+    mapper is the FiniteVolumeSkeletonMapper over the intersection index set), and it reports
+    the fixed structural properties encoded in dune/gdt/spaces/skeleton/finite-volume.hh:
+    piecewise constant (polorder 0), discontinuous, nominally lagrangian. conforming_only:
+    on a non-conforming leaf view codim-1 entities and intersections do not coincide."""
+    from dune.gdt import FiniteVolumeSkeletonSpace
+
+    grid = spec.make_grid()
+    space = FiniteVolumeSkeletonSpace(grid)
+    assert space.num_DoFs == grid.size(1)
+    assert space.min_polorder == space.max_polorder == 0
+    assert space.continuous(0) is False
+    assert space.is_lagrangian is True
+    assert space.dimDomain == spec.dim
+    assert space.type == "finite_volume_skeleton"
+    assert repr(space) == f"Space(finite_volume_skeleton, {space.num_DoFs} DoFs)"
+
+
+@given(spec=grid_specs(conforming_only=True))
+def test_rt0_space_has_one_dof_per_facet(spec):
+    """The lowest-order Raviart-Thomas space has exactly one (normal-flux) DoF per codim-1
+    entity; together with the properties block this pins the RT mapper and the structural
+    methods of dune/gdt/spaces/hdiv/raviart-thomas.hh across all conforming grids."""
+    from dune.gdt import RaviartThomasSpace
+
+    grid = spec.make_grid()
+    space = RaviartThomasSpace(grid, order=0)
+    assert space.num_DoFs == grid.size(1)
+    assert space.min_polorder == space.max_polorder == 0
+    assert space.continuous(0) is False
+    assert space.is_lagrangian is False
+    assert space.type == "raviart_thomas"
+
+
+@_needs_vector_grid
+@given(spec=grid_specs(dims=(2, 3), max_elements_per_dim=3), data=st.data())
+def test_vector_fv_space_attaches_r_dofs_per_element(spec, data):
+    """A vector-valued FiniteVolumeSpace attaches dim_range DoFs to every element (the
+    FiniteVolumeMapper's r * rC block); building the element sparsity pattern additionally
+    walks that mapper's global_indices for every element."""
+    from dune.gdt import FiniteVolumeSpace, make_element_sparsity_pattern
+    from dune.xt.grid import Dim
+
+    r = data.draw(st.sampled_from([2, spec.dim]), label="dim_range")
+    grid = spec.make_grid()
+    try:
+        space = FiniteVolumeSpace(grid, dim_range=Dim(r))
+    except TypeError:
+        pytest.skip("this build has no vector-valued FV factory")
+    assert space.num_DoFs == r * grid.size(0)
+    assert space.min_polorder == space.max_polorder == 0
+    assert make_element_sparsity_pattern(space) is not None
+
+
+@given(spec=grid_specs(), data=st.data())
+def test_fv_interpolation_is_cell_averaging(spec, data):
+    """Interpolating into a FiniteVolumeSpace runs the FiniteVolumeGlobalBasis' interpolate
+    (an element integral divided by the volume, dune/gdt/spaces/basis/finite-volume.hh); on
+    the affine elements of a structured grid the cell average of an affine function is its
+    value at the element's centroid, which the grid exposes as centers(0)."""
+    from dune.gdt import FiniteVolumeSpace, default_interpolation
+    from dune.xt.functions import GridFunction
+    from dune.xt.test.hypothesis_strategies import polynomials
+
+    poly = data.draw(polynomials(spec.dim, max_order=1, min_order=0), label="poly")
+    grid = spec.make_grid()
+    space = FiniteVolumeSpace(grid)
+    u_h = default_interpolation(GridFunction(grid, poly.to_function()), space)
+    centers = np.array(grid.centers(0), copy=True)
+    expected = poly(centers)
+    scale = max(1.0, np.abs(expected).max())
+    assert np.allclose(np.array(u_h.dofs.vector), expected, atol=1e-12 * scale)
+
+
+@given(spec=grid_specs(), data=st.data())
+def test_fv_functions_have_zero_weak_gradient(spec, data):
+    """A piecewise constant function has vanishing element-local gradients: the Laplace form
+    applied to an FV discrete function must be exactly zero. This runs the
+    FiniteVolumeGlobalBasis' jacobians (which write out zeros), while the L2 product of the
+    same function runs its evaluate (constant one) -- and scales quadratically."""
+    from dune.gdt import (
+        BilinearForm,
+        FiniteVolumeSpace,
+        LocalElementIntegralBilinearForm,
+        LocalElementProductIntegrand,
+        LocalLaplaceIntegrand,
+        default_interpolation,
+    )
+    from dune.xt.functions import GridFunction
+    from dune.xt.test.hypothesis_strategies import polynomials
+
+    poly = data.draw(polynomials(spec.dim, max_order=1, min_order=0), label="poly")
+    grid = spec.make_grid()
+    space = FiniteVolumeSpace(grid)
+    u_h = default_interpolation(GridFunction(grid, poly.to_function()), space)
+    u = GridFunction(grid, u_h)
+
+    # the 1d bindings model the (1x1 matrix valued) diffusion as a scalar grid function
+    if spec.dim == 1:
+        diffusion = GridFunction(grid, 1.0)
+    else:
+        eye = [
+            [1.0 if ii == jj else 0.0 for jj in range(spec.dim)]
+            for ii in range(spec.dim)
+        ]
+        diffusion = GridFunction(grid, eye)
+    laplace = BilinearForm(grid)
+    laplace += LocalElementIntegralBilinearForm(LocalLaplaceIntegrand(diffusion))
+    assert laplace.apply2(u, u) == 0.0
+
+    l2 = BilinearForm(grid)
+    l2 += LocalElementIntegralBilinearForm(
+        LocalElementProductIntegrand(GridFunction(grid, 1.0))
+    )
+    norm_squared = l2.apply2(u, u)
+    assert norm_squared >= 0.0
+    # apply2 is bilinear: scaling the DoFs by 2 scales the product by 4
+    vec = u_h.dofs.vector
+    for ii in range(len(vec)):
+        vec[ii] = 2.0 * vec[ii]
+    assert np.isclose(l2.apply2(u, u), 4.0 * norm_squared, rtol=1e-12, atol=1e-12)
+
+
+@given(spec=grid_specs(max_elements_per_dim=3), data=st.data())
+def test_fv_mass_matrix_is_diagonal_of_cell_volumes(spec, data):
+    """Assembling the L2 product on a FiniteVolumeSpace evaluates the FiniteVolumeGlobalBasis
+    itself (unlike the discrete-function properties above, which go through the FV shortcut of
+    ConstLocalDiscreteFunction): each basis function is the indicator of its element, so the
+    mass matrix acts as the diagonal of the cell volumes -- and the Laplace matrix, driven by
+    the basis' (zero) jacobians, annihilates everything. Checked through matrix-vector
+    products with a drawn probe vector."""
+    from dune.gdt import (
+        BilinearForm,
+        FiniteVolumeSpace,
+        LocalElementIntegralBilinearForm,
+        LocalElementProductIntegrand,
+        LocalLaplaceIntegrand,
+        MatrixOperator,
+        make_element_sparsity_pattern,
+    )
+    from dune.xt.functions import GridFunction
+    from dune.xt.la import IstlVector
+
+    grid = spec.make_grid()
+    space = FiniteVolumeSpace(grid)
+
+    def assemble(integrand):
+        form = BilinearForm(grid)
+        form += LocalElementIntegralBilinearForm(integrand)
+        op = MatrixOperator(
+            grid,
+            source_space=space,
+            range_space=space,
+            sparsity_pattern=make_element_sparsity_pattern(space),
+        )
+        op.append(form)
+        op.assemble()
+        return op.matrix
+
+    def apply_to(matrix, values):
+        vec = IstlVector(len(values), 0.0)
+        for ii, value in enumerate(values):
+            vec.set_entry(ii, float(value))
+        result = IstlVector(len(values), 0.0)
+        matrix.mv(vec, result)
+        return np.array(result, copy=True)
+
+    probe = data.draw(
+        st.lists(
+            st.floats(-1.0, 1.0, allow_nan=False, allow_infinity=False),
+            min_size=space.num_DoFs,
+            max_size=space.num_DoFs,
+        ),
+        label="probe",
+    )
+    volumes = []
+    grid.apply_on_each_element(lambda element: volumes.append(element.volume))
+
+    mass = assemble(LocalElementProductIntegrand(GridFunction(grid, 1.0)))
+    expected = np.asarray(volumes) * np.asarray(probe)
+    scale = max(1.0, np.abs(expected).max())
+    assert np.allclose(apply_to(mass, probe), expected, atol=1e-13 * scale)
+
+    if spec.dim == 1:
+        diffusion = GridFunction(grid, 1.0)
+    else:
+        eye = [
+            [1.0 if ii == jj else 0.0 for jj in range(spec.dim)]
+            for ii in range(spec.dim)
+        ]
+        diffusion = GridFunction(grid, eye)
+    laplace = assemble(LocalLaplaceIntegrand(diffusion))
+    assert not apply_to(laplace, probe).any()
+
+
+@_needs_simplex
+@given(spec=grid_specs(elements=("simplex",), conforming_only=True), data=st.data())
+def test_rt0_products_are_quadratic_forms(spec, data):
+    """L2 and H1-semi products of an RT0 discrete function run the RaviartThomasGlobalBasis'
+    evaluate (Piola transform, flip/scaling) resp. jacobians (the transformed shape function
+    gradients); both must behave as quadratic forms under scaling of the DoF vector."""
+    import dune.gdt
+    from dune.gdt import (
+        BilinearForm,
+        DiscreteFunction,
+        LocalElementIntegralBilinearForm,
+        LocalElementProductIntegrand,
+        LocalLaplaceIntegrand,
+        RaviartThomasSpace,
+    )
+    from dune.xt.functions import GridFunction
+    from dune.xt.grid import Dim
+
+    d = spec.dim
+    grid = spec.make_grid()
+    space = RaviartThomasSpace(grid, order=0)
+    u_h = DiscreteFunction(space, name="q")
+    vec = u_h.dofs.vector
+    dofs = data.draw(
+        st.lists(
+            st.floats(-10.0, 10.0, allow_nan=False, allow_infinity=False),
+            min_size=len(vec),
+            max_size=len(vec),
+        ),
+        label="dofs",
+    )
+    for ii, value in enumerate(dofs):
+        vec[ii] = value
+
+    if d == 1:
+        u = GridFunction(grid, u_h)
+        weight = GridFunction(grid, 1.0)
+        l2_form = BilinearForm(grid)
+        h1_form = BilinearForm(grid)
+        # the 1d bindings model the (1x1 matrix valued) diffusion as a scalar grid function
+        laplace = LocalLaplaceIntegrand(GridFunction(grid, 1.0))
+    else:
+        u = GridFunction(grid, u_h, dim_range=Dim(d))
+        eye = [[1.0 if ii == jj else 0.0 for jj in range(d)] for ii in range(d)]
+        eye_function = GridFunction(grid, eye)
+        weight = eye_function
+        try:
+            l2_form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
+            h1_form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
+        except TypeError:
+            impl = "".join(w.capitalize() for w in spec.impl.split("_"))
+            cls = getattr(
+                dune.gdt, f"BilinearForm{d}dSimplex{impl}Leaf{d}dRange{d}dSource"
+            )
+            l2_form, h1_form = cls(grid), cls(grid)
+        laplace = LocalLaplaceIntegrand(eye_function, dim_range_bases=Dim(d))
+    l2_form += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(weight))
+    h1_form += LocalElementIntegralBilinearForm(laplace)
+
+    l2 = l2_form.apply2(u, u)
+    h1_semi = h1_form.apply2(u, u)
+    assert l2 >= 0.0
+    assert h1_semi >= 0.0
+    for ii in range(len(vec)):
+        vec[ii] = 2.0 * vec[ii]
+    assert np.isclose(l2_form.apply2(u, u), 4.0 * l2, rtol=1e-10, atol=1e-10)
+    assert np.isclose(h1_form.apply2(u, u), 4.0 * h1_semi, rtol=1e-10, atol=1e-10)
 
 
 @given(data=st.data(), spec=grid_specs(max_elements_per_dim=3))

--- a/python/gdt/test/test_hypothesis_spaces.py
+++ b/python/gdt/test/test_hypothesis_spaces.py
@@ -557,10 +557,14 @@ def test_rt0_products_are_quadratic_forms(spec, data):
             l2_form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
             h1_form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
         except TypeError:
+            # builds predating the (ansatz_range, test_range) factory overloads still bind
+            # the class itself under its camel-cased name (verified against those wheels)
             impl = "".join(w.capitalize() for w in spec.impl.split("_"))
             cls = getattr(
-                dune.gdt, f"BilinearForm{d}dSimplex{impl}Leaf{d}dRange{d}dSource"
+                dune.gdt, f"BilinearForm{d}dSimplex{impl}Leaf{d}dRange{d}dSource", None
             )
+            if cls is None:
+                pytest.skip("this build has no vector-valued BilinearForm binding")
             l2_form, h1_form = cls(grid), cls(grid)
         laplace = LocalLaplaceIntegrand(eye_function, dim_range_bases=Dim(d))
     l2_form += LocalElementIntegralBilinearForm(LocalElementProductIntegrand(weight))

--- a/python/gdt/test/test_hypothesis_spaces_adaptation.py
+++ b/python/gdt/test/test_hypothesis_spaces_adaptation.py
@@ -1,0 +1,471 @@
+# ~~~
+# This file is part of the dune-gdt project:
+#   https://github.com/dune-gdt/dune-gdt
+# Copyright 2010-2026 dune-gdt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+"""Grid adaptation drives the spaces' restrict/prolong machinery (dune/gdt/spaces/interface.hh).
+
+The pre_adapt/adapt/post_adapt cycle of the AdaptationHelper is the only route through
+SpaceInterface::restrict_to / prolong_onto and through the backup/restore machinery of the
+global bases (dune/gdt/spaces/basis/): nothing else in the Python or C++ test suites ever
+adapts a grid underneath a space, which left that code (and the mappers'
+update_after_adapt) essentially uncovered. The properties here are exactness statements:
+refining or coarsening a grid must not change a discrete function that the space can
+represent exactly, so the prolonged/restricted DoF vectors are pinned against a fresh
+interpolation of the same polynomial on the adapted grid.
+
+The AdaptationHelper is only instantiated for the adaptive grids (OneDGrid and the
+conforming ALU simplex grids); YaspGrid is excluded upstream (its PersistentContainer is
+known to segfault, see dune/gdt/tools/adaptation-helper.hh).
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from dune.xt.test.hypothesis_strategies import (
+    GRID_BINDINGS,
+    GridSpec,
+    fv_mass,
+    has_gdt_bindings,
+    polynomials,
+)
+
+# The helper binds ONED_1D and the conforming ALU simplex grids (AvailableAdaptiveGridTypes in
+# python/gdt/dune/gdt/tools/adaptation-helper.cc); intersect with what this build provides.
+_ADAPTIVE_IMPLS = ("onedgrid", "aluconformgrid")
+ADAPTIVE_GRIDS = tuple(b for b in GRID_BINDINGS if b.impl in _ADAPTIVE_IMPLS)
+
+pytestmark = pytest.mark.skipif(
+    not ADAPTIVE_GRIDS or not has_gdt_bindings("AdaptationHelper"),
+    reason="no adaptive grid bindings available in this build",
+)
+
+
+@st.composite
+def adaptive_grid_specs(draw, dims=(1, 2, 3), max_elements_per_dim=2):
+    """A GridSpec for one of the adaptation-capable grids, on the unit box.
+
+    The unit box keeps the L2 projections behind restrict_to well conditioned; the geometry
+    itself is not the property under test here. max_elements_per_dim stays small because each
+    example runs several full adaptation cycles on 1-3 appended spaces.
+    """
+    binding = draw(st.sampled_from([b for b in ADAPTIVE_GRIDS if b.dim in dims]))
+    num_elements = draw(
+        st.tuples(*[st.integers(1, max_elements_per_dim) for _ in range(binding.dim)])
+    )
+    return GridSpec(
+        dim=binding.dim,
+        element=binding.element,
+        lower_left=(0.0,) * binding.dim,
+        upper_right=(1.0,) * binding.dim,
+        num_elements=num_elements,
+        impl=binding.impl,
+    )
+
+
+def _make_helper(grid, dim_range):
+    """An AdaptationHelper for the given range dimension, tolerant of the old factory.
+
+    The vector-valued factory used to register its dim_range/la_backend keyword names swapped
+    (fixed alongside these tests), so fall back to the old positional order if the keyword call
+    is rejected -- that keeps the suite runnable against wheels predating the fix.
+    """
+    from dune.gdt import AdaptationHelper
+    from dune.xt.grid import Dim
+    from dune.xt.la import Istl
+
+    if dim_range == 1:
+        return AdaptationHelper(grid)
+    try:
+        return AdaptationHelper(grid, dim_range=Dim(dim_range))
+    except TypeError:
+        return AdaptationHelper(grid, Istl(), Dim(dim_range))
+
+
+def _supports_signed_markers(helper):
+    """Whether the markers vector can hold the -1 that requests coarsening.
+
+    Before the fix that accompanies these tests the helper stored size_t markers, so
+    coarsening was not expressible from Python at all (and the restrict_to code below it was
+    unreachable).
+    """
+    return "SizeT" not in type(helper.markers).__name__
+
+
+def _mark(helper, element_indices, dim_range, value):
+    """Set the marker of the given elements to value (the markers vector holds r entries per
+    element, see the marker_indices FiniteVolumeSpace in the binding)."""
+    markers = helper.markers
+    for index in element_indices:
+        markers[index * dim_range] = value
+    helper.mark()
+
+
+def _refinement_markers(draw, num_elements):
+    """A non-empty subset of element indices to refine."""
+    return draw(
+        st.sets(
+            st.integers(0, num_elements - 1), min_size=1, max_size=min(num_elements, 4)
+        )
+    )
+
+
+def _scalar_function(poly):
+    return poly.to_function()
+
+
+def _interpolate(grid, function, space, dim_range=1):
+    from dune.gdt import default_interpolation
+    from dune.xt.functions import GridFunction
+    from dune.xt.grid import Dim
+
+    if dim_range == 1:
+        return default_interpolation(GridFunction(grid, function), space)
+    return default_interpolation(
+        GridFunction(grid, function, dim_range=Dim(dim_range)), space
+    )
+
+
+def _adaptation_cycle(helper, marked, dim_range=1, value=1):
+    _mark(helper, marked, dim_range, value)
+    helper.pre_adapt()
+    helper.adapt()
+    helper.post_adapt()
+
+
+@settings(max_examples=10)
+@given(spec=adaptive_grid_specs(), data=st.data())
+def test_cg_prolongation_preserves_representable_polynomials(spec, data):
+    """Refinement must reproduce any function the coarse CG space could already represent:
+    SpaceInterface::prolong_onto interpolates the father's data on each new element, which is
+    exact for polynomials of degree <= order. Pins prolong_onto (both the isNew and the
+    unchanged-element branch) plus the ContinuousMapper/DefaultGlobalBasis update_after_adapt.
+    """
+    from dune.gdt import ContinuousLagrangeSpace
+
+    # the ContinuousMapper supports order <= 2 on the simplicial grids (see
+    # test_hypothesis_spaces._cg_orders)
+    order = data.draw(st.integers(1, 2), label="order")
+    poly = data.draw(
+        polynomials(spec.dim, max_order=order, coefficient_bound=10.0), label="poly"
+    )
+    grid = spec.make_grid()
+    space = ContinuousLagrangeSpace(grid, order=order)
+    u_h = _interpolate(grid, _scalar_function(poly), space)
+
+    helper = _make_helper(grid, 1)
+    helper.append(space, u_h)
+    marked = _refinement_markers(data.draw, grid.size(0))
+    _adaptation_cycle(helper, marked)
+
+    fresh = _interpolate(
+        grid, _scalar_function(poly), ContinuousLagrangeSpace(grid, order=order)
+    )
+    scale = max(1.0, np.abs(np.array(fresh.dofs.vector)).max())
+    assert np.allclose(
+        np.array(u_h.dofs.vector), np.array(fresh.dofs.vector), atol=1e-9 * scale
+    )
+
+
+@settings(max_examples=10)
+@given(spec=adaptive_grid_specs(), data=st.data())
+def test_dg_prolongation_preserves_representable_polynomials(spec, data):
+    """The DG analogue of the CG property above; additionally pins the DiscontinuousMapper's
+    update_after_adapt (scalar branch) which recomputes the per-element DoF offsets."""
+    from dune.gdt import DiscontinuousLagrangeSpace
+
+    order = data.draw(st.integers(0, 2), label="order")
+    poly = data.draw(
+        polynomials(spec.dim, max_order=order, coefficient_bound=10.0), label="poly"
+    )
+    grid = spec.make_grid()
+    space = DiscontinuousLagrangeSpace(grid, order=order)
+    u_h = _interpolate(grid, _scalar_function(poly), space)
+
+    helper = _make_helper(grid, 1)
+    helper.append(space, u_h)
+    marked = _refinement_markers(data.draw, grid.size(0))
+    _adaptation_cycle(helper, marked)
+
+    fresh = _interpolate(
+        grid, _scalar_function(poly), DiscontinuousLagrangeSpace(grid, order=order)
+    )
+    scale = max(1.0, np.abs(np.array(fresh.dofs.vector)).max())
+    assert np.allclose(
+        np.array(u_h.dofs.vector), np.array(fresh.dofs.vector), atol=1e-9 * scale
+    )
+
+
+@settings(max_examples=10)
+@given(spec=adaptive_grid_specs(), data=st.data())
+def test_fv_prolongation_copies_father_values_and_conserves_mass(spec, data):
+    """FiniteVolumeSpace overrides prolong_onto with a plain copy from the father element, so
+    refinement changes neither the set of DoF values nor the discrete integral (mass)."""
+    from dune.gdt import FiniteVolumeSpace
+
+    poly = data.draw(
+        polynomials(spec.dim, max_order=1, coefficient_bound=10.0), label="poly"
+    )
+    grid = spec.make_grid()
+    space = FiniteVolumeSpace(grid)
+    u_h = _interpolate(grid, _scalar_function(poly), space)
+    old_values = np.array(u_h.dofs.vector, copy=True)
+    old_mass = fv_mass(u_h, grid)
+
+    helper = _make_helper(grid, 1)
+    helper.append(space, u_h)
+    marked = _refinement_markers(data.draw, grid.size(0))
+    _adaptation_cycle(helper, marked)
+
+    new_values = np.array(u_h.dofs.vector)
+    assert space.num_DoFs == grid.size(0) == len(new_values)
+    # children copy their father's DoF bit-exactly, unchanged elements keep theirs
+    assert set(new_values).issubset(set(old_values))
+    assert np.isclose(fv_mass(u_h, grid), old_mass, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.skipif(
+    not any(b.dim > 1 for b in ADAPTIVE_GRIDS),
+    reason="no multi-dimensional adaptive grid bindings available in this build",
+)
+@settings(max_examples=10)
+@given(spec=adaptive_grid_specs(dims=(2, 3)), data=st.data())
+def test_vector_dg_dimwise_mapper_survives_adaptation(spec, data):
+    """A vector-valued DG space defaults to the dimension-wise DoF numbering, so adapting it
+    runs DiscontinuousMapper::update_after_adapt through its per-range-dimension (else)
+    branches -- unreachable from the scalar tests. The exactness property is the same as in
+    the scalar DG test, per component."""
+    from dune.gdt import DiscontinuousLagrangeSpace
+    from dune.xt.functions import ExpressionFunction
+    from dune.xt.grid import Dim
+
+    r = spec.dim
+    order = data.draw(st.integers(0, 1), label="order")
+    components = [
+        data.draw(
+            polynomials(spec.dim, max_order=order, coefficient_bound=10.0),
+            label=f"poly[{i}]",
+        )
+        for i in range(r)
+    ]
+    function = ExpressionFunction(
+        dim_domain=Dim(spec.dim),
+        variable="x",
+        expressions=[p.expression() for p in components],
+        order=order,
+        name="v",
+    )
+    grid = spec.make_grid()
+
+    def make_space():
+        return DiscontinuousLagrangeSpace(grid, order=order, dim_range=Dim(r))
+
+    try:
+        space = make_space()
+    except TypeError:
+        pytest.skip("this build has no vector-valued DG factory")
+    assert space.dimwise_global_mapping is True
+    u_h = _interpolate(grid, function, space, dim_range=r)
+
+    helper = _make_helper(grid, r)
+    helper.append(space, u_h)
+    marked = _refinement_markers(data.draw, grid.size(0))
+    _adaptation_cycle(helper, marked, dim_range=r)
+
+    fresh = _interpolate(grid, function, make_space(), dim_range=r)
+    scale = max(1.0, np.abs(np.array(fresh.dofs.vector)).max())
+    assert np.allclose(
+        np.array(u_h.dofs.vector), np.array(fresh.dofs.vector), atol=1e-9 * scale
+    )
+
+
+def _vector_l2_form(grid, spec):
+    """A BilinearForm with the L2 product integrand for dim-valued functions, tolerant of
+    builds predating the (ansatz_range, test_range) factory overloads."""
+    import dune.gdt
+    from dune.gdt import (
+        BilinearForm,
+        LocalElementIntegralBilinearForm,
+        LocalElementProductIntegrand,
+    )
+    from dune.xt.functions import GridFunction
+    from dune.xt.grid import Dim
+
+    d = spec.dim
+    if d == 1:
+        form = BilinearForm(grid)
+        integrand = LocalElementProductIntegrand(GridFunction(grid, 1.0))
+    else:
+        try:
+            form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
+        except TypeError:
+            impl = "".join(w.capitalize() for w in spec.impl.split("_"))
+            cls = getattr(
+                dune.gdt,
+                f"BilinearForm{d}dSimplex{impl}Leaf{d}dRange{d}dSource",
+            )
+            form = cls(grid)
+        eye = [[1.0 if ii == jj else 0.0 for jj in range(d)] for ii in range(d)]
+        integrand = LocalElementProductIntegrand(GridFunction(grid, eye))
+    form += LocalElementIntegralBilinearForm(integrand)
+    return form
+
+
+def _as_grid_function(grid, discrete_function, dim_range):
+    from dune.xt.functions import GridFunction
+    from dune.xt.grid import Dim
+
+    if dim_range == 1:
+        return GridFunction(grid, discrete_function)
+    return GridFunction(grid, discrete_function, dim_range=Dim(dim_range))
+
+
+@settings(max_examples=10)
+@given(spec=adaptive_grid_specs(), data=st.data())
+def test_rt_prolongation_preserves_the_function(spec, data):
+    """RT0 is affine-invariant, so the father's function restricted to a child is again a
+    local RT0 function and prolongation (RT basis interpolate/evaluate + backup/restore, the
+    bulk of dune/gdt/spaces/basis/raviart-thomas.hh) must reproduce it exactly -- checked via
+    the L2 norm, which the bindings expose through BilinearForm.apply2. Broken before the
+    accompanying fix: ConstLocalDiscreteFunction held a *copy* of the space, so the stored
+    local functions read the pre-adaptation RT FE data."""
+    from dune.gdt import DiscreteFunction, RaviartThomasSpace
+
+    grid = spec.make_grid()
+    space = RaviartThomasSpace(grid, order=0)
+    u_h = DiscreteFunction(space, name="q")
+    vector = u_h.dofs.vector
+    dof_values = data.draw(
+        st.lists(
+            st.floats(-10.0, 10.0, allow_nan=False, allow_infinity=False),
+            min_size=len(vector),
+            max_size=len(vector),
+        ),
+        label="dofs",
+    )
+    for ii, value in enumerate(dof_values):
+        vector[ii] = value
+    l2_before = _vector_l2_form(grid, spec).apply2(
+        _as_grid_function(grid, u_h, spec.dim), _as_grid_function(grid, u_h, spec.dim)
+    )
+
+    helper = _make_helper(grid, spec.dim)
+    helper.append(space, u_h)
+    marked = _refinement_markers(data.draw, grid.size(0))
+    _adaptation_cycle(helper, marked, dim_range=spec.dim)
+
+    assert space.num_DoFs == len(u_h.dofs.vector)
+    l2_after = _vector_l2_form(grid, spec).apply2(
+        _as_grid_function(grid, u_h, spec.dim), _as_grid_function(grid, u_h, spec.dim)
+    )
+    assert np.isclose(l2_after, l2_before, rtol=1e-8, atol=1e-10)
+
+
+@settings(max_examples=10)
+@given(spec=adaptive_grid_specs(), data=st.data())
+def test_coarsening_restores_representable_polynomials(spec, data):
+    """Coarsening runs SpaceInterface::restrict_to (an element-local L2 projection) resp. the
+    FiniteVolumeSpace override (a volume-weighted average); for a function the coarse space
+    can represent exactly, both are exact. Refine everything, then coarsen everything, and pin
+    the result against a fresh interpolation on whatever grid the coarsening produced."""
+    from dune.gdt import (
+        ContinuousLagrangeSpace,
+        DiscontinuousLagrangeSpace,
+        FiniteVolumeSpace,
+    )
+
+    kind = data.draw(st.sampled_from(["cg", "dg", "fv"]), label="kind")
+    order = {"cg": 1, "dg": data.draw(st.integers(0, 1), label="order"), "fv": 0}[kind]
+    # the polynomial must be representable in the *space* for restriction to be exact -- except
+    # for FV, whose restriction (volume-weighted averaging of exact cell averages) is exact for
+    # any function the fine interpolation integrated exactly
+    poly = data.draw(
+        polynomials(spec.dim, max_order=1 if kind == "fv" else order),
+        label="poly",
+    )
+
+    def make_space(grid):
+        if kind == "cg":
+            return ContinuousLagrangeSpace(grid, order=order)
+        if kind == "dg":
+            return DiscontinuousLagrangeSpace(grid, order=order)
+        return FiniteVolumeSpace(grid)
+
+    grid = spec.make_grid()
+    space = make_space(grid)
+    u_h = _interpolate(grid, _scalar_function(poly), space)
+
+    helper = _make_helper(grid, 1)
+    if not _supports_signed_markers(helper):
+        pytest.skip("this build's AdaptationHelper cannot mark for coarsening")
+    helper.append(space, u_h)
+    # refine everything, so there is something to coarsen ...
+    _adaptation_cycle(helper, range(grid.size(0)))
+    # ... then coarsen everything
+    _adaptation_cycle(helper, range(grid.size(0)), value=-1)
+
+    fresh = _interpolate(grid, _scalar_function(poly), make_space(grid))
+    assert space.num_DoFs == len(fresh.dofs.vector)
+    scale = max(1.0, np.abs(np.array(fresh.dofs.vector)).max())
+    # restriction solves small element-local L2 systems, so allow for a little more noise
+    # than the pure-interpolation properties above
+    assert np.allclose(
+        np.array(u_h.dofs.vector), np.array(fresh.dofs.vector), atol=1e-7 * scale
+    )
+
+
+@settings(max_examples=5)
+@given(spec=adaptive_grid_specs())
+def test_skeleton_space_prolongation_is_not_implemented(spec):
+    """FiniteVolumeSkeletonSpace deliberately throws in prolong_onto (and updates its mapper
+    and basis in update_after_adapt on the way there) -- the documented not-implemented
+    contract, pinned here so silently wrong prolongations cannot appear instead."""
+    from dune.gdt import DiscreteFunction, FiniteVolumeSkeletonSpace
+    from dune.xt.common import DuneError
+
+    grid = spec.make_grid()
+    space = FiniteVolumeSkeletonSpace(grid)
+    u_h = DiscreteFunction(space, name="s")
+    helper = _make_helper(grid, 1)
+    helper.append(space, u_h)
+    _mark(helper, range(grid.size(0)), 1, 1)
+    helper.pre_adapt()
+    with pytest.raises(DuneError, match="[Nn]ot implemented"):
+        helper.adapt()
+
+
+@settings(max_examples=5)
+@given(spec=adaptive_grid_specs())
+def test_skeleton_space_restriction_is_not_implemented(spec):
+    """The restrict_to counterpart of the property above: refine first (without the skeleton
+    space appended, since its prolongation throws), then request coarsening with the skeleton
+    space appended -- pre_adapt must hit its not-implemented restrict_to."""
+    from dune.gdt import DiscreteFunction, FiniteVolumeSkeletonSpace
+    from dune.xt.common import DuneError
+
+    grid = spec.make_grid()
+    helper = _make_helper(grid, 1)
+    if not _supports_signed_markers(helper):
+        pytest.skip("this build's AdaptationHelper cannot mark for coarsening")
+    # refine with no space appended, purely to create coarsenable elements
+    _adaptation_cycle(helper, range(grid.size(0)))
+
+    space = FiniteVolumeSkeletonSpace(grid)
+    u_h = DiscreteFunction(space, name="s")
+    helper.append(space, u_h)
+    _mark(helper, range(grid.size(0)), 1, -1)
+    with pytest.raises(DuneError, match="[Nn]ot implemented"):
+        helper.pre_adapt()
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)

--- a/python/gdt/test/test_hypothesis_spaces_adaptation.py
+++ b/python/gdt/test/test_hypothesis_spaces_adaptation.py
@@ -86,7 +86,12 @@ def _make_helper(grid, dim_range):
     try:
         return AdaptationHelper(grid, dim_range=Dim(dim_range))
     except TypeError:
+        pass
+    try:
         return AdaptationHelper(grid, Istl(), Dim(dim_range))
+    except TypeError:
+        # neither the fixed nor the old-swapped signature exists -> no vector-valued helper
+        pytest.skip("this build has no vector-valued AdaptationHelper")
 
 
 def _supports_signed_markers(helper):
@@ -306,11 +311,16 @@ def _vector_l2_form(grid, spec):
         try:
             form = BilinearForm(grid, ansatz_range=Dim(d), test_range=Dim(d))
         except TypeError:
+            # builds predating the (ansatz_range, test_range) factory overloads still bind
+            # the class itself under its camel-cased name (verified against those wheels)
             impl = "".join(w.capitalize() for w in spec.impl.split("_"))
             cls = getattr(
                 dune.gdt,
                 f"BilinearForm{d}dSimplex{impl}Leaf{d}dRange{d}dSource",
+                None,
             )
+            if cls is None:
+                pytest.skip("this build has no vector-valued BilinearForm binding")
             form = cls(grid)
         eye = [[1.0 if ii == jj else 0.0 for jj in range(d)] for ii in range(d)]
         integrand = LocalElementProductIntegrand(GridFunction(grid, eye))


### PR DESCRIPTION
Coverage in `dune/gdt/spaces/` was dominated by never-exercised code paths ([codecov, main](https://app.codecov.io/gh/dune-gdt/dune-gdt/tree/main/dune%2Fgdt%2Fspaces)):

| file | line coverage |
|---|---|
| `interface.hh` | 16.7% |
| `basis/raviart-thomas.hh` | 29.5% |
| `basis/finite-volume.hh` | 37.9% |
| `mapper/discontinuous.hh` | 47.2% |
| `skeleton/finite-volume.hh` | 53.1% |
| `basis/interface.hh` | 57.9% |
| `l2/finite-volume.hh` | 62.6% |
| `mapper/interfaces.hh` | 66.7% |
| `basis/default.hh` | 67.1% |
| `mapper/finite-volume.hh` | 72.2% |

The common cause: nothing ever adapts a grid underneath a space from the Python suite (which is where coverage-relevant execution happens), and the FV/RT global bases were never evaluated. This PR closes those gaps with hypothesis property tests over the existing bindings, plus three bug fixes the work uncovered:

### Bug fix: `ConstLocalDiscreteFunction` held a *copy* of the space

`space_(spc.copy())` localized the copy's basis, so any local function created before a grid adaptation (exactly what `AdaptationHelper::append` stores) kept reading its private copy's stale state afterwards. For stateless bases (CG/DG/FV) this went unnoticed; for the stateful Raviart-Thomas basis it crashes the prolongation loop with an out-of-range access — found by the new RT adaptation test. The space is now held by reference (the DoF-vector half of the same object always referenced the live space's mapper anyway), which also removes an O(grid) space copy per local function. The shared local FE families are mutex-protected, so parallel assembly remains safe.

### Bug fix: Bochner list-of-vectors factories tagged every vector with `time_points[0]`

Both list-of-vectors `DiscreteBochnerFunction` factory overloads initialized a `counter` for the per-vector `_t` time annotation but never incremented it (spotted by CodeRabbit's review of this PR). Latent so far, since `evaluate()` locates vectors by temporal DoF index rather than by the annotation — but any future consumer of the `_t` notes would have seen every vector at the first time point. Fixed by incrementing, and the two copy-pasted loops were subsequently deduplicated into a named `make_vector_array` helper (which also resolves SonarCloud's lambda-length findings) so a bug like this can't hide in two places again.

### Bindings: coarsening was not expressible from Python

The `AdaptationHelper` binding's `markers` vector was `size_t`-valued, so `Grid::mark(-1, ...)` could never be requested — making every `restrict_to` implementation unreachable. Markers are now double-valued (still buffer-compatible: the documented `np.array(helper.markers, copy=False)` access keeps working). The vector-valued helper factory's `dim_range`/`la_backend` keyword names, which were attached to each other's parameters, are un-swapped.

### New/extended property tests

* **`test_hypothesis_spaces_adaptation.py` (new):** refining or coarsening must not change a discrete function the space can represent exactly — prolonged/restricted DoF vectors are pinned against a fresh interpolation of the same generated polynomial on the adapted grid, for CG, DG (scalar + dimension-wise vector), and FV (plus mass conservation and bit-exact father copies); RT0 prolongation preserves the L2 norm (affine invariance of RT0); the skeleton space's not-implemented restrict/prolong contract is pinned via the raised errors. Covers `interface.hh` `restrict_to`/`prolong_onto`/`adapt`, the bases' backup/restore, and every mapper's `update_after_adapt` (including the dimension-wise `DiscontinuousMapper` branches).
* **`test_hypothesis_spaces.py`:** skeleton space has one DoF per intersection (+ structural properties), RT0 one DoF per facet, vector FV `r` DoFs per element; FV interpolation is exact cell averaging; the FV mass matrix acts as `diag(cell volumes)` and the FV Laplace matrix annihilates everything (this assembles the FV *basis*, which the FV shortcut in `ConstLocalDiscreteFunction` otherwise bypasses); RT0 L2/H1-semi products behave as quadratic forms (Piola-transformed `evaluate`/`jacobians`).
* **`test_hypothesis_bochner.py`:** `DiscreteBochnerFunction.evaluate(time)` interpolates linearly in time — the only binding-reachable route through the `DynamicVector`-returning `global_indices` default implementation in `mapper/interfaces.hh`.

All tests that don't depend on the fixes were verified locally against the latest `main` wheels (29 passed); the fix-dependent ones (coarsening, RT adaptation) are exercised by this PR's CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2ehXBF37rJscfNvLyrDAm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed L2 projection so all local degrees of freedom are preserved.
  * Improved temporal function evaluation and interpolation between time points.
  * Corrected finite-volume, Raviart–Thomas, and vector-valued space behavior.
  * Improved adaptive-grid refinement and coarsening across supported spaces.
  * Preserved grid-mark values when exchanging adaptation data with Python.

* **Compatibility**
  * Updated vector-valued factory argument ordering for clearer Python usage.
  * Improved handling of local functions associated with existing spaces.

* **Tests**
  * Added broad property-based coverage for spaces, interpolation, operators, and grid adaptation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->