### PR TITLE
Add unit test exercising norm dispatch in StationaryEocStudy::compute()

### DIFF
--- a/dune/gdt/test/misc/stationary_eocstudies_norms.cc
+++ b/dune/gdt/test/misc/stationary_eocstudies_norms.cc
@@ -1,0 +1,94 @@
+// This file is part of the dune-gdt project:
+//   https://github.com/dune-community/dune-gdt
+// Copyright 2010-2018 dune-gdt developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   dune-gdt developers
+
+#ifndef DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS
+#  define DUNE_XT_COMMON_TEST_MAIN_CATCH_EXCEPTIONS 1
+#endif
+
+#include <dune/xt/test/main.hxx> // <- this one has to come first (includes the config.h)!
+
+#include <memory>
+
+#include <dune/xt/common/exceptions.hh>
+#include <dune/xt/grid/grids.hh>
+#include <dune/xt/grid/gridprovider/cube.hh>
+
+#include <dune/gdt/operators/identity.hh>
+#include <dune/gdt/spaces/l2/finite-volume.hh>
+#include <dune/gdt/test/stationary-eocstudies/base.hh>
+
+using namespace Dune;
+using namespace Dune::GDT;
+using namespace Dune::GDT::Test;
+
+namespace {
+
+
+using G = YASP_2D_EQUIDISTANT_OFFSET;
+using GV = typename G::LeafGridView;
+
+
+/**
+ * \brief Smallest possible concrete StationaryEocStudy, used to exercise the norm dispatch in
+ *        StationaryEocStudy::compute() (base.hh) directly, independent of any concrete discretization.
+ *
+ * The residual operator is the identity, so solve() always yields the zero vector: both the current and the
+ * reference solution are the zero function, which makes every norm of their difference trivially zero and thus
+ * avoids the need for any precomputed/golden EOC values.
+ */
+class NormsStudy : public StationaryEocStudy<GV>
+{
+  using BaseType = StationaryEocStudy<GV>;
+
+protected:
+  using typename BaseType::GP;
+  using typename BaseType::O;
+  using typename BaseType::S;
+
+public:
+  NormsStudy()
+    : BaseType(/*visualizer=*/[](const auto&, const auto&) {},
+               /*num_refinements=*/0,
+               /*num_additional_refinements_for_reference=*/0)
+  {
+  }
+
+protected:
+  GP make_initial_grid() override
+  {
+    return XT::Grid::make_cube_grid<G>(0., 1., 4u);
+  }
+
+  std::unique_ptr<S> make_space(const GP& current_grid) override
+  {
+    return std::make_unique<FiniteVolumeSpace<GV>>(current_grid.leaf_view());
+  }
+
+  std::unique_ptr<O> make_residual_operator(const S& space) override
+  {
+    return std::make_unique<IdentityOperator<GV>>(space);
+  }
+}; // class NormsStudy
+
+
+} // namespace
+
+
+TEST_F(NormsStudy, computes_the_known_norms)
+{
+  const auto data = this->compute(0, {"L_1", "L_2", "H_1_semi"}, {}, {});
+  EXPECT_DOUBLE_EQ(0., data.at("norm").at("L_1"));
+  EXPECT_DOUBLE_EQ(0., data.at("norm").at("L_2"));
+  EXPECT_DOUBLE_EQ(0., data.at("norm").at("H_1_semi"));
+}
+
+TEST_F(NormsStudy, throws_for_an_unknown_norm)
+{
+  EXPECT_THROW(this->compute(0, {"not_a_known_norm"}, {}, {}), XT::Common::Exceptions::wrong_input_given);
+}


### PR DESCRIPTION
## Summary

Codecov flags the norm-dispatch block in `dune/gdt/test/stationary-eocstudies/base.hh` (`StationaryEocStudy::compute()`) as uncovered. Investigation showed why:

- `base.hh` is a header-only helper (`dune/gdt/test/CMakeLists.txt` explicitly notes it "provide[s] base.hh helpers included by tests in other subdirs" — there's no dedicated test executable for it).
- Its only concrete consumer, `StationaryDiffusionIpdgEocStudy` (`diffusion-ipdg.hh`), is used by two problems: `OS2015` (test file is `.cc.disabled`, not built in CI) and `ESV2007` (the only enabled one).
- `ESV2007DiffusionTest::norms()` overrides the norm list entirely and only ever requests `H_1_semi` — never `L_2` or `L_1`.

As a result, in `compute()`'s norm-id dispatch, only the `H_1_semi` branch was ever exercised; the `L_1` branch, the `L_2` branch, and the "unknown norm"/`DUNE_THROW` error paths were dead code from the test suite's perspective.

## Changes

- Add `dune/gdt/test/misc/stationary_eocstudies_norms.cc` with a minimal concrete `StationaryEocStudy` subclass (`NormsStudy`) that:
  - Uses a tiny cube grid + `FiniteVolumeSpace` + an `IdentityOperator` as the residual operator, so `solve()` always yields the zero vector — meaning both the current and reference solutions are the zero function, and every norm of their difference is trivially and exactly `0`. This avoids needing any precomputed/golden EOC values (unlike the `.mini`-driven EOC tests), since we can't build the full DUNE stack in this environment to generate them.
  - Calls `compute()` directly with `{"L_1", "L_2", "H_1_semi"}` and asserts each resulting norm is `0`.
  - Calls `compute()` with an unrecognized norm id and asserts it throws `XT::Common::Exceptions::wrong_input_given`.

No existing files were modified; the new `.cc` is picked up automatically by the existing glob-based test registration in `dune/gdt/test/misc/` (no `.mini` file, no `CMakeLists.txt` changes needed).

## Note

I was unable to build/run this locally — this environment has no prebuilt DUNE stack (dune-common/dune-grid/dune-istl/etc.) and no cached vcpkg toolchain, and building the full stack from scratch wasn't feasible in this session. I traced all types (`SpaceInterface`, `FiniteVolumeSpace`, `IdentityOperator`, `OperatorInterface` defaults) carefully by reading the relevant headers to confirm they line up, and mirrored patterns from existing, currently-passing tests (`ESV2007DiffusionTest`, `dune/gdt/test/misc/norms.cc`, `dune/gdt/test/misc/sparsity_pattern.cc`). Please let CI confirm compilation/execution — happy to iterate on any failures.

## Test plan

- [ ] CI build passes
- [ ] `test_stationary_eocstudies_norms` (or similarly named target) passes, exercising the `L_1`, `L_2`, and unknown-norm-throw branches in `base.hh`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHaxrvwgRmD8jz5p95H5KL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for stationary EOC studies using finite-volume discretization.
  * Verified expected zero-valued norms.
  * Confirmed invalid norm requests produce the appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->