### PR TITLE
Confirm Option A for #421: keep dune-grid-glue mandatory, document config.h.cmake fallback

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -71,6 +71,9 @@
 #cmakedefine01 DUNE_XT_WITH_PYTHON_BINDINGS
 
 /*** Silence implicitly False evaluation of undefined macro warnings ****/
+/* dune-grid-glue is a mandatory dependency (see dune.module and CMakeLists.txt), so this
+ * fallback never fires for in-tree builds. It is kept for downstream consumers who compile
+ * against installed dune-gdt headers with their own, possibly glue-less, config.h. */
 #ifndef HAVE_DUNE_GRID_GLUE
 #define HAVE_DUNE_GRID_GLUE 0
 #endif


### PR DESCRIPTION
## Summary

Resolves #421 by confirming **Option A** — dune-grid-glue stays a mandatory dependency (the status quo after #420).

- `dune.module`, `CMakeLists.txt`, and `vcpkg.json` already declare `dune-grid-glue` unconditionally (done in #420); no changes needed there.
- The only remaining item from the issue: the `#ifndef HAVE_DUNE_GRID_GLUE / #define HAVE_DUNE_GRID_GLUE 0` fallback in `config.h.cmake` can never fire for in-tree builds anymore, since the dependency is now required. It was flagged as possibly-dead code by review bots on #420, so this PR adds a comment documenting that it's intentionally kept for downstream consumers who compile against installed dune-gdt headers with their own (possibly glue-less) `config.h`.

## Test plan

- [x] Documentation-only change to a comment in `config.h.cmake`; no behavior change, no build required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MumxAAWBd25V3rb37kUc4j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `dune-grid-glue` is required for in-tree builds.
  * Documented the `HAVE_DUNE_GRID_GLUE` fallback for custom downstream configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->