### PR TITLE
Cover estimate_fixed_explicit_dt / estimate_fixed_explicit_dt_to_T_end directly

### DIFF
--- a/dune/gdt/test/burgers/burgers__1d__explicit__dt_estimates.cc
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dt_estimates.cc
@@ -25,6 +25,7 @@
 #include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
 
 #include <algorithm>
+#include <string>
 
 #include <dune/xt/grid/grids.hh>
 
@@ -71,6 +72,28 @@ struct BurgersFixedExplicitDtTest : public BurgersExplicitTest<G>
     }
     return largest_sup_norm / u_0.dofs().vector().sup_norm();
   }
+
+  /**
+   * \brief Checks estimate_fixed_explicit_dt_to_T_end() for the given space type.
+   *
+   * A fraction of the actual T_end of the problem keeps this cheap, the estimator does not care. min_dt is roughly an
+   * order of magnitude below the dt the burgers .mini configs pin for either space type, so the bisection is
+   * guaranteed a valid left bracket (it would throw bisection_error otherwise).
+   */
+  void check_estimate_fixed_explicit_dt_to_T_end(const std::string& space_type)
+  {
+    SCOPED_TRACE("space_type = " + space_type);
+    this->space_type_ = space_type;
+    const auto grid = this->make_initial_grid();
+    const auto space = this->make_space(grid);
+    const double T_end = 0.1 * this->T_end_;
+    const double min_dt = 1e-3;
+    const double max_overshoot = 1.25;
+    const auto dt = this->estimate_fixed_explicit_dt_to_T_end(*space, min_dt, T_end, max_overshoot);
+    EXPECT_GE(dt, min_dt);
+    EXPECT_LE(dt, T_end);
+    EXPECT_LE(this->largest_relative_sup_norm_during_explicit_euler(*space, dt, T_end), max_overshoot);
+  }
 }; // struct BurgersFixedExplicitDtTest
 
 
@@ -93,29 +116,10 @@ TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_is_stable_for_dg
 
 TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stable_for_dg)
 {
-  this->space_type_ = "dg_p1";
-  const auto grid = this->make_initial_grid();
-  const auto space = this->make_space(grid);
-  // a fraction of the actual T_end of the problem keeps this cheap, the estimator does not care
-  const double T_end = 0.1 * this->T_end_;
-  const double min_dt = 1e-3;
-  const double max_overshoot = 1.25;
-  const auto dt = this->estimate_fixed_explicit_dt_to_T_end(*space, min_dt, T_end, max_overshoot);
-  EXPECT_GE(dt, min_dt);
-  EXPECT_LE(dt, T_end);
-  EXPECT_LE(this->largest_relative_sup_norm_during_explicit_euler(*space, dt, T_end), max_overshoot);
+  this->check_estimate_fixed_explicit_dt_to_T_end("dg_p1");
 }
 
 TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stable_for_fv)
 {
-  this->space_type_ = "fv";
-  const auto grid = this->make_initial_grid();
-  const auto space = this->make_space(grid);
-  const double T_end = 0.1 * this->T_end_;
-  const double min_dt = 1e-3;
-  const double max_overshoot = 1.25;
-  const auto dt = this->estimate_fixed_explicit_dt_to_T_end(*space, min_dt, T_end, max_overshoot);
-  EXPECT_GE(dt, min_dt);
-  EXPECT_LE(dt, T_end);
-  EXPECT_LE(this->largest_relative_sup_norm_during_explicit_euler(*space, dt, T_end), max_overshoot);
+  this->check_estimate_fixed_explicit_dt_to_T_end("fv");
 }

--- a/dune/gdt/test/burgers/burgers__1d__explicit__dt_estimates.cc
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dt_estimates.cc
@@ -1,0 +1,114 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Felix Schindler (2019)
+
+/**
+ * \file burgers__1d__explicit__dt_estimates.cc
+ * \brief Direct tests for the bisection based dt estimates of InstationaryNonconformingHyperbolicEocStudy.
+ *
+ * The EOC studies themselves never reach InstationaryNonconformingHyperbolicEocStudy::estimate_fixed_explicit_dt()
+ * and ::estimate_fixed_explicit_dt_to_T_end(): the burgers .mini configs all pin setup.use_fixed_dt to a precomputed
+ * positive value (the bisection is too costly to run in every EOC test), and the only other consumer,
+ * inviscid-compressible-flow, guards both calls behind a non-fv space type it never instantiates. Both estimators are
+ * therefore exercised here directly, on a single coarse grid with a small T_end and few steps, which is cheap enough
+ * for CI while still checking what they promise: a dt within the searched bracket which keeps explicit Euler stable.
+ */
+
+#define DUNE_XT_COMMON_TEST_MAIN_ENABLE_TIMED_LOGGING 1
+#define DUNE_XT_COMMON_TEST_MAIN_ENABLE_INFO_LOGGING 1
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <dune/xt/grid/grids.hh>
+
+#include <dune/gdt/test/instationary-eocstudies/hyperbolic-nonconforming.hh>
+
+#include "base.hh"
+
+using namespace Dune;
+using namespace Dune::GDT;
+
+
+template <class G>
+struct BurgersFixedExplicitDtTest : public BurgersExplicitTest<G>
+{
+  using BaseType = BurgersExplicitTest<G>;
+  using typename BaseType::S;
+
+  BurgersFixedExplicitDtTest()
+    : BaseType()
+  {
+    this->numerical_flux_type_ = "engquist_osher";
+  }
+
+  /**
+   * \brief Integrates the initial values with explicit Euler up to T_end and returns the resulting sup norm, relative
+   *        to the one of the initial values.
+   *
+   * Anything below max_overshoot means the given dt was indeed stable in the sense of the estimators, which use the
+   * very same criterion to accept a dt.
+   */
+  double relative_sup_norm_after_explicit_euler(const S& space, const double dt, const double T_end)
+  {
+    const auto u_0 = this->make_initial_values(space);
+    const auto op = this->make_lhs_operator(space);
+    auto u = u_0.dofs().vector();
+    double time = 0.;
+    while (time < T_end + dt) {
+      u -= op->apply(u, {{"_t", {time}}, {"_dt", {dt}}}) * dt;
+      time += dt;
+    }
+    return u.sup_norm() / u_0.dofs().vector().sup_norm();
+  }
+}; // struct BurgersFixedExplicitDtTest
+
+
+using Burgers1dFixedExplicitDtTest = BurgersFixedExplicitDtTest<YASP_1D_EQUIDISTANT_OFFSET>;
+
+TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_is_stable_for_dg)
+{
+  this->space_type_ = "dg_p1";
+  const auto grid = this->make_initial_grid();
+  const auto space = this->make_space(grid);
+  // few steps only, we are merely after a dt which does not blow up immediately
+  const double max_overshoot = 1.25;
+  const int max_steps_to_try = 10;
+  const auto dt = this->estimate_fixed_explicit_dt(*space, max_overshoot, max_steps_to_try);
+  EXPECT_GT(dt, 0.);
+  EXPECT_LE(dt, this->T_end_); // the bisection may not leave its bracket
+  EXPECT_LE(this->relative_sup_norm_after_explicit_euler(*space, dt, /*T_end=*/max_steps_to_try * dt), max_overshoot);
+}
+
+TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stable_for_dg)
+{
+  this->space_type_ = "dg_p1";
+  const auto grid = this->make_initial_grid();
+  const auto space = this->make_space(grid);
+  // a fraction of the actual T_end of the problem keeps this cheap, the estimator does not care
+  const double T_end = 0.1 * this->T_end_;
+  const double min_dt = 1e-3;
+  const double max_overshoot = 1.25;
+  const auto dt = this->estimate_fixed_explicit_dt_to_T_end(*space, min_dt, T_end, max_overshoot);
+  EXPECT_GE(dt, min_dt);
+  EXPECT_LE(dt, T_end);
+  EXPECT_LE(this->relative_sup_norm_after_explicit_euler(*space, dt, T_end), max_overshoot);
+}
+
+TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stable_for_fv)
+{
+  this->space_type_ = "fv";
+  const auto grid = this->make_initial_grid();
+  const auto space = this->make_space(grid);
+  const double T_end = 0.1 * this->T_end_;
+  const double min_dt = 1e-3;
+  const double max_overshoot = 1.25;
+  const auto dt = this->estimate_fixed_explicit_dt_to_T_end(*space, min_dt, T_end, max_overshoot);
+  EXPECT_GE(dt, min_dt);
+  EXPECT_LE(dt, T_end);
+  EXPECT_LE(this->relative_sup_norm_after_explicit_euler(*space, dt, T_end), max_overshoot);
+}

--- a/dune/gdt/test/burgers/burgers__1d__explicit__dt_estimates.cc
+++ b/dune/gdt/test/burgers/burgers__1d__explicit__dt_estimates.cc
@@ -24,6 +24,8 @@
 
 #include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
 
+#include <algorithm>
+
 #include <dune/xt/grid/grids.hh>
 
 #include <dune/gdt/test/instationary-eocstudies/hyperbolic-nonconforming.hh>
@@ -47,23 +49,27 @@ struct BurgersFixedExplicitDtTest : public BurgersExplicitTest<G>
   }
 
   /**
-   * \brief Integrates the initial values with explicit Euler up to T_end and returns the resulting sup norm, relative
-   *        to the one of the initial values.
+   * \brief Integrates the initial values with explicit Euler up to T_end and returns the largest sup norm encountered
+   *        on the way, relative to the one of the initial values.
    *
    * Anything below max_overshoot means the given dt was indeed stable in the sense of the estimators, which use the
-   * very same criterion to accept a dt.
+   * very same criterion to accept a dt. Note that the maximum over all steps is what matters here: the estimators
+   * reject a dt as soon as a single step overshoots, so only looking at the final state would accept a dt which blew
+   * up in between and decayed again.
    */
-  double relative_sup_norm_after_explicit_euler(const S& space, const double dt, const double T_end)
+  double largest_relative_sup_norm_during_explicit_euler(const S& space, const double dt, const double T_end)
   {
     const auto u_0 = this->make_initial_values(space);
     const auto op = this->make_lhs_operator(space);
     auto u = u_0.dofs().vector();
+    double largest_sup_norm = u.sup_norm();
     double time = 0.;
     while (time < T_end + dt) {
       u -= op->apply(u, {{"_t", {time}}, {"_dt", {dt}}}) * dt;
       time += dt;
+      largest_sup_norm = std::max(largest_sup_norm, u.sup_norm());
     }
-    return u.sup_norm() / u_0.dofs().vector().sup_norm();
+    return largest_sup_norm / u_0.dofs().vector().sup_norm();
   }
 }; // struct BurgersFixedExplicitDtTest
 
@@ -81,7 +87,8 @@ TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_is_stable_for_dg
   const auto dt = this->estimate_fixed_explicit_dt(*space, max_overshoot, max_steps_to_try);
   EXPECT_GT(dt, 0.);
   EXPECT_LE(dt, this->T_end_); // the bisection may not leave its bracket
-  EXPECT_LE(this->relative_sup_norm_after_explicit_euler(*space, dt, /*T_end=*/max_steps_to_try * dt), max_overshoot);
+  EXPECT_LE(this->largest_relative_sup_norm_during_explicit_euler(*space, dt, /*T_end=*/max_steps_to_try * dt),
+            max_overshoot);
 }
 
 TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stable_for_dg)
@@ -96,7 +103,7 @@ TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stab
   const auto dt = this->estimate_fixed_explicit_dt_to_T_end(*space, min_dt, T_end, max_overshoot);
   EXPECT_GE(dt, min_dt);
   EXPECT_LE(dt, T_end);
-  EXPECT_LE(this->relative_sup_norm_after_explicit_euler(*space, dt, T_end), max_overshoot);
+  EXPECT_LE(this->largest_relative_sup_norm_during_explicit_euler(*space, dt, T_end), max_overshoot);
 }
 
 TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stable_for_fv)
@@ -110,5 +117,5 @@ TEST_F(Burgers1dFixedExplicitDtTest, estimate_fixed_explicit_dt_to_T_end_is_stab
   const auto dt = this->estimate_fixed_explicit_dt_to_T_end(*space, min_dt, T_end, max_overshoot);
   EXPECT_GE(dt, min_dt);
   EXPECT_LE(dt, T_end);
-  EXPECT_LE(this->relative_sup_norm_after_explicit_euler(*space, dt, T_end), max_overshoot);
+  EXPECT_LE(this->largest_relative_sup_norm_during_explicit_euler(*space, dt, T_end), max_overshoot);
 }


### PR DESCRIPTION
Closes #431.

## What

Adds `dune/gdt/test/burgers/burgers__1d__explicit__dt_estimates.cc`, a small standalone test suite that calls `InstationaryNonconformingHyperbolicEocStudy::estimate_fixed_explicit_dt()` and `::estimate_fixed_explicit_dt_to_T_end()` directly. No production code changes.

Three cases, all on the burgers problem's initial 16-cell 1d grid with the engquist-osher flux:

- `estimate_fixed_explicit_dt_is_stable_for_dg` — `dg_p1`, `max_steps_to_try = 10`
- `estimate_fixed_explicit_dt_to_T_end_is_stable_for_dg` — `dg_p1`, `T_end = 0.1`, `min_dt = 1e-3`
- `estimate_fixed_explicit_dt_to_T_end_is_stable_for_fv` — same, `fv` space type

Each asserts what the estimators promise: the returned `dt` stays inside the bracket handed to the bisection, and re-integrating the initial values with explicit Euler at that `dt` keeps the sup norm within the requested `max_overshoot`. The fixture's `largest_relative_sup_norm_during_explicit_euler()` helper mirrors the estimators' own acceptance loop — including its per-step criterion, so a `dt` that overshoots mid-integration and decays again is caught — which makes the check the estimator's contract rather than a hardcoded number that would need re-tuning. The two `_to_T_end` cases share `check_estimate_fixed_explicit_dt_to_T_end()`, parameterized by space type, with a `SCOPED_TRACE` naming the variant on failure.

The file has no `.mini` companion, so `_process_sources()` registers it through `dune_add_test()` — the same path the `misc/` tests take.

## Why this shape

Both functions were dead in CI, as traced in the issue:

- `burgers/base.hh:125` only reaches `estimate_fixed_explicit_dt_to_T_end()` when `setup.use_fixed_dt < 0`, and every burgers `.mini` (`fv`, `dg_p1`, `dg_p2`, `dg_p3`) pins it to a precomputed positive value precisely so the bisection does not run per EOC test.
- `inviscid-compressible-flow/base.hh:373,375` reaches both, but only for `space_type_ != "fv"`, and the one test binary instantiating that study hardcodes `"fv"`.
- `linear-transport/base.hh` only uses the sibling `estimate_fixed_explicit_fv_dt()`.

The issue floats two fixes; I went with neither, for cost reasons:

- Flipping a burgers `.mini` to a negative `use_fixed_dt` reinstates exactly the bisection that value was introduced to avoid, at full `T_end = 1` across all refinement levels — and it still only covers `estimate_fixed_explicit_dt_to_T_end()`, not `estimate_fixed_explicit_dt()`.
- A `dg_p*` explicit inviscid-compressible-flow variant would cover both, but means a new euler EOC study (m = 3, DG operator, bisection at full `T_end`) plus a fresh set of expected EOC results to compute and maintain.

Exercising the estimators standalone at a short horizon covers both functions and both space-type branches, and the whole suite is a few thousand operator applications on ≤ 32 DoFs.

## Testing

Not built or run here — this environment has no dune-common/dune-grid/dune-istl and no configured build tree, so the new test compiles and runs for the first time in CI. Worth watching for compile errors on the fixture's `using` declarations and for the two `min_dt = 1e-3` brackets: if `condition(min_dt)` ever came out false, `find_largest_by_bisection()` throws `bisection_error` rather than failing an assertion. Both are ~10x below the stable `dt` implied by the existing `use_fixed_dt` values in the burgers `.mini` files (`0.0097` fv, `0.0104` dg_p1), so there is a comfortable margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DtTENi8jhAoW3MiKaanUP

---
_Generated by [Claude Code](https://claude.ai/code/session_017DtTENi8jhAoW3MiKaanUP)_