### PR TITLE
test(gdt): cover dispatch-trampoline error paths in dune.gdt.__init__

### DIFF
--- a/python/gdt/test/test_init_dispatch.py
+++ b/python/gdt/test/test_init_dispatch.py
@@ -20,29 +20,29 @@ from types import SimpleNamespace
 
 import pytest
 
-import dune.gdt
+dune_gdt = pytest.importorskip("dune.gdt", exc_type=ImportError)
 
 
 def test_dim_of_rejects_an_object_without_a_dimension_attribute():
     with pytest.raises(TypeError, match="cannot determine the grid dimension"):
-        dune.gdt._dim_of(object())
+        dune_gdt._dim_of(object())
 
 
 def test_split_submodule_wraps_import_error():
     with pytest.raises(
         ImportError, match=r"cannot dispatch to dune\.gdt\.no_such_base_7d"
     ):
-        dune.gdt._split_submodule("no_such_base", 7)
+        dune_gdt._split_submodule("no_such_base", 7)
 
 
 def test_factory_requires_the_dimension_carrying_argument():
-    factory = dune.gdt._make_dispatch("no_such_base", "SomeFactory", dim_kwarg="grid")
+    factory = dune_gdt._make_dispatch("no_such_base", "SomeFactory", dim_kwarg="grid")
     with pytest.raises(TypeError, match="missing the dimension-carrying argument"):
         factory()
 
 
 def test_factory_accepts_the_dimension_carrying_argument_as_a_keyword():
-    factory = dune.gdt._make_dispatch("no_such_base", "SomeFactory", dim_kwarg="grid")
+    factory = dune_gdt._make_dispatch("no_such_base", "SomeFactory", dim_kwarg="grid")
     probe = SimpleNamespace(dimension=3)
     # the keyword is resolved into `probe` and handed to _dim_of/_split_submodule; the submodule
     # itself does not exist, so the call still fails, but only after the keyword-lookup branch

--- a/python/gdt/test/test_init_dispatch.py
+++ b/python/gdt/test/test_init_dispatch.py
@@ -1,0 +1,59 @@
+# ~~~
+# This file is part of the dune-gdt project:
+#   https://github.com/dune-gdt/dune-gdt
+# Copyright 2010-2026 dune-gdt developers and contributors. All rights reserved.
+# License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+#      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+#          with "runtime exception" (http://www.dune-project.org/license.html)
+# Authors:
+#   René Fritze (2026)
+# ~~~
+
+# Exercises the error paths of the dimension-split dispatch trampolines defined in
+# dune.gdt.__init__ (see the "dimension-split binding trampolines" comment there): the
+# dimension-probing helper (_dim_of), the per-dimension submodule loader (_split_submodule), and
+# the dispatching factory closure built by _make_dispatch. The factories exercised elsewhere
+# always pass a well-formed dimension-carrying argument for a submodule that is actually built,
+# so these malformed-input branches need dedicated tests with deliberately bogus arguments.
+
+from types import SimpleNamespace
+
+import pytest
+
+import dune.gdt
+
+
+def test_dim_of_rejects_an_object_without_a_dimension_attribute():
+    with pytest.raises(TypeError, match="cannot determine the grid dimension"):
+        dune.gdt._dim_of(object())
+
+
+def test_split_submodule_wraps_import_error():
+    with pytest.raises(
+        ImportError, match=r"cannot dispatch to dune\.gdt\.no_such_base_7d"
+    ):
+        dune.gdt._split_submodule("no_such_base", 7)
+
+
+def test_factory_requires_the_dimension_carrying_argument():
+    factory = dune.gdt._make_dispatch("no_such_base", "SomeFactory", dim_kwarg="grid")
+    with pytest.raises(TypeError, match="missing the dimension-carrying argument"):
+        factory()
+
+
+def test_factory_accepts_the_dimension_carrying_argument_as_a_keyword():
+    factory = dune.gdt._make_dispatch("no_such_base", "SomeFactory", dim_kwarg="grid")
+    probe = SimpleNamespace(dimension=3)
+    # the keyword is resolved into `probe` and handed to _dim_of/_split_submodule; the submodule
+    # itself does not exist, so the call still fails, but only after the keyword-lookup branch
+    # (as opposed to the positional-argument branch exercised by the real factories) has run
+    with pytest.raises(
+        ImportError, match=r"cannot dispatch to dune\.gdt\.no_such_base_3d"
+    ):
+        factory(grid=probe)
+
+
+if __name__ == "__main__":
+    from dune.xt.test.base import runmodule
+
+    runmodule(__file__)


### PR DESCRIPTION
## Summary

Adds targeted unit tests for the pure-Python "dimension-split binding trampoline" helpers in `python/gdt/dune/gdt/__init__.py` (`_dim_of`, `_split_submodule`, `_make_dispatch`). Per Codecov, these lines were uncovered:

- `_dim_of`'s `TypeError` when an argument exposes none of `dimension`/`dimDomain`/`dim_domain` (line 147)
- `_split_submodule`'s `ImportError`-wrapping branch when the per-dimension submodule can't be imported (lines 162-163)
- Both branches of the dimension-carrying-argument lookup inside the `_make_dispatch` closure — the keyword-argument branch, and the "missing entirely" branch (lines 175, 176, 178)

None of these are reachable through the existing factory calls elsewhere in the test suite, since those always pass a well-formed positional dimension-carrying argument for a submodule that is actually built in CI. The new tests call the helpers directly with deliberately malformed inputs (an object with no dimension attribute, a bogus module-base name, a factory called with no dimension-carrying argument at all, and one called with it passed as a keyword) to exercise these paths without needing new compiled bindings.

### Out of scope

Two other gaps under `python/gdt/dune/gdt` reported by Codecov are not addressed here since they aren't fixable by adding more tests:
- `visualize_function` in `__init__.py` is gated by `config.HAVE_K3D`, which is false in the coverage-producing CI job (k3d isn't installed there).
- Most of `basic.py`'s re-export lines are only reached if every listed binding submodule imports successfully; `test_basic.py`'s own comment notes this facade is `importorskip`'d because at least one submodule (e.g. the ISTL operators in debug builds) isn't always available.

## Test plan
- [ ] CI: `python/gdt/test/test_init_dispatch.py` runs against the full build and the four new assertions (verified locally against the extracted trampoline logic with stand-in stub objects, since this sandbox has no compiled `dune.gdt` bindings)
- [x] `ruff check` / `ruff format --diff` pass on the new file


---
_Generated by [Claude Code](https://claude.ai/code/session_01MsqrNHo1KxEb7K1xRJoF75)_