### PR TITLE
[cleanup] add explicit to single-argument constructors (SonarCloud cpp:S1709) (rebase of #233)

### DIFF
--- a/dune/gdt/data/stationary_heat_equation.hh
+++ b/dune/gdt/data/stationary_heat_equation.hh
@@ -53,7 +53,7 @@ struct ESV2007DiffusionProblem
 
   // We can only reproduce the results from ESV2007 by using a quadrature of order 3, which we obtain with a p1 DG space
   // and a force of order 2.
-  ESV2007DiffusionProblem(int force_order = 2)
+  explicit ESV2007DiffusionProblem(int force_order = 2)
     : diffusion(XT::LA::eye_matrix<XT::Common::FieldMatrix<double, d, d>>(d, d))
     , dirichlet(0.)
     , neumann(0.)

--- a/dune/gdt/data/stokes.hh
+++ b/dune/gdt/data/stokes.hh
@@ -59,12 +59,12 @@ struct StokesDirichletProblem
   using DomainType = typename ScalarGridFunction::LocalFunctionType::DomainType;
   using DiffusionTensor = XT::Functions::GridFunctionInterface<E, d, d, RangeField>;
 
-  StokesDirichletProblem(std::shared_ptr<const DiffusionTensor> diffusion_in = default_diffusion(),
-                         std::shared_ptr<const VectorGridFunction> rhs_f_in = default_rhs_f(),
-                         std::shared_ptr<const VectorGridFunction> rhs_g_in = default_rhs_g(),
-                         std::shared_ptr<const VectorGridFunction> dirichlet_in = default_dirichlet_values(),
-                         std::shared_ptr<const VectorGridFunction> reference_sol_u = nullptr,
-                         std::shared_ptr<const ScalarGridFunction> reference_sol_p = nullptr)
+  explicit StokesDirichletProblem(std::shared_ptr<const DiffusionTensor> diffusion_in = default_diffusion(),
+                                  std::shared_ptr<const VectorGridFunction> rhs_f_in = default_rhs_f(),
+                                  std::shared_ptr<const VectorGridFunction> rhs_g_in = default_rhs_g(),
+                                  std::shared_ptr<const VectorGridFunction> dirichlet_in = default_dirichlet_values(),
+                                  std::shared_ptr<const VectorGridFunction> reference_sol_u = nullptr,
+                                  std::shared_ptr<const ScalarGridFunction> reference_sol_p = nullptr)
     : diffusion_(diffusion_in)
     , rhs_f_(rhs_f_in)
     , rhs_g_(rhs_g_in)

--- a/dune/gdt/discretefunction/bochner.hh
+++ b/dune/gdt/discretefunction/bochner.hh
@@ -74,7 +74,7 @@ public:
                                                   << bochner_space_.spatial_space().mapper().size());
   } // DiscreteBochnerFunction(...)
 
-  DiscreteBochnerFunction(const BochnerSpace<GV, r, rC, R>& bochner_space, const std::string nm = "")
+  explicit DiscreteBochnerFunction(const BochnerSpace<GV, r, rC, R>& bochner_space, const std::string nm = "")
     : bochner_space_(bochner_space)
     , dof_vectors_(new XT::LA::ListVectorArray<V>(bochner_space_.spatial_space().mapper().size(),
                                                   bochner_space_.temporal_space().mapper().size()))

--- a/dune/gdt/discretefunction/default-datahandle.hh
+++ b/dune/gdt/discretefunction/default-datahandle.hh
@@ -32,7 +32,7 @@ class DiscreteFunctionDataHandle
                                   typename DiscreteFunctionType::SpaceType::R>
 {
 public:
-  DiscreteFunctionDataHandle(DiscreteFunctionType& discrete_function, bool fixed_size = true)
+  explicit DiscreteFunctionDataHandle(DiscreteFunctionType& discrete_function, bool fixed_size = true)
     : discrete_function_(discrete_function)
     , mapper_(discrete_function_.space().mapper())
     , vector_(discrete_function_.dofs().vector())

--- a/dune/gdt/discretefunction/default.hh
+++ b/dune/gdt/discretefunction/default.hh
@@ -236,7 +236,7 @@ public:
   {
   }
 
-  DiscreteFunction(const SpaceType& spc, const std::string nm = "DiscreteFunction")
+  explicit DiscreteFunction(const SpaceType& spc, const std::string nm = "DiscreteFunction")
     : VectorStorage(new VectorType(spc.mapper().size(), 0.))
     , BaseType(spc, VectorStorage::access(), nm)
     , dofs_(space_.mapper(), VectorStorage::access())

--- a/dune/gdt/local/bilinear-forms/integrals.hh
+++ b/dune/gdt/local/bilinear-forms/integrals.hh
@@ -53,10 +53,11 @@ public:
   using IntegrandType = LocalBinaryElementIntegrandInterface<E, t_r, t_rC, TR, F, a_r, a_rC, AR>;
   using GenericIntegrand = GenericLocalBinaryElementIntegrand<E, t_r, t_rC, TR, F, a_r, a_rC, AR>;
 
-  LocalElementIntegralBilinearForm(const IntegrandType& integrand,
-                                   const int over_integrate = 0,
-                                   const std::string& logging_prefix = "",
-                                   const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalElementIntegralBilinearForm(
+      const IntegrandType& integrand,
+      const int over_integrate = 0,
+      const std::string& logging_prefix = "",
+      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType(integrand.parameter_type(),
                logging_prefix.empty() ? "LocalElementIntegralBilinearForm" : logging_prefix,
                logging_state)
@@ -172,7 +173,7 @@ public:
 
   using IntegrandType = LocalQuaternaryIntersectionIntegrandInterface<I, t_r, t_rC, TR, F, a_r, a_rC, AR>;
 
-  LocalCouplingIntersectionIntegralBilinearForm(
+  explicit LocalCouplingIntersectionIntegralBilinearForm(
       const IntegrandType& integrand,
       const int over_integrate = 0,
       const std::string& logging_prefix = "",
@@ -311,10 +312,11 @@ public:
 
   using IntegrandType = LocalBinaryIntersectionIntegrandInterface<I, t_r, t_rC, TR, F, a_r, a_rC, AR>;
 
-  LocalIntersectionIntegralBilinearForm(const IntegrandType& integrand,
-                                        const int over_integrate = 0,
-                                        const std::string& logging_prefix = "",
-                                        const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalIntersectionIntegralBilinearForm(
+      const IntegrandType& integrand,
+      const int over_integrate = 0,
+      const std::string& logging_prefix = "",
+      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType(integrand.parameter_type(),
                logging_prefix.empty() ? "LocalIntersectionIntegralBilinearForm" : logging_prefix,
                logging_state)

--- a/dune/gdt/local/bilinear-forms/interfaces.hh
+++ b/dune/gdt/local/bilinear-forms/interfaces.hh
@@ -86,9 +86,10 @@ public:
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, t_r, t_rC, TR>;
   using LocalAnsatzBasisType = XT::Functions::ElementFunctionSetInterface<E, a_r, a_rC, AR>;
 
-  LocalElementBilinearFormInterface(const XT::Common::ParameterType& param_type = {},
-                                    const std::string& logging_prefix = "",
-                                    const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalElementBilinearFormInterface(
+      const XT::Common::ParameterType& param_type = {},
+      const std::string& logging_prefix = "",
+      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : XT::Common::ParametricInterface(param_type)
     , Logger(logging_prefix.empty() ? "LocalElementBilinearForm" : logging_prefix, logging_state)
   {
@@ -186,7 +187,7 @@ public:
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, t_r, t_rC, TR>;
   using LocalAnsatzBasisType = XT::Functions::ElementFunctionSetInterface<E, a_r, a_rC, AR>;
 
-  LocalCouplingIntersectionBilinearFormInterface(
+  explicit LocalCouplingIntersectionBilinearFormInterface(
       const XT::Common::ParameterType& param_type = {},
       const std::string& logging_prefix = "",
       const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
@@ -306,9 +307,10 @@ public:
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, t_r, t_rC, TR>;
   using LocalAnsatzBasisType = XT::Functions::ElementFunctionSetInterface<E, a_r, a_rC, AR>;
 
-  LocalIntersectionBilinearFormInterface(const XT::Common::ParameterType& param_type = {},
-                                         const std::string& logging_prefix = "",
-                                         const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalIntersectionBilinearFormInterface(
+      const XT::Common::ParameterType& param_type = {},
+      const std::string& logging_prefix = "",
+      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : XT::Common::ParametricInterface(param_type)
     , Logger(logging_prefix.empty() ? "LocalIntersectionBilinearForm" : logging_prefix, logging_state)
   {

--- a/dune/gdt/local/finite-elements/0d.hh
+++ b/dune/gdt/local/finite-elements/0d.hh
@@ -163,7 +163,7 @@ class Local0dFiniteElementCoefficients : public LocalFiniteElementCoefficientsIn
   using BaseType = LocalFiniteElementCoefficientsInterface<D, 0>;
 
 public:
-  Local0dFiniteElementCoefficients(const size_t r = 1)
+  explicit Local0dFiniteElementCoefficients(const size_t r = 1)
     : geometry_type_(GeometryTypes::simplex(0))
     , local_keys_(r)
   {

--- a/dune/gdt/local/finite-elements/default.hh
+++ b/dune/gdt/local/finite-elements/default.hh
@@ -190,7 +190,7 @@ class ThreadSafeDefaultLocalFiniteElementFamily : public LocalFiniteElementFamil
 public:
   using typename BaseType::LocalFiniteElementType;
 
-  ThreadSafeDefaultLocalFiniteElementFamily(
+  explicit ThreadSafeDefaultLocalFiniteElementFamily(
       std::function<std::unique_ptr<LocalFiniteElementType>(const GeometryType&, const int&)> factory)
     : factory_(factory)
   {
@@ -246,7 +246,7 @@ public:
 
   using LocalBasisType = LocalFiniteElementBasisInterface<D, d, R, r, 1>;
 
-  LocalL2FiniteElementInterpolation(const LocalBasisType& local_basis)
+  explicit LocalL2FiniteElementInterpolation(const LocalBasisType& local_basis)
     : local_basis_(local_basis.copy())
   {
   }

--- a/dune/gdt/local/finite-elements/lagrange.hh
+++ b/dune/gdt/local/finite-elements/lagrange.hh
@@ -52,7 +52,7 @@ class LocalZeroOrderLagrangeFiniteElement
   using BaseType = LocalFiniteElementDefault<D, d, R, r>;
 
 public:
-  LocalZeroOrderLagrangeFiniteElement(const GeometryType& geometry_type)
+  explicit LocalZeroOrderLagrangeFiniteElement(const GeometryType& geometry_type)
     : Storage(new Wrapper(0, geometry_type))
     , BaseType(0,
                Storage::access().basis().copy(),

--- a/dune/gdt/local/finite-elements/power.hh
+++ b/dune/gdt/local/finite-elements/power.hh
@@ -63,7 +63,7 @@ public:
 
   using UnpoweredType = LocalFiniteElementBasisInterface<D, d, R, r>;
 
-  LocalPowerFiniteElementBasis(const UnpoweredType& unpowered)
+  explicit LocalPowerFiniteElementBasis(const UnpoweredType& unpowered)
     : unpowered_(unpowered.copy())
   {
   }
@@ -165,7 +165,7 @@ public:
 
   using UnpoweredType = LocalFiniteElementInterpolationInterface<D, d, R, r, 1>;
 
-  LocalPowerFiniteElementInterpolation(const UnpoweredType& unpowered)
+  explicit LocalPowerFiniteElementInterpolation(const UnpoweredType& unpowered)
     : unpowered_(unpowered.copy())
   {
   }
@@ -335,7 +335,7 @@ public:
 
   using UnpoweredType = LocalFiniteElementInterface<D, d, R, r, rC>;
 
-  LocalPowerFiniteElement(const UnpoweredType& unpowered)
+  explicit LocalPowerFiniteElement(const UnpoweredType& unpowered)
     : BaseType(unpowered.order(),
                unpowered.basis().copy(),
                unpowered.coefficients().copy(),
@@ -359,7 +359,7 @@ public:
 
   using UnpoweredType = LocalFiniteElementInterface<D, d, R, r>;
 
-  LocalPowerFiniteElement(const UnpoweredType& unpowered)
+  explicit LocalPowerFiniteElement(const UnpoweredType& unpowered)
     : BaseType(unpowered.order(),
                std::make_unique<LocalPowerFiniteElementBasis<power, D, d, R, r>>(unpowered.basis()),
                std::make_unique<LocalPowerFiniteElementCoefficients<D, d>>(unpowered.coefficients(), power),

--- a/dune/gdt/local/finite-elements/wrapper.hh
+++ b/dune/gdt/local/finite-elements/wrapper.hh
@@ -93,13 +93,13 @@ public:
   using typename BaseType::DomainType;
   using typename BaseType::RangeType;
 
-  LocalFiniteElementBasisWrapper(std::shared_ptr<const Implementation> imp)
+  explicit LocalFiniteElementBasisWrapper(std::shared_ptr<const Implementation> imp)
     : imp_(imp)
     , geometry_type_(imp_->type())
   {
   }
 
-  LocalFiniteElementBasisWrapper(Implementation*&& imp_ptr)
+  explicit LocalFiniteElementBasisWrapper(Implementation*&& imp_ptr)
     : LocalFiniteElementBasisWrapper(std::shared_ptr<Implementation>(std::move(imp_ptr)))
   {
   }
@@ -107,7 +107,7 @@ public:
   template <class ImpType,
             typename = typename std::enable_if<std::is_same<ImpType, Implementation>::value
                                                && std::is_copy_constructible<ImpType>::value>::type>
-  LocalFiniteElementBasisWrapper(const ImpType& imp)
+  explicit LocalFiniteElementBasisWrapper(const ImpType& imp)
     : LocalFiniteElementBasisWrapper(new ImpType(imp))
   {
   }
@@ -192,14 +192,14 @@ public:
   using typename BaseType::DomainType;
   using typename BaseType::RangeType;
 
-  LocalFiniteElementInterpolationWrapper(std::shared_ptr<const Implementation> imp)
+  explicit LocalFiniteElementInterpolationWrapper(std::shared_ptr<const Implementation> imp)
     : imp_(imp)
     , geometry_type_(imp_->type())
     , dofs_(imp_->size())
   {
   }
 
-  LocalFiniteElementInterpolationWrapper(Implementation*&& imp_ptr)
+  explicit LocalFiniteElementInterpolationWrapper(Implementation*&& imp_ptr)
     : LocalFiniteElementInterpolationWrapper(std::shared_ptr<Implementation>(std::move(imp_ptr)))
   {
   }
@@ -207,7 +207,7 @@ public:
   template <class ImpType,
             typename = typename std::enable_if<std::is_same<ImpType, Implementation>::value
                                                && std::is_copy_constructible<ImpType>::value>::type>
-  LocalFiniteElementInterpolationWrapper(const ImpType& imp)
+  explicit LocalFiniteElementInterpolationWrapper(const ImpType& imp)
     : LocalFiniteElementInterpolationWrapper(new ImpType(imp))
   {
   }
@@ -272,13 +272,13 @@ class LocalFiniteElementCoefficientsWrapper : public LocalFiniteElementCoefficie
   using BaseType = LocalFiniteElementCoefficientsInterface<D, d>;
 
 public:
-  LocalFiniteElementCoefficientsWrapper(std::shared_ptr<const Implementation> imp)
+  explicit LocalFiniteElementCoefficientsWrapper(std::shared_ptr<const Implementation> imp)
     : imp_(imp)
     , geometry_type_(imp_->type())
   {
   }
 
-  LocalFiniteElementCoefficientsWrapper(Implementation*&& imp_ptr)
+  explicit LocalFiniteElementCoefficientsWrapper(Implementation*&& imp_ptr)
     : LocalFiniteElementCoefficientsWrapper(std::shared_ptr<Implementation>(std::move(imp_ptr)))
   {
   }
@@ -286,7 +286,7 @@ public:
   template <class ImpType,
             typename = typename std::enable_if<std::is_same<ImpType, Implementation>::value
                                                && std::is_copy_constructible<ImpType>::value>::type>
-  LocalFiniteElementCoefficientsWrapper(const ImpType& imp)
+  explicit LocalFiniteElementCoefficientsWrapper(const ImpType& imp)
     : LocalFiniteElementCoefficientsWrapper(new ImpType(imp))
   {
   }

--- a/dune/gdt/local/functionals/integrals.hh
+++ b/dune/gdt/local/functionals/integrals.hh
@@ -43,7 +43,7 @@ public:
   using IntegrandType = LocalUnaryElementIntegrandInterface<E, r, rC, R>;
   using GenericIntegrand = GenericLocalUnaryElementIntegrand<E, r, rC, R>;
 
-  LocalElementIntegralFunctional(const IntegrandType& integrand, const int over_integrate = 0)
+  explicit LocalElementIntegralFunctional(const IntegrandType& integrand, const int over_integrate = 0)
     : BaseType(integrand.parameter_type())
     , integrand_(integrand.copy_as_unary_element_integrand())
     , over_integrate_(over_integrate)
@@ -130,7 +130,7 @@ public:
   using IntegrandType = LocalUnaryIntersectionIntegrandInterface<I, r, rC, R>;
   using GenericIntegrand = GenericLocalUnaryIntersectionIntegrand<I, r, rC, R>;
 
-  LocalIntersectionIntegralFunctional(const IntegrandType& integrand, const int over_integrate = 0)
+  explicit LocalIntersectionIntegralFunctional(const IntegrandType& integrand, const int over_integrate = 0)
     : BaseType(integrand.parameter_type())
     , integrand_(integrand.copy_as_unary_intersection_integrand())
     , over_integrate_(over_integrate)

--- a/dune/gdt/local/functionals/interfaces.hh
+++ b/dune/gdt/local/functionals/interfaces.hh
@@ -60,7 +60,7 @@ public:
   using ElementType = Element;
   using LocalBasisType = XT::Functions::ElementFunctionSetInterface<E, r, rC, R>;
 
-  LocalElementFunctionalInterface(const XT::Common::ParameterType& param_type = {})
+  explicit LocalElementFunctionalInterface(const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type)
   {
   }
@@ -122,7 +122,7 @@ public:
 
   using LocalBasisType = XT::Functions::ElementFunctionSetInterface<E, r, rC, R>;
 
-  LocalIntersectionFunctionalInterface(const XT::Common::ParameterType& param_type = {})
+  explicit LocalIntersectionFunctionalInterface(const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type)
   {
   }

--- a/dune/gdt/local/integrands/abs.hh
+++ b/dune/gdt/local/integrands/abs.hh
@@ -37,8 +37,8 @@ public:
   using typename BaseType::DomainType;
   using typename BaseType::LocalTestBasisType;
 
-  LocalElementAbsIntegrand(const std::string& logging_prefix = "",
-                           const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalElementAbsIntegrand(const std::string& logging_prefix = "",
+                                    const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType({}, logging_prefix.empty() ? "LocalElementAbsIntegrand" : logging_prefix, logging_state)
   {
   }

--- a/dune/gdt/local/integrands/interfaces.hh
+++ b/dune/gdt/local/integrands/interfaces.hh
@@ -99,9 +99,10 @@ public:
   using DomainType = FieldVector<D, d>;
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, r, rC, R>;
 
-  LocalUnaryElementIntegrandInterface(const XT::Common::ParameterType& param_type = {},
-                                      const std::string& logging_prefix = "",
-                                      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalUnaryElementIntegrandInterface(
+      const XT::Common::ParameterType& param_type = {},
+      const std::string& logging_prefix = "",
+      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : XT::Common::ParametricInterface(param_type)
     , Logger(logging_prefix.empty() ? "LocalUnaryElementIntegrand" : logging_prefix, logging_state)
   {
@@ -208,9 +209,10 @@ public:
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, t_r, t_rC, TR>;
   using LocalAnsatzBasisType = XT::Functions::ElementFunctionSetInterface<E, a_r, a_rC, AR>;
 
-  LocalBinaryElementIntegrandInterface(const XT::Common::ParameterType& param_type = {},
-                                       const std::string& logging_prefix = "",
-                                       const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalBinaryElementIntegrandInterface(
+      const XT::Common::ParameterType& param_type = {},
+      const std::string& logging_prefix = "",
+      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : XT::Common::ParametricInterface(param_type)
     , XT::Grid::ElementBoundObject<Element>()
     , Logger(logging_prefix.empty() ? "LocalBinaryElementIntegrand" : logging_prefix, logging_state)
@@ -333,7 +335,7 @@ public:
   using DomainType = FieldVector<D, d - 1>;
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, r, rC, RF>;
 
-  LocalUnaryIntersectionIntegrandInterface(
+  explicit LocalUnaryIntersectionIntegrandInterface(
       const XT::Common::ParameterType& param_type = {},
       const std::string& logging_prefix = "",
       const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
@@ -463,7 +465,7 @@ public:
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, t_r, t_rC, TR>;
   using LocalAnsatzBasisType = XT::Functions::ElementFunctionSetInterface<E, a_r, a_rC, AR>;
 
-  LocalBinaryIntersectionIntegrandInterface(
+  explicit LocalBinaryIntersectionIntegrandInterface(
       const XT::Common::ParameterType& param_type = {},
       const std::string& logging_prefix = "",
       const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
@@ -611,7 +613,7 @@ public:
   using LocalTestBasisType = XT::Functions::ElementFunctionSetInterface<E, t_r, t_rC, TR>;
   using LocalAnsatzBasisType = XT::Functions::ElementFunctionSetInterface<E, a_r, a_rC, AR>;
 
-  LocalQuaternaryIntersectionIntegrandInterface(
+  explicit LocalQuaternaryIntersectionIntegrandInterface(
       const XT::Common::ParameterType& param_type = {},
       const std::string& logging_prefix = "",
       const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())

--- a/dune/gdt/local/integrands/jump.hh
+++ b/dune/gdt/local/integrands/jump.hh
@@ -46,10 +46,10 @@ public:
   using typename BaseType::LocalAnsatzBasisType;
   using typename BaseType::LocalTestBasisType;
 
-  Inner(const std::function<double(const I&)>& intersection_diameter =
-            LocalIPDGIntegrands::internal::default_intersection_diameter<I>(),
-        const std::string& logging_prefix = "",
-        const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit Inner(const std::function<double(const I&)>& intersection_diameter =
+                     LocalIPDGIntegrands::internal::default_intersection_diameter<I>(),
+                 const std::string& logging_prefix = "",
+                 const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType({}, logging_prefix.empty() ? "LocalJumpIntegrands::Inner" : logging_prefix, logging_state)
     , intersection_diameter_(intersection_diameter)
   {
@@ -185,10 +185,10 @@ public:
   using typename BaseType::LocalAnsatzBasisType;
   using typename BaseType::LocalTestBasisType;
 
-  Boundary(const std::function<double(const I&)>& intersection_diameter =
-               LocalIPDGIntegrands::internal::default_intersection_diameter<I>(),
-           const std::string& logging_prefix = "",
-           const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit Boundary(const std::function<double(const I&)>& intersection_diameter =
+                        LocalIPDGIntegrands::internal::default_intersection_diameter<I>(),
+                    const std::string& logging_prefix = "",
+                    const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType({}, logging_prefix.empty() ? "LocalJumpIntegrands::Boundary" : logging_prefix, logging_state)
     , intersection_diameter_(intersection_diameter)
   {

--- a/dune/gdt/local/numerical-fluxes/engquist-osher.hh
+++ b/dune/gdt/local/numerical-fluxes/engquist-osher.hh
@@ -57,12 +57,12 @@ public:
   using typename BaseType::StateType;
   using typename BaseType::XIndependentFluxType;
 
-  NumericalEngquistOsherFlux(const FluxType& flx)
+  explicit NumericalEngquistOsherFlux(const FluxType& flx)
     : BaseType(flx)
   {
   }
 
-  NumericalEngquistOsherFlux(const XIndependentFluxType& flx)
+  explicit NumericalEngquistOsherFlux(const XIndependentFluxType& flx)
     : BaseType(flx)
   {
   }

--- a/dune/gdt/local/numerical-fluxes/interface.hh
+++ b/dune/gdt/local/numerical-fluxes/interface.hh
@@ -54,7 +54,7 @@ public:
   using StateType = typename FluxType::StateType;
   using DynamicStateType = typename FluxType::DynamicStateType;
 
-  NumericalFluxInterface(const FluxType& flx, const XT::Common::ParameterType& param_type = {})
+  explicit NumericalFluxInterface(const FluxType& flx, const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type + flx.parameter_type())
     , flux_(flx)
     , local_flux_inside_(flux_.access().local_function())
@@ -62,7 +62,8 @@ public:
   {
   }
 
-  NumericalFluxInterface(std::unique_ptr<const FluxType>&& flx_ptr, const XT::Common::ParameterType& param_type = {})
+  explicit NumericalFluxInterface(std::unique_ptr<const FluxType>&& flx_ptr,
+                                  const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type + flx_ptr->parameter_type())
     , flux_(std::move(flx_ptr))
     , local_flux_inside_(flux_.access().local_function())
@@ -70,7 +71,7 @@ public:
   {
   }
 
-  NumericalFluxInterface(const XIndependentFluxType& func, const XT::Common::ParameterType& param_type = {})
+  explicit NumericalFluxInterface(const XIndependentFluxType& func, const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type + func.parameter_type())
     , flux_(static_cast<std::unique_ptr<const FluxType>&&>(std::make_unique<const FluxWrapperType>(func)))
     , local_flux_inside_(flux_.access().local_function())
@@ -78,8 +79,8 @@ public:
   {
   }
 
-  NumericalFluxInterface(std::unique_ptr<const XIndependentFluxType>&& func_ptr,
-                         const XT::Common::ParameterType& param_type = {})
+  explicit NumericalFluxInterface(std::unique_ptr<const XIndependentFluxType>&& func_ptr,
+                                  const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type + func_ptr->parameter_type())
     , flux_(
           static_cast<std::unique_ptr<const FluxType>&&>(std::make_unique<const FluxWrapperType>(std::move(func_ptr))))

--- a/dune/gdt/local/numerical-fluxes/lax-friedrichs.hh
+++ b/dune/gdt/local/numerical-fluxes/lax-friedrichs.hh
@@ -40,7 +40,7 @@ public:
   using typename BaseType::XIndependentFluxType;
   using FluxJacobianType = XT::Common::FieldVector<XT::Common::FieldMatrix<R, m, m>, d>;
 
-  NumericalLaxFriedrichsFlux(const FluxType& flx, const double lambda = 0.)
+  explicit NumericalLaxFriedrichsFlux(const FluxType& flx, const double lambda = 0.)
     : BaseType(flx)
     , lambda_(lambda)
   {
@@ -48,7 +48,7 @@ public:
       DUNE_THROW(Dune::NotImplemented, "Not yet implemented for m > 1 if lambda is not provided!");
   }
 
-  NumericalLaxFriedrichsFlux(const XIndependentFluxType& func, const double lambda = 0.)
+  explicit NumericalLaxFriedrichsFlux(const XIndependentFluxType& func, const double lambda = 0.)
     : BaseType(func)
     , lambda_(lambda)
   {

--- a/dune/gdt/local/numerical-fluxes/upwind.hh
+++ b/dune/gdt/local/numerical-fluxes/upwind.hh
@@ -50,12 +50,12 @@ public:
   using typename BaseType::StateType;
   using typename BaseType::XIndependentFluxType;
 
-  NumericalUpwindFlux(const FluxType& flx)
+  explicit NumericalUpwindFlux(const FluxType& flx)
     : BaseType(flx)
   {
   }
 
-  NumericalUpwindFlux(const XIndependentFluxType& func)
+  explicit NumericalUpwindFlux(const XIndependentFluxType& func)
     : BaseType(func)
   {
   }

--- a/dune/gdt/local/numerical-fluxes/vijayasundaram.hh
+++ b/dune/gdt/local/numerical-fluxes/vijayasundaram.hh
@@ -80,7 +80,7 @@ public:
         };
   }
 
-  NumericalVijayasundaramFlux(const FluxType& flx)
+  explicit NumericalVijayasundaramFlux(const FluxType& flx)
     : BaseType(flx)
     , flux_eigen_decomposition_(default_flux_eigen_decomposition())
   {
@@ -88,7 +88,7 @@ public:
       DUNE_THROW(Dune::NotImplemented, "This flux is not yet implemented for x-dependent fluxes!");
   }
 
-  NumericalVijayasundaramFlux(const XIndependentFluxType& flx)
+  explicit NumericalVijayasundaramFlux(const XIndependentFluxType& flx)
     : BaseType(flx)
     , flux_eigen_decomposition_(default_flux_eigen_decomposition())
   {

--- a/dune/gdt/local/operators/advection-dg.hh
+++ b/dune/gdt/local/operators/advection-dg.hh
@@ -61,7 +61,7 @@ public:
   using LocalMassMatrixProviderType = LocalMassMatrixProvider<RGV, m, 1, RF>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalAdvectionDgVolumeOperator(const FluxType& flux)
+  explicit LocalAdvectionDgVolumeOperator(const FluxType& flux)
     : BaseType(1, flux.parameter_type())
     , flux_(flux)
     , local_flux_(flux_.local_function())
@@ -228,7 +228,7 @@ public:
   using LocalMassMatrixProviderType = LocalMassMatrixProvider<IRGV, m, 1, IRR>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalAdvectionDgCouplingOperator(const NumericalFluxType& numerical_flux, bool compute_outside = true)
+  explicit LocalAdvectionDgCouplingOperator(const NumericalFluxType& numerical_flux, bool compute_outside = true)
     : BaseType(2, numerical_flux.parameter_type())
     , numerical_flux_(numerical_flux.copy())
     , local_flux_inside_(numerical_flux_->flux().local_function())
@@ -734,10 +734,10 @@ public:
   using LocalMassMatrixProviderType = LocalMassMatrixProvider<RGV, m, 1, RF>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalAdvectionDgArtificialViscosityShockCapturingOperator(const SGV& assembly_grid_view,
-                                                            const double& nu_1 = 0.2,
-                                                            const double& alpha_1 = 1.0,
-                                                            const size_t index = 0)
+  explicit LocalAdvectionDgArtificialViscosityShockCapturingOperator(const SGV& assembly_grid_view,
+                                                                     const double& nu_1 = 0.2,
+                                                                     const double& alpha_1 = 1.0,
+                                                                     const size_t index = 0)
     : BaseType(2)
     , assembly_grid_view_(assembly_grid_view)
     , nu_1_(nu_1)

--- a/dune/gdt/local/operators/advection-fv.hh
+++ b/dune/gdt/local/operators/advection-fv.hh
@@ -70,8 +70,8 @@ public:
   static const typename LocalSourceType::DomainType static_x;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalAdvectionFvCouplingOperator(const NumericalFluxType& numerical_flux,
-                                   const bool source_is_elementwise_constant = false)
+  explicit LocalAdvectionFvCouplingOperator(const NumericalFluxType& numerical_flux,
+                                            const bool source_is_elementwise_constant = false)
     : BaseType(2, numerical_flux.parameter_type())
     , numerical_flux_(numerical_flux.copy())
     , source_is_elementwise_constant_(source_is_elementwise_constant)
@@ -224,7 +224,7 @@ public:
                                         const XT::Common::Parameter& /*param*/)>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalAdvectionFvBoundaryTreatmentByCustomNumericalFluxOperator(
+  explicit LocalAdvectionFvBoundaryTreatmentByCustomNumericalFluxOperator(
       LambdaType numerical_boundary_flux_lambda,
       const XT::Common::ParameterType& boundary_treatment_param_type = {},
       const bool source_is_elementwise_constant = false)

--- a/dune/gdt/local/operators/generic.hh
+++ b/dune/gdt/local/operators/generic.hh
@@ -56,9 +56,9 @@ public:
                                                  const XT::Common::Parameter& /*param*/)>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  GenericLocalElementOperator(GenericFunctionType func,
-                              const size_t num_local_sources = 0,
-                              const XT::Common::ParameterType& param_type = {})
+  explicit GenericLocalElementOperator(GenericFunctionType func,
+                                       const size_t num_local_sources = 0,
+                                       const XT::Common::ParameterType& param_type = {})
     : BaseType(num_local_sources, param_type)
     , func_(func)
   {
@@ -134,9 +134,9 @@ public:
                                                  const XT::Common::Parameter& /*param*/)>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  GenericLocalIntersectionOperator(GenericFunctionType func,
-                                   const size_t num_local_sources = 1,
-                                   const XT::Common::ParameterType& param_type = {})
+  explicit GenericLocalIntersectionOperator(GenericFunctionType func,
+                                            const size_t num_local_sources = 1,
+                                            const XT::Common::ParameterType& param_type = {})
     : BaseType(num_local_sources, param_type)
     , func_(func)
   {

--- a/dune/gdt/local/operators/indicator.hh
+++ b/dune/gdt/local/operators/indicator.hh
@@ -49,7 +49,7 @@ public:
   using LocalBilinearFormType = LocalElementBilinearFormInterface<E, s_r, s_rC, SF, RF, s_r, s_rC, SF>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalElementBilinearFormIndicatorOperator(const LocalBilinearFormType& bilinear_form)
+  explicit LocalElementBilinearFormIndicatorOperator(const LocalBilinearFormType& bilinear_form)
     : BaseType(1)
     , local_bilinear_form_(bilinear_form.copy())
   {
@@ -123,7 +123,7 @@ public:
   using LocalBilinearFormType = LocalCouplingIntersectionBilinearFormInterface<I, s_r, s_rC, SF, RF, s_r, s_rC, SF>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalCouplingIntersectionBilinearFormIndicatorOperator(const LocalBilinearFormType& bilinear_form)
+  explicit LocalCouplingIntersectionBilinearFormIndicatorOperator(const LocalBilinearFormType& bilinear_form)
     : BaseType(2)
     , local_bilinear_form_(bilinear_form.copy())
   {
@@ -220,7 +220,7 @@ public:
   using LocalBilinearFormType = LocalIntersectionBilinearFormInterface<I, s_r, s_rC, SF, RF, s_r, s_rC, SF>;
 
   // When using this constructor, source has to be set by a call to with_source before calling apply
-  LocalIntersectionBilinearFormIndicatorOperator(const LocalBilinearFormType& bilinear_form)
+  explicit LocalIntersectionBilinearFormIndicatorOperator(const LocalBilinearFormType& bilinear_form)
     : BaseType(1)
     , local_bilinear_form_(bilinear_form.copy())
   {

--- a/dune/gdt/local/operators/interfaces.hh
+++ b/dune/gdt/local/operators/interfaces.hh
@@ -83,7 +83,8 @@ public:
   using SourceSpaceType = typename DiscreteSourceType::SpaceType;
 
   // Allows construction without source, source has to be set by a call to with_source before calling apply
-  LocalElementOperatorInterface(const size_t num_local_sources = 1, const XT::Common::ParameterType& param_type = {})
+  explicit LocalElementOperatorInterface(const size_t num_local_sources = 1,
+                                         const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type)
     , source_()
     , local_sources_(0)
@@ -92,9 +93,9 @@ public:
       local_sources_.emplace_back(nullptr);
   }
 
-  LocalElementOperatorInterface(const SourceType& source,
-                                const size_t num_local_sources = 1,
-                                const XT::Common::ParameterType& param_type = {})
+  explicit LocalElementOperatorInterface(const SourceType& source,
+                                         const size_t num_local_sources = 1,
+                                         const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type)
     , source_(source)
     , local_sources_(0)
@@ -226,8 +227,8 @@ public:
   using LocalOutsideRangeType = LocalDiscreteFunction<ORV, ORGV, r_r, r_rC, RF>;
 
   // Allows construction without source, source has to be set by a call to with_source before calling apply
-  LocalIntersectionOperatorInterface(const size_t num_local_sources = 2,
-                                     const XT::Common::ParameterType& param_type = {})
+  explicit LocalIntersectionOperatorInterface(const size_t num_local_sources = 2,
+                                              const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type)
     , source_()
     , local_sources_(0)
@@ -236,9 +237,9 @@ public:
       local_sources_.emplace_back(nullptr);
   }
 
-  LocalIntersectionOperatorInterface(const SourceType& src,
-                                     const size_t num_local_sources = 2,
-                                     const XT::Common::ParameterType& param_type = {})
+  explicit LocalIntersectionOperatorInterface(const SourceType& src,
+                                              const size_t num_local_sources = 2,
+                                              const XT::Common::ParameterType& param_type = {})
     : XT::Common::ParametricInterface(param_type)
     , source_(src)
     , local_sources_(0)

--- a/dune/gdt/operators/bilinear-form.hh
+++ b/dune/gdt/operators/bilinear-form.hh
@@ -85,9 +85,9 @@ public:
       LocalCouplingIntersectionBilinearFormInterface<I, r_r, r_rC, F, F, s_r, s_rC, F>;
   using LocalIntersectionBilinearFormType = LocalIntersectionBilinearFormInterface<I, r_r, r_rC, F, F, s_r, s_rC, F>;
 
-  BilinearForm(const AssemblyGridViewType assembly_grid_view,
-               const std::string& logging_prefix = "",
-               const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit BilinearForm(const AssemblyGridViewType assembly_grid_view,
+                        const std::string& logging_prefix = "",
+                        const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType({}, logging_prefix.empty() ? "BilinearForm" : logging_prefix, logging_state)
     , assembly_grid_view_(assembly_grid_view)
   {

--- a/dune/gdt/operators/identity.hh
+++ b/dune/gdt/operators/identity.hh
@@ -44,9 +44,9 @@ public:
   using typename BaseType::SourceSpaceType;
   using typename BaseType::VectorType;
 
-  IdentityOperator(const SourceSpaceType& space,
-                   const std::string& logging_prefix = "",
-                   const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit IdentityOperator(const SourceSpaceType& space,
+                            const std::string& logging_prefix = "",
+                            const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : BaseType({}, logging_prefix.empty() ? "IdentityOperator" : logging_prefix, logging_state)
     , space_(space)
   {

--- a/dune/gdt/spaces/basis/default.hh
+++ b/dune/gdt/spaces/basis/default.hh
@@ -98,7 +98,7 @@ private:
     using typename BaseType::LocalFiniteElementType;
     using typename BaseType::RangeType;
 
-    LocalizedDefaultGlobalBasis(const DefaultGlobalBasis<GV, r, rC, R>& self)
+    explicit LocalizedDefaultGlobalBasis(const DefaultGlobalBasis<GV, r, rC, R>& self)
       : BaseType()
       , self_(self)
     {

--- a/dune/gdt/spaces/basis/finite-volume.hh
+++ b/dune/gdt/spaces/basis/finite-volume.hh
@@ -56,7 +56,7 @@ public:
   ThisType& operator=(const ThisType&) = delete;
   ThisType& operator=(ThisType&&) = delete;
 
-  FiniteVolumeGlobalBasis(const GridViewType& grd_vw)
+  explicit FiniteVolumeGlobalBasis(const GridViewType& grd_vw)
     : grid_view_(grd_vw)
     , local_finite_elements_()
   {
@@ -98,7 +98,7 @@ private:
     using typename BaseType::RangeType;
     using typename BaseType::SingleDerivativeRangeType;
 
-    LocalizedFiniteVolumeGlobalBasis(const FiniteVolumeGlobalBasis<GV, r, R>& self)
+    explicit LocalizedFiniteVolumeGlobalBasis(const FiniteVolumeGlobalBasis<GV, r, R>& self)
       : BaseType()
       , self_(self)
     {

--- a/dune/gdt/spaces/basis/interface.hh
+++ b/dune/gdt/spaces/basis/interface.hh
@@ -48,8 +48,9 @@ public:
 
   using LocalFiniteElementType = LocalFiniteElementInterface<D, d, R, r, rC>;
 
-  LocalizedGlobalFiniteElementInterface(const std::string& logging_prefix = "",
-                                        const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit LocalizedGlobalFiniteElementInterface(
+      const std::string& logging_prefix = "",
+      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : Logger(logging_prefix.empty() ? "LocalizedGlobalBasis" : logging_prefix, logging_state)
   {
     LOG_(info) << "LocalizedGlobalBasis()" << std::endl;
@@ -155,8 +156,8 @@ public:
   using ElementType = E;
   using LocalizedType = LocalizedGlobalFiniteElementInterface<E, r, rC, R>;
 
-  GlobalBasisInterface(const std::string& logging_prefix = "",
-                       const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit GlobalBasisInterface(const std::string& logging_prefix = "",
+                                const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : Logger(logging_prefix.empty() ? "GlobalBasis" : logging_prefix, logging_state)
   {
     LOG_(debug) << "GlobalBasis()" << std::endl;

--- a/dune/gdt/spaces/basis/raviart-thomas.hh
+++ b/dune/gdt/spaces/basis/raviart-thomas.hh
@@ -120,9 +120,10 @@ private:
     using typename BaseType::LocalFiniteElementType;
     using typename BaseType::RangeType;
 
-    LocalizedRaviartThomasGlobalBasis(const RaviartThomasGlobalBasis<GL, R>& self,
-                                      const std::string& logging_prefix = "",
-                                      const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+    explicit LocalizedRaviartThomasGlobalBasis(
+        const RaviartThomasGlobalBasis<GL, R>& self,
+        const std::string& logging_prefix = "",
+        const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
       : BaseType(logging_prefix.empty() ? "LocalizedRtGlobalBasis" : logging_prefix, logging_state)
       , self_(self)
       , set_data_in_post_bind_(true)

--- a/dune/gdt/spaces/bochner.hh
+++ b/dune/gdt/spaces/bochner.hh
@@ -35,7 +35,7 @@ class BochnerSpace
 {
 public:
   template <class... TemporalGridArgs>
-  BochnerSpace(const SpaceInterface<GV, r, rC, R>& spatial_space, TemporalGridArgs&&... temporal_grid_args)
+  explicit BochnerSpace(const SpaceInterface<GV, r, rC, R>& spatial_space, TemporalGridArgs&&... temporal_grid_args)
     : spatial_space_(spatial_space)
     , temporal_grid_(std::forward<TemporalGridArgs>(temporal_grid_args)...)
     , temporal_space_(temporal_grid_.leafGridView(), /*order=*/1)

--- a/dune/gdt/spaces/interface.hh
+++ b/dune/gdt/spaces/interface.hh
@@ -80,8 +80,8 @@ public:
 
   using DofCommunicatorType = typename DofCommunicationChooser<GridViewType>::Type;
 
-  SpaceInterface(const std::string& logging_prefix = "",
-                 const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit SpaceInterface(const std::string& logging_prefix = "",
+                          const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : Logger(logging_prefix.empty() ? "Space" : logging_prefix, logging_state)
     , dof_communicator_(nullptr)
     , adapted_(false)

--- a/dune/gdt/spaces/l2/discontinuous-lagrange.hh
+++ b/dune/gdt/spaces/l2/discontinuous-lagrange.hh
@@ -79,7 +79,7 @@ private:
   using GlobalBasisImplementation = DefaultGlobalBasis<GridViewType, r, 1, R>;
 
 public:
-  DiscontinuousLagrangeSpace(GridViewType grd_vw, const int order = 1, const bool dimws_glbl_mppng = false)
+  explicit DiscontinuousLagrangeSpace(GridViewType grd_vw, const int order = 1, const bool dimws_glbl_mppng = false)
     : BaseType()
     , grid_view_(grd_vw)
     , order_(order)

--- a/dune/gdt/spaces/l2/finite-volume.hh
+++ b/dune/gdt/spaces/l2/finite-volume.hh
@@ -63,7 +63,7 @@ private:
   using GlobalBasisImplementation = FiniteVolumeGlobalBasis<GridViewType, r, R>;
 
 public:
-  FiniteVolumeSpace(GridViewType grd_vw)
+  explicit FiniteVolumeSpace(GridViewType grd_vw)
     : BaseType()
     , grid_view_(grd_vw)
     , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, r>>())

--- a/dune/gdt/spaces/mapper/finite-volume-skeleton.hh
+++ b/dune/gdt/spaces/mapper/finite-volume-skeleton.hh
@@ -58,7 +58,7 @@ public:
   using typename BaseType::ElementType;
   using typename BaseType::GridViewType;
 
-  FiniteVolumeSkeletonMapper(const GridViewType& grd_vw)
+  explicit FiniteVolumeSkeletonMapper(const GridViewType& grd_vw)
     : grid_view_(grd_vw)
     , local_finite_elements_()
     , element_indices_(grid_view_)

--- a/dune/gdt/spaces/mapper/finite-volume.hh
+++ b/dune/gdt/spaces/mapper/finite-volume.hh
@@ -56,7 +56,7 @@ public:
   using typename BaseType::ElementType;
   using typename BaseType::GridViewType;
 
-  FiniteVolumeMapper(const GridViewType& grd_vw)
+  explicit FiniteVolumeMapper(const GridViewType& grd_vw)
     : grid_view_(grd_vw)
     , local_finite_elements_()
     , mapper_(grid_view_, mcmgElementLayout())

--- a/dune/gdt/spaces/parallel/datahandles.hh
+++ b/dune/gdt/spaces/parallel/datahandles.hh
@@ -266,7 +266,7 @@ public:
     }
   }
 
-  DataGatherScatter(GatherScatter gather_scatter = GatherScatter())
+  explicit DataGatherScatter(GatherScatter gather_scatter = GatherScatter())
     : _gather_scatter(gather_scatter)
   {
   }
@@ -323,7 +323,7 @@ public:
     }
   }
 
-  DataEntityGatherScatter(GatherScatter gather_scatter = GatherScatter())
+  explicit DataEntityGatherScatter(GatherScatter gather_scatter = GatherScatter())
     : gather_scatter_(gather_scatter)
   {
   }
@@ -520,7 +520,7 @@ public:
   /**
    * \param rank  The MPI rank of the current process.
    */
-  DisjointPartitioningGatherScatter(RankIndex rank)
+  explicit DisjointPartitioningGatherScatter(RankIndex rank)
     : rank_(rank)
   {
   }

--- a/dune/gdt/spaces/parallel/helper.hh
+++ b/dune/gdt/spaces/parallel/helper.hh
@@ -57,7 +57,7 @@ class GenericParallelHelper
 
 
 public:
-  GenericParallelHelper(const SpaceType& space, int verbose = 1)
+  explicit GenericParallelHelper(const SpaceType& space, int verbose = 1)
     : space_(space)
     , rank_(space.grid_view().comm().rank())
     , rank_vector_(space.mapper().size(), rank_)

--- a/dune/gdt/spaces/skeleton/finite-volume.hh
+++ b/dune/gdt/spaces/skeleton/finite-volume.hh
@@ -60,7 +60,7 @@ private:
   using GlobalBasisImplementation = FiniteVolumeGlobalBasis<GridViewType, 1, R>;
 
 public:
-  FiniteVolumeSkeletonSpace(GridViewType grd_vw)
+  explicit FiniteVolumeSkeletonSpace(GridViewType grd_vw)
     : BaseType()
     , grid_view_(grd_vw)
     , local_finite_elements_(std::make_unique<const LocalLagrangeFiniteElementFamily<D, d, R, 1>>())

--- a/dune/gdt/test/burgers/base.hh
+++ b/dune/gdt/test/burgers/base.hh
@@ -50,7 +50,7 @@ protected:
   using typename BaseType::V;
 
 public:
-  BurgersTest(const std::string timestepping)
+  explicit BurgersTest(const std::string timestepping)
     : Problem(new BurgersProblem<G>())
     , BaseType(Problem::access().T_end,
                timestepping,

--- a/dune/gdt/test/inviscid-compressible-flow/base.hh
+++ b/dune/gdt/test/inviscid-compressible-flow/base.hh
@@ -108,7 +108,7 @@ protected:
   using RangeType = XT::Common::FieldVector<R, m>;
 
 public:
-  InviscidCompressibleFlowEulerTest(const std::string timestepping, const size_t num_refinements = 2)
+  explicit InviscidCompressibleFlowEulerTest(const std::string timestepping, const size_t num_refinements = 2)
     : Problem(new InviscidCompressibleFlowEulerProblem<G>())
     , BaseType(
           this->access().T_end,

--- a/dune/gdt/test/linear-transport/base.hh
+++ b/dune/gdt/test/linear-transport/base.hh
@@ -91,7 +91,7 @@ protected:
   using typename BaseType::V;
 
 public:
-  LinearTransportTest(const std::string timestepping)
+  explicit LinearTransportTest(const std::string timestepping)
     : Problem(new LinearTransportProblem<G>())
     , BaseType(Problem::access().T_end,
                timestepping,

--- a/dune/gdt/test/spaces/h1_continuous_lagrange.hh
+++ b/dune/gdt/test/spaces/h1_continuous_lagrange.hh
@@ -29,7 +29,7 @@ struct ContinuousLagrangeSpaceTest
 
   XT::Grid::GridProvider<G> grid_provider;
 
-  ContinuousLagrangeSpaceTest(XT::Grid::GridProvider<G>&& grid_provider_)
+  explicit ContinuousLagrangeSpaceTest(XT::Grid::GridProvider<G>&& grid_provider_)
     : grid_provider(grid_provider_)
   {
     this->grid_view = std::make_shared<typename XT::Grid::GridProvider<G>::LeafGridViewType>(grid_provider.leaf_view());

--- a/dune/gdt/test/spaces/l2_discontinuous_galerkin.hh
+++ b/dune/gdt/test/spaces/l2_discontinuous_galerkin.hh
@@ -26,7 +26,7 @@ struct DiscontinuousLagrangeSpaceTest
 {
   XT::Grid::GridProvider<G> grid_provider;
 
-  DiscontinuousLagrangeSpaceTest(XT::Grid::GridProvider<G>&& grid_provider_)
+  explicit DiscontinuousLagrangeSpaceTest(XT::Grid::GridProvider<G>&& grid_provider_)
     : grid_provider(grid_provider_)
   {
     this->grid_view = std::make_shared<typename XT::Grid::GridProvider<G>::LeafGridViewType>(grid_provider.leaf_view());

--- a/dune/gdt/test/stationary-eocstudies/base.hh
+++ b/dune/gdt/test/stationary-eocstudies/base.hh
@@ -81,7 +81,7 @@ protected:
 public:
   using E = XT::Grid::extract_entity_t<GV>;
 
-  StationaryEocStudy(
+  explicit StationaryEocStudy(
       std::function<void(const DF&, const std::string&)> visualizer =
           [](const auto& solution, const auto& prefix) {
             if (DXTC_TEST_CONFIG_GET("setup.visualize", false))

--- a/dune/gdt/test/stokes/stokes-taylorhood.hh
+++ b/dune/gdt/test/stokes/stokes-taylorhood.hh
@@ -69,7 +69,7 @@ class StokesDirichletTest : public ::testing::Test
   using RangeField = double;
 
 public:
-  StokesDirichletTest(StokesDirichletProblem<GV> problem)
+  explicit StokesDirichletTest(StokesDirichletProblem<GV> problem)
     : problem_(problem)
   {
   }

--- a/dune/gdt/tools/adaptation-helper.hh
+++ b/dune/gdt/tools/adaptation-helper.hh
@@ -52,9 +52,9 @@ public:
   using G = typename GV::Grid;
   static_assert(!XT::Grid::is_yaspgrid<G>::value, "The PersistentContainer is known to segfault for YaspGrid!");
 
-  AdaptationHelper(G& grd,
-                   const std::string& logging_prefix = "",
-                   const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
+  explicit AdaptationHelper(G& grd,
+                            const std::string& logging_prefix = "",
+                            const std::array<bool, 3>& logging_state = XT::Common::default_logger_state())
     : Logger(logging_prefix.empty() ? "AdaptationHelper" : logging_prefix, logging_state)
     , grid_(grd)
     , data_(new std::remove_reference_t<decltype(*data_)>)

--- a/dune/gdt/tools/euler.hh
+++ b/dune/gdt/tools/euler.hh
@@ -71,7 +71,7 @@ class EulerTools
 public:
   static constexpr size_t m = d + 2;
 
-  EulerTools(const double& gmma) // air or water at roughly 20 deg Cels.: gmma = 1.4
+  explicit EulerTools(const double& gmma) // air or water at roughly 20 deg Cels.: gmma = 1.4
     : gamma_(gmma)
   {
   }

--- a/dune/xt/common/configuration.hh
+++ b/dune/xt/common/configuration.hh
@@ -35,9 +35,9 @@ namespace XT::Common {
 /// \brief Bundles the default behaviour flags of a Configuration (default-access warnings, logging on exit, logfile).
 struct ConfigurationDefaults
 {
-  ConfigurationDefaults(bool warn_on_default_access_in = false,
-                        bool log_on_exit_in = false,
-                        std::string logfile_in = std::string("data/log/dxtc_parameter.log"));
+  explicit ConfigurationDefaults(bool warn_on_default_access_in = false,
+                                 bool log_on_exit_in = false,
+                                 std::string logfile_in = std::string("data/log/dxtc_parameter.log"));
   const bool warn_on_default_access;
   const bool log_on_exit;
   const std::string logfile;

--- a/dune/xt/common/fixed_map.hh
+++ b/dune/xt/common/fixed_map.hh
@@ -162,7 +162,7 @@ public:
   {
   }
 
-  FixedMap(const MapType& map)
+  explicit FixedMap(const MapType& map)
     : map_(map)
   {
   }

--- a/dune/xt/common/fmatrix-2.6.hh
+++ b/dune/xt/common/fmatrix-2.6.hh
@@ -153,7 +153,7 @@ private:
   // copy from dune/common/densematrix.hh, we have to copy it as it is a private member of Dune::DenseMatrix
   struct ElimPivot
   {
-    ElimPivot(std::vector<size_type>& pivot)
+    explicit ElimPivot(std::vector<size_type>& pivot)
       : pivot_(pivot)
     {
       using size_type = typename std::vector<size_type>::size_type;
@@ -177,7 +177,7 @@ private:
   template <typename V>
   struct Elim
   {
-    Elim(V& rhs)
+    explicit Elim(V& rhs)
       : rhs_(&rhs)
     {
     }
@@ -197,7 +197,7 @@ private:
 
   struct ElimDet
   {
-    ElimDet(field_type& sign)
+    explicit ElimDet(field_type& sign)
       : sign_(sign)
     {
       sign_ = 1;

--- a/dune/xt/common/math.hh
+++ b/dune/xt/common/math.hh
@@ -158,7 +158,7 @@ public:
   MinMaxAvg() = default;
 
   template <class stl_container_type>
-  MinMaxAvg(const stl_container_type& elements)
+  explicit MinMaxAvg(const stl_container_type& elements)
   {
     static_assert((std::is_same<ElementType, typename stl_container_type::value_type>::value),
                   "cannot assign mismatching types");

--- a/dune/xt/common/parallel/threadstorage.hh
+++ b/dune/xt/common/parallel/threadstorage.hh
@@ -306,7 +306,7 @@ template <class Imp, typename Result, class Reduction = std::plus<Result>>
 class ThreadResultPropagator
 {
 public:
-  ThreadResultPropagator(Imp* imp)
+  explicit ThreadResultPropagator(Imp* imp)
     : imp_(imp)
     , base_(imp)
   {

--- a/dune/xt/common/parameter.hh
+++ b/dune/xt/common/parameter.hh
@@ -288,7 +288,7 @@ std::ostream& operator<<(std::ostream& out, const Parameter& mu);
 class ParametricInterface
 {
 public:
-  ParametricInterface(ParameterType param_type = {});
+  explicit ParametricInterface(ParameterType param_type = {});
 
   ParametricInterface(const ParametricInterface& other) = default;
 

--- a/dune/xt/common/print.hh
+++ b/dune/xt/common/print.hh
@@ -105,7 +105,7 @@ class VectorPrinter : public internal::DefaultPrinter<T, use_repr>
 public:
   const std::string class_name;
 
-  VectorPrinter(const T& val, const Configuration& cfg = {}, std::string clss_nm = Typename<T>::value())
+  explicit VectorPrinter(const T& val, const Configuration& cfg = {}, std::string clss_nm = Typename<T>::value())
     : internal::DefaultPrinter<T, use_repr>(val, cfg)
     , class_name(std::move(clss_nm))
   {
@@ -156,7 +156,7 @@ class MatrixPrinter : public internal::DefaultPrinter<T, use_repr>
 public:
   const std::string class_name;
 
-  MatrixPrinter(const T& val, const Configuration& cfg = {}, std::string clss_nm = Typename<T>::value())
+  explicit MatrixPrinter(const T& val, const Configuration& cfg = {}, std::string clss_nm = Typename<T>::value())
     : internal::DefaultPrinter<T, use_repr>(val, cfg)
     , class_name(std::move(clss_nm))
   {
@@ -247,7 +247,7 @@ template <class T, bool use_repr, typename anything>
 class Printer : public internal::DefaultPrinter<T, use_repr>
 {
 public:
-  Printer(const T& val, const Configuration& param = {})
+  explicit Printer(const T& val, const Configuration& param = {})
     : internal::DefaultPrinter<T, use_repr>(val, param)
   {
   }
@@ -271,7 +271,7 @@ template <class M, bool use_repr>
 class Printer<M, use_repr, std::enable_if_t<is_matrix<M>::value>> : public internal::MatrixPrinter<M, use_repr>
 {
 public:
-  Printer(const M& val, const Configuration& param = {{"oneline", "false"}})
+  explicit Printer(const M& val, const Configuration& param = {{"oneline", "false"}})
     : internal::MatrixPrinter<M, use_repr>(val, param)
   {
   }
@@ -282,7 +282,7 @@ template <bool use_repr, typename anything>
 class Printer<Configuration, use_repr, anything> : public internal::DefaultPrinter<Configuration, use_repr>
 {
 public:
-  Printer(const Configuration& val, const Configuration& param = {{"oneline", "false"}})
+  explicit Printer(const Configuration& val, const Configuration& param = {{"oneline", "false"}})
     : internal::DefaultPrinter<Configuration, use_repr>(val, param)
   {
   }
@@ -318,7 +318,7 @@ template <bool use_repr, typename anything>
 class Printer<ParameterType, use_repr, anything> : public internal::DefaultPrinter<ParameterType, use_repr>
 {
 public:
-  Printer(const ParameterType& val, const Configuration& param = {})
+  explicit Printer(const ParameterType& val, const Configuration& param = {})
     : internal::DefaultPrinter<ParameterType, use_repr>(val, param)
   {
   }
@@ -354,7 +354,7 @@ template <bool use_repr, typename anything>
 class Printer<Parameter, use_repr, anything> : public internal::DefaultPrinter<Parameter, use_repr>
 {
 public:
-  Printer(const Parameter& val, const Configuration& param = {})
+  explicit Printer(const Parameter& val, const Configuration& param = {})
     : internal::DefaultPrinter<Parameter, use_repr>(val, param)
   {
   }
@@ -494,7 +494,7 @@ public:
   using reference = T;
   using iterator_category = std::output_iterator_tag;
 
-  PrefixOutputIterator(std::ostream& o, std::string p = "")
+  explicit PrefixOutputIterator(std::ostream& o, std::string p = "")
     : ostream(o)
     , prefix(std::move(p))
     , first(true)

--- a/dune/xt/common/random.hh
+++ b/dune/xt/common/random.hh
@@ -134,9 +134,9 @@ class DefaultRNG<std::complex<T>, false>
   using BaseType = RNG<std::complex<T>, typename UniformDistributionSelector<T>::type, std::default_random_engine>;
 
 public:
-  DefaultRNG(T min = std::numeric_limits<T>::min(),
-             T max = std::numeric_limits<T>::max(),
-             std::random_device::result_type seed = std::random_device()())
+  explicit DefaultRNG(T min = std::numeric_limits<T>::min(),
+                      T max = std::numeric_limits<T>::max(),
+                      std::random_device::result_type seed = std::random_device()())
     : BaseType(std::default_random_engine(seed), typename UniformDistributionSelector<T>::type(min, max))
   {
   }
@@ -149,15 +149,16 @@ class DefaultRNG<VectorType, true>
   using RngType = DefaultRNG<T>;
 
 public:
-  DefaultRNG(VectorType min_vec = VectorAbstraction<VectorType>::create(VectorAbstraction<VectorType>::has_static_size
-                                                                            ? VectorAbstraction<VectorType>::static_size
-                                                                            : 1,
-                                                                        std::numeric_limits<T>::min()),
-             VectorType max_vec = VectorAbstraction<VectorType>::create(VectorAbstraction<VectorType>::has_static_size
-                                                                            ? VectorAbstraction<VectorType>::static_size
-                                                                            : 1,
-                                                                        std::numeric_limits<T>::max()),
-             std::random_device::result_type seed = std::random_device()())
+  explicit DefaultRNG(
+      VectorType min_vec = VectorAbstraction<VectorType>::create(VectorAbstraction<VectorType>::has_static_size
+                                                                     ? VectorAbstraction<VectorType>::static_size
+                                                                     : 1,
+                                                                 std::numeric_limits<T>::min()),
+      VectorType max_vec = VectorAbstraction<VectorType>::create(VectorAbstraction<VectorType>::has_static_size
+                                                                     ? VectorAbstraction<VectorType>::static_size
+                                                                     : 1,
+                                                                 std::numeric_limits<T>::max()),
+      std::random_device::result_type seed = std::random_device()())
   {
     if (min_vec.size() != max_vec.size())
       DUNE_THROW(Exceptions::shapes_do_not_match,
@@ -187,7 +188,8 @@ template <>
 class DefaultRNG<std::string> : public RandomStrings
 {
 public:
-  DefaultRNG(size_t ilength = default_rng_string_length, std::random_device::result_type seed = std::random_device()())
+  explicit DefaultRNG(size_t ilength = default_rng_string_length,
+                      std::random_device::result_type seed = std::random_device()())
     : RandomStrings(ilength, seed)
   {
   }

--- a/dune/xt/common/timedlogging.hh
+++ b/dune/xt/common/timedlogging.hh
@@ -82,10 +82,10 @@ public:
   std::array<bool, 3> state;
   size_t copy_count{0};
 
-  DefaultLogger(const std::string& prfx = "",
-                const std::array<bool, 3>& initial_state = default_logger_state(),
-                std::array<std::string, 3> colors = {{"blue", "darkgray", "red"}},
-                bool global_timer = true);
+  explicit DefaultLogger(const std::string& prfx = "",
+                         const std::array<bool, 3>& initial_state = default_logger_state(),
+                         std::array<std::string, 3> colors = {{"blue", "darkgray", "red"}},
+                         bool global_timer = true);
 
   DefaultLogger(const DefaultLogger&);
 
@@ -174,7 +174,7 @@ class WithLogger
 public:
   mutable DefaultLogger logger;
 
-  WithLogger(const std::string& id, const std::array<bool, 3>& initial_state = {{true, true, true}})
+  explicit WithLogger(const std::string& id, const std::array<bool, 3>& initial_state = {{true, true, true}})
     : logger(id, initial_state)
   {
     LOG_(debug) << "WithLogger(this=" << this << ")" << std::endl;

--- a/dune/xt/common/validation.hh
+++ b/dune/xt/common/validation.hh
@@ -112,7 +112,7 @@ template <class T>
 class ValidateLess : public ValidatorInterface<T, ValidateLess<T>>
 {
 public:
-  ValidateLess(const T& lhs)
+  explicit ValidateLess(const T& lhs)
     : lhs_(lhs)
   {
   }
@@ -135,7 +135,7 @@ template <class T>
 class ValidateGreater : public ValidatorInterface<T, ValidateGreater<T>>
 {
 public:
-  ValidateGreater(const T& lhs)
+  explicit ValidateGreater(const T& lhs)
     : lhs_(lhs)
   {
   }
@@ -159,11 +159,11 @@ template <class T, class Validator>
 class ValidateInverse : public ValidatorInterface<T, ValidateInverse<T, Validator>>
 {
 public:
-  ValidateInverse(const Validator validator = Validator())
+  explicit ValidateInverse(const Validator validator = Validator())
     : validator_(validator)
   {
   }
-  ValidateInverse(const T arg)
+  explicit ValidateInverse(const T arg)
     : validator_(Validator(arg))
   {
   }

--- a/dune/xt/functions/ESV2007.hh
+++ b/dune/xt/functions/ESV2007.hh
@@ -74,8 +74,8 @@ public:
     return config;
   } // ... defaults(...)
 
-  Testcase1Force(const size_t ord = defaults().template get<int>("integration_order"),
-                 std::string nm = "ESV2007Testcase1Force")
+  explicit Testcase1Force(const size_t ord = defaults().template get<int>("integration_order"),
+                          std::string nm = "ESV2007Testcase1Force")
     : order_(static_cast<int>(ord))
     , name_(std::move(nm))
   {
@@ -174,8 +174,8 @@ public:
     return config;
   } // ... defaults(...)
 
-  Testcase1ExactSolution(const size_t ord = defaults().template get<int>("integration_order"),
-                         std::string nm = "ESV2007Testcase1ExactSolution")
+  explicit Testcase1ExactSolution(const size_t ord = defaults().template get<int>("integration_order"),
+                                  std::string nm = "ESV2007Testcase1ExactSolution")
     : order_(static_cast<int>(ord))
     , name_(std::move(nm))
   {

--- a/dune/xt/functions/base/derivatives-of-element-functions.hh
+++ b/dune/xt/functions/base/derivatives-of-element-functions.hh
@@ -186,21 +186,21 @@ public:
   using typename BaseType::ElementType;
   using typename BaseType::RangeReturnType;
 
-  DerivativeElementFunction(ElementFunctionType& func)
+  explicit DerivativeElementFunction(ElementFunctionType& func)
     : BaseType()
     , func_(func)
     , do_post_bind_(true)
   {
   }
 
-  DerivativeElementFunction(std::shared_ptr<ElementFunctionType> func)
+  explicit DerivativeElementFunction(std::shared_ptr<ElementFunctionType> func)
     : BaseType()
     , func_(func)
     , do_post_bind_(true)
   {
   }
 
-  DerivativeElementFunction(std::unique_ptr<ElementFunctionType>&& func)
+  explicit DerivativeElementFunction(std::unique_ptr<ElementFunctionType>&& func)
     : BaseType()
     , func_(std::move(func))
     , do_post_bind_(true)

--- a/dune/xt/functions/base/function-as-flux-function.hh
+++ b/dune/xt/functions/base/function-as-flux-function.hh
@@ -37,12 +37,12 @@ public:
   using typename BaseType::LocalFunctionType;
   using FunctionType = FunctionInterface<s, r, rC, R>;
 
-  StateFunctionAsFluxFunctionWrapper(const FunctionType& function)
+  explicit StateFunctionAsFluxFunctionWrapper(const FunctionType& function)
     : function_storage_(function)
   {
   }
 
-  StateFunctionAsFluxFunctionWrapper(std::unique_ptr<const FunctionType>&& function_ptr)
+  explicit StateFunctionAsFluxFunctionWrapper(std::unique_ptr<const FunctionType>&& function_ptr)
     : function_storage_(std::move(function_ptr))
   {
   }
@@ -88,7 +88,7 @@ private:
     using typename BaseType::RangeReturnType;
     using typename BaseType::StateType;
 
-    LocalFunction(const FunctionType& function)
+    explicit LocalFunction(const FunctionType& function)
       : BaseType()
       , function_(function)
     {

--- a/dune/xt/functions/base/function-as-grid-function.hh
+++ b/dune/xt/functions/base/function-as-grid-function.hh
@@ -39,19 +39,19 @@ public:
   using typename BaseType::LocalFunctionType;
   using FunctionType = FunctionInterface<d, r, rC, R>;
 
-  FunctionAsGridFunctionWrapper(const FunctionType& function)
+  explicit FunctionAsGridFunctionWrapper(const FunctionType& function)
     : BaseType(function.parameter_type())
     , function_(function.copy_as_function())
   {
   }
 
-  FunctionAsGridFunctionWrapper(FunctionType*&& function_ptr)
+  explicit FunctionAsGridFunctionWrapper(FunctionType*&& function_ptr)
     : BaseType(function_ptr->parameter_type())
     , function_(std::move(function_ptr))
   {
   }
 
-  FunctionAsGridFunctionWrapper(std::unique_ptr<FunctionType>&& function_ptr)
+  explicit FunctionAsGridFunctionWrapper(std::unique_ptr<FunctionType>&& function_ptr)
     : BaseType(function_ptr->parameter_type())
     , function_(std::move(function_ptr))
   {
@@ -99,7 +99,7 @@ private:
     using typename BaseType::DomainType;
     using typename BaseType::RangeReturnType;
 
-    LocalFunction(const FunctionType& function)
+    explicit LocalFunction(const FunctionType& function)
       : BaseType()
       , function_(function.copy_as_function())
       , geometry_(nullptr)

--- a/dune/xt/functions/base/visualization.hh
+++ b/dune/xt/functions/base/visualization.hh
@@ -145,7 +145,7 @@ class ComponentVisualizer : public VisualizerInterface<r, rC, R>
 public:
   using typename BaseType::RangeType;
 
-  ComponentVisualizer(const int comp)
+  explicit ComponentVisualizer(const int comp)
     : comp_(comp)
   {
   }

--- a/dune/xt/functions/elementwise-diameter.hh
+++ b/dune/xt/functions/elementwise-diameter.hh
@@ -76,7 +76,7 @@ public:
   using BaseType::rC;
   using typename BaseType::LocalFunctionType;
 
-  ElementwiseDiameterFunction(std::string nm = "ElementwiseDiameterFunction")
+  explicit ElementwiseDiameterFunction(std::string nm = "ElementwiseDiameterFunction")
     : BaseType()
     , name_(std::move(nm))
   {

--- a/dune/xt/functions/generic/element-function.hh
+++ b/dune/xt/functions/generic/element-function.hh
@@ -233,7 +233,7 @@ public:
       const std::array<size_t, d>&, const DomainType&, const Common::Parameter&)>;
   using GenericPostBindFunctionType = std::function<void(const ElementType&)>;
 
-  GenericElementFunction(
+  explicit GenericElementFunction(
       GenericOrderFunctionType order_func,
       GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
       const Common::ParameterType& param_type = {},
@@ -249,7 +249,7 @@ public:
   {
   }
 
-  GenericElementFunction(
+  explicit GenericElementFunction(
       const int ord,
       GenericEvaluateFunctionType evaluate_lambda = default_evaluate_function(),
       const Common::ParameterType& param_type = {},

--- a/dune/xt/functions/generic/function.hh
+++ b/dune/xt/functions/generic/function.hh
@@ -54,12 +54,12 @@ public:
   using GenericDerivativeFunctionType = std::function<DerivativeRangeReturnType(
       const std::array<size_t, d>&, const DomainType&, const Common::Parameter&)>;
 
-  GenericFunction(GenericOrderFunctionType order_func,
-                  GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
-                  std::string nm = "smooth_lambda_function",
-                  const Common::ParameterType& param_type = {},
-                  GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
-                  GenericDerivativeFunctionType derivative_func = default_derivative_function())
+  explicit GenericFunction(GenericOrderFunctionType order_func,
+                           GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
+                           std::string nm = "smooth_lambda_function",
+                           const Common::ParameterType& param_type = {},
+                           GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
+                           GenericDerivativeFunctionType derivative_func = default_derivative_function())
     : BaseType(param_type)
     , order_(std::move(order_func))
     , evaluate_(evaluate_func)
@@ -70,12 +70,12 @@ public:
   {
   }
 
-  GenericFunction(int ord,
-                  GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
-                  std::string nm = "smooth_lambda_function",
-                  const Common::ParameterType& param_type = {},
-                  GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
-                  GenericDerivativeFunctionType derivative_func = default_derivative_function())
+  explicit GenericFunction(int ord,
+                           GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
+                           std::string nm = "smooth_lambda_function",
+                           const Common::ParameterType& param_type = {},
+                           GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
+                           GenericDerivativeFunctionType derivative_func = default_derivative_function())
     : BaseType(param_type)
     , order_([=](const auto& /*param*/) { return ord; })
     , evaluate_(std::move(evaluate_func))

--- a/dune/xt/functions/generic/grid-function.hh
+++ b/dune/xt/functions/generic/grid-function.hh
@@ -176,13 +176,13 @@ public:
   using GenericDerivativeFunctionType = std::function<DerivativeRangeReturnType(
       const std::array<size_t, d>&, const DomainType&, const XT::Common::Parameter&)>;
 
-  GenericGridFunction(const int ord,
-                      GenericPostBindFunctionType post_bind_func = default_post_bind_function(),
-                      GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
-                      const Common::ParameterType& param_type = Common::ParameterType(),
-                      std::string nm = "GenericGridFunction",
-                      GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
-                      GenericDerivativeFunctionType derivative_func = default_derivative_function())
+  explicit GenericGridFunction(const int ord,
+                               GenericPostBindFunctionType post_bind_func = default_post_bind_function(),
+                               GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
+                               const Common::ParameterType& param_type = Common::ParameterType(),
+                               std::string nm = "GenericGridFunction",
+                               GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
+                               GenericDerivativeFunctionType derivative_func = default_derivative_function())
     : BaseType(param_type)
     , order_(default_order_lambda(ord))
     , post_bind_(std::move(post_bind_func))
@@ -193,13 +193,13 @@ public:
   {
   }
 
-  GenericGridFunction(GenericOrderFunctionType order_func,
-                      GenericPostBindFunctionType post_bind_func = default_post_bind_function(),
-                      GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
-                      const Common::ParameterType& param_type = Common::ParameterType(),
-                      std::string nm = "GenericGridFunction",
-                      GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
-                      GenericDerivativeFunctionType derivative_func = default_derivative_function())
+  explicit GenericGridFunction(GenericOrderFunctionType order_func,
+                               GenericPostBindFunctionType post_bind_func = default_post_bind_function(),
+                               GenericEvaluateFunctionType evaluate_func = default_evaluate_function(),
+                               const Common::ParameterType& param_type = Common::ParameterType(),
+                               std::string nm = "GenericGridFunction",
+                               GenericJacobianFunctionType jacobian_func = default_jacobian_function(),
+                               GenericDerivativeFunctionType derivative_func = default_derivative_function())
     : BaseType(param_type)
     , order_(std::move(order_func))
     , post_bind_(std::move(post_bind_func))

--- a/dune/xt/functions/indicator.hh
+++ b/dune/xt/functions/indicator.hh
@@ -46,7 +46,7 @@ class IndicatorGridFunction : public GridFunctionInterface<E, r, rC, R>
     using typename InterfaceType::RangeType;
     using GeometryType = typename ElementType::Geometry;
 
-    LocalIndicatorGridFunction(
+    explicit LocalIndicatorGridFunction(
         const std::shared_ptr<std::vector<std::tuple<DomainType, DomainType, RangeType>>> subdomain_and_value_tuples)
       : InterfaceType()
       , subdomain_and_value_tuples_(subdomain_and_value_tuples)
@@ -120,8 +120,8 @@ public:
     return config;
   } // ... defaults(...)
 
-  IndicatorGridFunction(std::shared_ptr<std::vector<std::tuple<DomainType, DomainType, RangeType>>> values,
-                        std::string name_in = "IndicatorGridFunction")
+  explicit IndicatorGridFunction(std::shared_ptr<std::vector<std::tuple<DomainType, DomainType, RangeType>>> values,
+                                 std::string name_in = "IndicatorGridFunction")
     : subdomain_and_value_tuples_(std::move(values))
     , name_(std::move(name_in))
   {
@@ -133,8 +133,8 @@ public:
 FunctionType function({{lowerleft_1, upperright_1, value_1}, {lowerleft_2, upperright_2, value_2}});
 \endcode
    */
-  IndicatorGridFunction(const std::vector<std::tuple<DomainType, DomainType, RangeType>>& values,
-                        const std::string& nm = "IndicatorGridFunction")
+  explicit IndicatorGridFunction(const std::vector<std::tuple<DomainType, DomainType, RangeType>>& values,
+                                 const std::string& nm = "IndicatorGridFunction")
     : IndicatorGridFunction(std::make_shared<std::vector<std::tuple<DomainType, DomainType, RangeType>>>(values), nm)
   {
   }
@@ -148,8 +148,8 @@ FunctionType function({{{{0., 1.}, {0., 1.}}, 0.7}, {{{6., 10.}, {8., 10.}}, 0.9
 \endcode
    * if you want to set indicator intervals [0,1] x [0,1] with value 0.7 and [6,10] x [8,10] with value 0.9.
    */
-  IndicatorGridFunction(const std::vector<std::pair<Common::FieldMatrix<D, d, 2>, RangeType>>& values,
-                        const std::string& nm = "IndicatorGridFunction")
+  explicit IndicatorGridFunction(const std::vector<std::pair<Common::FieldMatrix<D, d, 2>, RangeType>>& values,
+                                 const std::string& nm = "IndicatorGridFunction")
     : IndicatorGridFunction(convert_from_domains(values), nm)
   {
   }
@@ -216,21 +216,21 @@ public:
   using typename BaseType::DomainType;
   using typename BaseType::RangeReturnType;
 
-  IndicatorFunction(std::shared_ptr<std::vector<std::tuple<DomainType, DomainType, RangeReturnType>>> values,
-                    std::string nm = "IndicatorFunction")
+  explicit IndicatorFunction(std::shared_ptr<std::vector<std::tuple<DomainType, DomainType, RangeReturnType>>> values,
+                             std::string nm = "IndicatorFunction")
     : subdomain_and_value_tuples_(std::move(values))
     , name_(std::move(nm))
   {
   }
 
-  IndicatorFunction(const std::vector<std::tuple<DomainType, DomainType, RangeReturnType>>& values,
-                    const std::string& nm = "IndicatorFunction")
+  explicit IndicatorFunction(const std::vector<std::tuple<DomainType, DomainType, RangeReturnType>>& values,
+                             const std::string& nm = "IndicatorFunction")
     : IndicatorFunction(std::make_shared<std::vector<std::tuple<DomainType, DomainType, RangeReturnType>>>(values), nm)
   {
   }
 
-  IndicatorFunction(const std::vector<std::pair<Common::FieldMatrix<D, d, 2>, RangeReturnType>>& values,
-                    const std::string& nm = "IndicatorFunction")
+  explicit IndicatorFunction(const std::vector<std::pair<Common::FieldMatrix<D, d, 2>, RangeReturnType>>& values,
+                             const std::string& nm = "IndicatorFunction")
     : IndicatorFunction(convert_from_domains(values), nm)
   {
   }

--- a/dune/xt/functions/interfaces/element-flux-functions.hh
+++ b/dune/xt/functions/interfaces/element-flux-functions.hh
@@ -103,7 +103,7 @@ public:
   /// \}
 
 
-  ElementFluxFunctionSetInterface(const XT::Common::ParameterType& param_type = {})
+  explicit ElementFluxFunctionSetInterface(const XT::Common::ParameterType& param_type = {})
     : Common::ParametricInterface(param_type)
   {
   }
@@ -400,7 +400,7 @@ public:
 
   /// \}
 
-  ElementFluxFunctionInterface(const XT::Common::ParameterType& param_type = {})
+  explicit ElementFluxFunctionInterface(const XT::Common::ParameterType& param_type = {})
     : BaseType(param_type)
   {
   }

--- a/dune/xt/functions/interfaces/element-functions.hh
+++ b/dune/xt/functions/interfaces/element-functions.hh
@@ -135,7 +135,7 @@ public:
   /// \}
 
 
-  ElementFunctionSetInterface(const XT::Common::ParameterType& param_type = {})
+  explicit ElementFunctionSetInterface(const XT::Common::ParameterType& param_type = {})
     : Common::ParametricInterface(param_type)
   {
   }
@@ -493,7 +493,7 @@ public:
 
   /// \}
 
-  ElementFunctionInterface(const XT::Common::ParameterType& param_type = {})
+  explicit ElementFunctionInterface(const XT::Common::ParameterType& param_type = {})
     : BaseType(param_type)
   {
   }

--- a/dune/xt/functions/interfaces/flux-function.hh
+++ b/dune/xt/functions/interfaces/flux-function.hh
@@ -75,7 +75,7 @@ public:
 
   static constexpr bool available = false;
 
-  FluxFunctionInterface(const Common::ParameterType& param_type = {})
+  explicit FluxFunctionInterface(const Common::ParameterType& param_type = {})
     : Common::ParametricInterface(param_type)
   {
   }

--- a/dune/xt/functions/interfaces/grid-function.hh
+++ b/dune/xt/functions/interfaces/grid-function.hh
@@ -106,9 +106,9 @@ private:
   }
 
 public:
-  GridFunctionInterface(const Common::ParameterType& param_type = {},
-                        const std::string& logging_prefix = "",
-                        const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit GridFunctionInterface(const Common::ParameterType& param_type = {},
+                                 const std::string& logging_prefix = "",
+                                 const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : Common::ParametricInterface(param_type)
     , Logger(logging_prefix.empty() ? "GridFunctionInterface" : logging_prefix, logging_state)
   {

--- a/dune/xt/grid/boundaryinfo/functionbased.hh
+++ b/dune/xt/grid/boundaryinfo/functionbased.hh
@@ -51,10 +51,10 @@ public:
 
   using BaseType::logger;
 
-  FunctionBasedBoundaryInfo(const BoundaryType& default_boundary_type = NoBoundary(),
-                            const double tol = 1e-10,
-                            const std::string& logging_prefix = "",
-                            const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit FunctionBasedBoundaryInfo(const BoundaryType& default_boundary_type = NoBoundary(),
+                                     const double tol = 1e-10,
+                                     const std::string& logging_prefix = "",
+                                     const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : BaseType(logging_prefix.empty() ? "FunctionBasedBoundaryInfo" : logging_prefix, logging_state)
     , tol_(tol)
     , default_boundary_type_(default_boundary_type.copy())

--- a/dune/xt/grid/boundaryinfo/interfaces.hh
+++ b/dune/xt/grid/boundaryinfo/interfaces.hh
@@ -80,8 +80,8 @@ public:
   using DomainType = Common::FieldVector<DomainFieldType, dimDomain>;
   using WorldType = Common::FieldVector<DomainFieldType, dimWorld>;
 
-  BoundaryInfo(const std::string& logging_prefix = "",
-               const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit BoundaryInfo(const std::string& logging_prefix = "",
+                        const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : Logger(logging_prefix.empty() ? "BoundaryInfo" : logging_prefix, logging_state)
   {
   }

--- a/dune/xt/grid/boundaryinfo/normalbased.hh
+++ b/dune/xt/grid/boundaryinfo/normalbased.hh
@@ -164,10 +164,10 @@ public:
   /**
    * \attention Takes ownership of default_boundary_type, do not delete manually!
    */
-  NormalBasedBoundaryInfo(const DomainFieldType tol = 1e-10,
-                          BoundaryType*&& default_boundary_type = new NoBoundary(),
-                          const std::string& logging_prefix = "",
-                          const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit NormalBasedBoundaryInfo(const DomainFieldType tol = 1e-10,
+                                   BoundaryType*&& default_boundary_type = new NoBoundary(),
+                                   const std::string& logging_prefix = "",
+                                   const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : BaseType(logging_prefix.empty() ? "NormalBasedBoundaryInfo" : logging_prefix, logging_state)
     , tol_(tol)
     , default_boundary_type_(default_boundary_type)

--- a/dune/xt/grid/dd/glued.hh
+++ b/dune/xt/grid/dd/glued.hh
@@ -195,7 +195,7 @@ private:
     using ctype = typename GridView::ctype;
 
   public:
-    CouplingFaceDescriptor(const MacroIntersectionType& macro_intersection)
+    explicit CouplingFaceDescriptor(const MacroIntersectionType& macro_intersection)
       : macro_intersection_(macro_intersection)
     {
     }
@@ -227,11 +227,11 @@ private:
   }
 
 public:
-  Glued(MacroGridProviderType& macro_grid_provider,
-        const size_t num_local_refinements = 0,
-        const bool prepare_glues = false,
-        const bool allow_for_broken_orientation_of_coupling_intersections = false,
-        const ctype& allowed_overlap = 10 * XT::Common::FloatCmp::DefaultEpsilon<ctype>::value())
+  explicit Glued(MacroGridProviderType& macro_grid_provider,
+                 const size_t num_local_refinements = 0,
+                 const bool prepare_glues = false,
+                 const bool allow_for_broken_orientation_of_coupling_intersections = false,
+                 const ctype& allowed_overlap = 10 * XT::Common::FloatCmp::DefaultEpsilon<ctype>::value())
     : macro_grid_(macro_grid_provider)
     , allowed_overlap_(allowed_overlap)
     , macro_leaf_view_(macro_grid_.leaf_view())
@@ -1072,7 +1072,7 @@ class GluedVTKWriter
 public:
   using GluedGridType = Glued<MacroGridType, LocalGridType, layer>;
 
-  GluedVTKWriter(const GluedGridType& glued_grid, const int local_level = -1)
+  explicit GluedVTKWriter(const GluedGridType& glued_grid, const int local_level = -1)
     : glued_grid_(glued_grid)
     , local_levels_(glued_grid_.num_subdomains(), -1)
   {

--- a/dune/xt/grid/filters/base.hh
+++ b/dune/xt/grid/filters/base.hh
@@ -132,8 +132,8 @@ public:
 
   mutable Common::DefaultLogger logger;
 
-  IntersectionFilter(const std::string& logging_prefix = "xt.grid.intersectionfilter",
-                     const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit IntersectionFilter(const std::string& logging_prefix = "xt.grid.intersectionfilter",
+                              const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : logger(logging_prefix, logging_state)
   {
   }
@@ -311,12 +311,12 @@ public:
   using typename BaseType::GridViewType;
   using typename BaseType::IntersectionType;
 
-  NegatedIntersectionFilter(const BaseType& filter)
+  explicit NegatedIntersectionFilter(const BaseType& filter)
     : filter_(filter.copy())
   {
   }
 
-  NegatedIntersectionFilter(BaseType*&& filter)
+  explicit NegatedIntersectionFilter(BaseType*&& filter)
     : filter_(std::move(filter))
   {
   }
@@ -345,12 +345,12 @@ public:
   using typename BaseType::ElementType;
   using typename BaseType::GridViewType;
 
-  NegatedElementFilter(const BaseType& filter)
+  explicit NegatedElementFilter(const BaseType& filter)
     : filter_(filter.copy())
   {
   }
 
-  NegatedElementFilter(BaseType*&& filter)
+  explicit NegatedElementFilter(BaseType*&& filter)
     : filter_(std::move(filter))
   {
   }

--- a/dune/xt/grid/filters/intersection.hh
+++ b/dune/xt/grid/filters/intersection.hh
@@ -248,7 +248,7 @@ public:
     }
   }
 
-  InnerIntersectionsOnceMap(const std::map<size_t, std::set<size_t>>& outside_indices_to_ignore)
+  explicit InnerIntersectionsOnceMap(const std::map<size_t, std::set<size_t>>& outside_indices_to_ignore)
     : outside_indices_to_ignore_(outside_indices_to_ignore)
   {
   }
@@ -474,7 +474,7 @@ public:
     InnerIntersectionsOnceMap<GV>::fill_ignore_map(outside_indices_to_ignore, entity_range, grid_view);
   }
 
-  PeriodicBoundaryIntersectionsOnceMap(const std::map<size_t, std::set<size_t>>& outside_indices_to_ignore)
+  explicit PeriodicBoundaryIntersectionsOnceMap(const std::map<size_t, std::set<size_t>>& outside_indices_to_ignore)
     : outside_indices_to_ignore_(outside_indices_to_ignore)
   {
   }

--- a/dune/xt/grid/functors/interfaces.hh
+++ b/dune/xt/grid/functors/interfaces.hh
@@ -51,8 +51,8 @@ public:
   using GV = GridViewType;
   using E = ElementType;
 
-  ElementFunctor(const std::string& log_prefix = "",
-                 const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit ElementFunctor(const std::string& log_prefix = "",
+                          const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : Common::WithLogger<ElementFunctor<GL>>(log_prefix.empty() ? "ElementFunctor" : log_prefix, logging_state)
   {
   }
@@ -99,8 +99,8 @@ public:
   using E = ElementType;
   using I = IntersectionType;
 
-  IntersectionFunctor(const std::string& log_prefix = "",
-                      const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit IntersectionFunctor(const std::string& log_prefix = "",
+                               const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : Common::WithLogger<IntersectionFunctor<GL>>(log_prefix.empty() ? "IntersectionFunctor" : log_prefix,
                                                   logging_state)
   {
@@ -155,8 +155,8 @@ public:
   using E = ElementType;
   using I = IntersectionType;
 
-  ElementAndIntersectionFunctor(const std::string& log_prefix = "",
-                                const std::array<bool, 3>& logging_state = Common::default_logger_state())
+  explicit ElementAndIntersectionFunctor(const std::string& log_prefix = "",
+                                         const std::array<bool, 3>& logging_state = Common::default_logger_state())
     : Common::WithLogger<ElementAndIntersectionFunctor<GL>>(
           log_prefix.empty() ? "ElementAndIntersectionFunctor" : log_prefix, logging_state)
   {

--- a/dune/xt/grid/gridprovider/coupling.hh
+++ b/dune/xt/grid/gridprovider/coupling.hh
@@ -39,7 +39,7 @@ public:
     return "xt.grid.couplinggridprovider";
   }
 
-  CouplingGridProvider(const CouplingGridViewType view)
+  explicit CouplingGridProvider(const CouplingGridViewType view)
     : view_(view)
   {
   }

--- a/dune/xt/grid/gridprovider/provider.hh
+++ b/dune/xt/grid/gridprovider/provider.hh
@@ -69,12 +69,12 @@ public:
   /**
    * \attention Do not delete grd_ptr manually afterwards!
    */
-  GridProvider(GridType*&& grd_ptr)
+  explicit GridProvider(GridType*&& grd_ptr)
     : grid_ptr_(std::move(grd_ptr))
   {
   }
 
-  GridProvider(std::shared_ptr<GridType> grd_ptr)
+  explicit GridProvider(std::shared_ptr<GridType> grd_ptr)
     : grid_ptr_(std::move(grd_ptr))
   {
   }

--- a/dune/xt/grid/information.hh
+++ b/dune/xt/grid/information.hh
@@ -43,7 +43,7 @@ struct Statistics
   size_t numberOfBoundaryIntersections;
   double maxGridWidth;
   template <class GridLayerType>
-  Statistics(const GridLayerType& grid_layer)
+  explicit Statistics(const GridLayerType& grid_layer)
     : numberOfEntities(grid_layer.size(0))
     , numberOfIntersections(0)
     , numberOfInnerIntersections(0)
@@ -145,7 +145,7 @@ struct Dimensions
     return entity_volume.min() != 0.0 ? entity_volume.max() / entity_volume.min() : -1;
   }
 
-  Dimensions(const GridLayerType& grid_layer)
+  explicit Dimensions(const GridLayerType& grid_layer)
   {
     GridDimensionsFunctor f(coord_limits, entity_volume, entity_width);
     Walker<GridLayerType> gw(grid_layer);
@@ -153,7 +153,7 @@ struct Dimensions
     gw.walk();
   }
 
-  Dimensions(const ElementType& entity)
+  explicit Dimensions(const ElementType& entity)
   {
     GridDimensionsFunctor f(coord_limits, entity_volume, entity_width);
     f.apply_local(entity);

--- a/dune/xt/grid/output/entity_visualization.hh
+++ b/dune/xt/grid/output/entity_visualization.hh
@@ -64,7 +64,7 @@ struct ElementVisualization
   {
   public:
     using Element = extract_entity_t<GridViewType>;
-    FunctorBase(std::string filename = "Functor", std::string dirname = ".")
+    explicit FunctorBase(std::string filename = "Functor", std::string dirname = ".")
       : filename_(std::move(filename))
       , dir_(std::move(dirname))
     {
@@ -99,7 +99,7 @@ struct ElementVisualization
   {
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    VolumeFunctor(const std::string& filename = "VolumeFunctor", const std::string& dirname = ".")
+    explicit VolumeFunctor(const std::string& filename = "VolumeFunctor", const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
     {
     }
@@ -115,7 +115,7 @@ struct ElementVisualization
   {
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    ProcessIdFunctor(const std::string& filename = "ProcessIDFunctor", const std::string& dirname = ".")
+    explicit ProcessIdFunctor(const std::string& filename = "ProcessIDFunctor", const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
     {
     }
@@ -133,9 +133,9 @@ struct ElementVisualization
 
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    BoundaryIDFunctor(const GridViewType& view,
-                      const std::string& filename = "BoundaryIDFunctor",
-                      const std::string& dirname = ".")
+    explicit BoundaryIDFunctor(const GridViewType& view,
+                               const std::string& filename = "BoundaryIDFunctor",
+                               const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
       , gridview_(view)
     {
@@ -168,9 +168,9 @@ struct ElementVisualization
 
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    BoundaryIDFunctor(const GridViewType& view,
-                      const std::string& filename = "BoundaryIDFunctor",
-                      const std::string& dirname = ".")
+    explicit BoundaryIDFunctor(const GridViewType& view,
+                               const std::string& filename = "BoundaryIDFunctor",
+                               const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
       , gridview_(view)
     {
@@ -228,7 +228,7 @@ struct ElementVisualization
 
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    AreaMarker(const std::string& filename = "AreaFunctor", const std::string& dirname = ".")
+    explicit AreaMarker(const std::string& filename = "AreaFunctor", const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
     {
     }
@@ -261,7 +261,7 @@ struct ElementVisualization
   {
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    GeometryFunctor(const std::string& filename = "GeometryFunctor", const std::string& dirname = ".")
+    explicit GeometryFunctor(const std::string& filename = "GeometryFunctor", const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
     {
     }
@@ -288,7 +288,8 @@ struct ElementVisualization
   {
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    PartitionTypeFunctor(const std::string& filename = "PartitionTypeFunctor", const std::string& dirname = ".")
+    explicit PartitionTypeFunctor(const std::string& filename = "PartitionTypeFunctor",
+                                  const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
     {
     }
@@ -308,9 +309,9 @@ struct ElementVisualization
 
   public:
     using Element = typename FunctorBase<GridViewType>::Element;
-    IndexFunctor(const GridViewType& view,
-                 const std::string& filename = "IndexFunctor",
-                 const std::string& dirname = ".")
+    explicit IndexFunctor(const GridViewType& view,
+                          const std::string& filename = "IndexFunctor",
+                          const std::string& dirname = ".")
       : FunctorBase<GridViewType>(filename, dirname)
       , gridview_(view)
     {

--- a/dune/xt/grid/output/pgf.hh
+++ b/dune/xt/grid/output/pgf.hh
@@ -35,7 +35,7 @@ namespace Dune::XT::Grid {
 struct PgfCoordWrapper : Dune::FieldVector<double, 2>
 {
   template <int wdim>
-  explicit PgfCoordWrapper(const Dune::FieldVector<double, wdim>& vector)
+  PgfCoordWrapper(const Dune::FieldVector<double, wdim>& vector)
     : Dune::FieldVector<double, 2>(0.0)
   {
     for (size_t i = 0; i < size_t(std::min(wdim, 2)); ++i)

--- a/dune/xt/grid/output/pgf.hh
+++ b/dune/xt/grid/output/pgf.hh
@@ -35,7 +35,7 @@ namespace Dune::XT::Grid {
 struct PgfCoordWrapper : Dune::FieldVector<double, 2>
 {
   template <int wdim>
-  PgfCoordWrapper(const Dune::FieldVector<double, wdim>& vector)
+  explicit PgfCoordWrapper(const Dune::FieldVector<double, wdim>& vector)
     : Dune::FieldVector<double, 2>(0.0)
   {
     for (size_t i = 0; i < size_t(std::min(wdim, 2)); ++i)
@@ -52,7 +52,7 @@ struct PgfCoordWrapper : Dune::FieldVector<double, 2>
 class PgfEntityFunctor
 {
 public:
-  PgfEntityFunctor(std::ostream& output)
+  explicit PgfEntityFunctor(std::ostream& output)
     : file_(output)
   {
   }
@@ -227,7 +227,7 @@ template <class GridType>
 class PgfOutput
 {
 public:
-  PgfOutput(GridType& grid)
+  explicit PgfOutput(GridType& grid)
     : grid_(grid)
   {
   }

--- a/dune/xt/grid/search.hh
+++ b/dune/xt/grid/search.hh
@@ -108,7 +108,7 @@ private:
   }
 
 public:
-  EntityInlevelSearch(const GridLayerType& grid_layer)
+  explicit EntityInlevelSearch(const GridLayerType& grid_layer)
     : grid_layer_(grid_layer)
     , it_last_(grid_layer_.template begin<codim>())
   {
@@ -187,7 +187,7 @@ private:
   }
 
 public:
-  FallbackEntityInlevelSearch(const GridLayerType& grid_layer)
+  explicit FallbackEntityInlevelSearch(const GridLayerType& grid_layer)
     : grid_layer_(grid_layer)
     , it_last_(grid_layer_.template begin<0>())
   {
@@ -263,7 +263,7 @@ class EntityHierarchicSearch : public EntitySearchBase<GridLayerType>
   const int start_level_;
 
 public:
-  EntityHierarchicSearch(const GridLayerType& grid_layer)
+  explicit EntityHierarchicSearch(const GridLayerType& grid_layer)
     : grid_layer_(grid_layer)
     , start_level_(0)
   {

--- a/dune/xt/grid/type_traits.hh
+++ b/dune/xt/grid/type_traits.hh
@@ -491,7 +491,7 @@ struct EntityLess
   using IndexSet = typename GV::IndexSet;
   using E = typename GV::Grid::template Codim<0>::Entity;
 
-  EntityLess(const IndexSet& index_set)
+  explicit EntityLess(const IndexSet& index_set)
     : index_set_(index_set)
   {
   }

--- a/dune/xt/grid/view/from-part.hh
+++ b/dune/xt/grid/view/from-part.hh
@@ -43,7 +43,7 @@ class TemporaryConstView
   {
     using type = GridLayerType;
 
-    const_storage(const GridLayerType& grid_view)
+    explicit const_storage(const GridLayerType& grid_view)
       : value(grid_view)
     {
     }
@@ -56,7 +56,7 @@ class TemporaryConstView
   {
     using type = typename GridLayerType::GridViewType;
 
-    const_storage(const GridLayerType& grid_part)
+    explicit const_storage(const GridLayerType& grid_part)
       : grid_part_(grid_part)
       , value(grid_part_)
     {
@@ -69,7 +69,7 @@ class TemporaryConstView
 public:
   using type = typename const_storage<>::type;
 
-  TemporaryConstView(const GridLayerType& grid_layer)
+  explicit TemporaryConstView(const GridLayerType& grid_layer)
     : const_storage_(grid_layer)
   {
   }
@@ -100,7 +100,7 @@ class TemporaryView : public TemporaryConstView<GridLayerType>
   {
     using type = GridLayerType;
 
-    storage(GridLayerType& grid_view)
+    explicit storage(GridLayerType& grid_view)
       : value(grid_view)
     {
     }
@@ -113,7 +113,7 @@ class TemporaryView : public TemporaryConstView<GridLayerType>
   {
     using type = typename GridLayerType::GridViewType;
 
-    storage(GridLayerType& grid_part)
+    explicit storage(GridLayerType& grid_part)
       : value(grid_part)
     {
     }
@@ -126,7 +126,7 @@ class TemporaryView : public TemporaryConstView<GridLayerType>
 public:
   using type = typename storage<>::type;
 
-  TemporaryView(GridLayerType& grid_layer)
+  explicit TemporaryView(GridLayerType& grid_layer)
     : BaseType(grid_layer)
     , storage_(grid_layer)
   {

--- a/dune/xt/grid/view/periodic.hh
+++ b/dune/xt/grid/view/periodic.hh
@@ -891,8 +891,8 @@ public:
   using BaseType::dimension;
   using BaseGridViewType = BaseGridViewImp;
 
-  PeriodicGridView(const BaseGridViewType& base_grid_view,
-                   const std::bitset<dimension> periodic_directions = std::bitset<dimension>().set())
+  explicit PeriodicGridView(const BaseGridViewType& base_grid_view,
+                            const std::bitset<dimension> periodic_directions = std::bitset<dimension>().set())
     : ImplementationStorage(new Implementation(base_grid_view, periodic_directions))
     , BaseType(ImplementationStorage::access())
   {

--- a/dune/xt/la/container/common/matrix/dense.hh
+++ b/dune/xt/la/container/common/matrix/dense.hh
@@ -229,7 +229,7 @@ public:
   }
 
   template <class T>
-  CommonDenseMatrix(const DenseMatrix<T>& other, const size_t num_mutexes = 1)
+  explicit CommonDenseMatrix(const DenseMatrix<T>& other, const size_t num_mutexes = 1)
     : backend_(std::make_unique<BackendType>(other.rows(), other.cols()))
     , mutexes_(std::make_unique<MutexesType>(num_mutexes))
   {
@@ -239,7 +239,7 @@ public:
   } // CommonDenseMatrix(...)
 
   template <class T, class F>
-  CommonDenseMatrix(const MatrixInterface<T, F>& other, const size_t num_mutexes = 1)
+  explicit CommonDenseMatrix(const MatrixInterface<T, F>& other, const size_t num_mutexes = 1)
     : backend_(std::make_unique<BackendType>(other.rows(), other.cols()))
     , mutexes_(std::make_unique<MutexesType>(num_mutexes))
   {

--- a/dune/xt/la/container/common/matrix/sparse.hh
+++ b/dune/xt/la/container/common/matrix/sparse.hh
@@ -135,11 +135,11 @@ public:
     }
   } // CommonSparseMatrix(rr, cc, patt, num_mutexes)
 
-  CommonSparseMatrix(const size_t rr = 0,
-                     const size_t cc = 0,
-                     const ScalarType& value = ScalarType(0),
-                     const size_t num_mutexes = 1,
-                     const EpsType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value() / 1000.)
+  explicit CommonSparseMatrix(const size_t rr = 0,
+                              const size_t cc = 0,
+                              const ScalarType& value = ScalarType(0),
+                              const size_t num_mutexes = 1,
+                              const EpsType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value() / 1000.)
     : num_rows_(rr)
     , num_cols_(cc)
     , entries_(std::make_shared<EntriesVectorType>(is_zero(value, eps) ? 0 : num_rows_ * num_cols_, value))
@@ -598,11 +598,11 @@ public:
     }
   } // CommonSparseMatrix(rr, cc, patt, num_mutexes)
 
-  CommonSparseMatrix(const size_t rr = 0,
-                     const size_t cc = 0,
-                     const ScalarType& value = ScalarType(0),
-                     const size_t num_mutexes = 1,
-                     const EpsType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value() / 1000.)
+  explicit CommonSparseMatrix(const size_t rr = 0,
+                              const size_t cc = 0,
+                              const ScalarType& value = ScalarType(0),
+                              const size_t num_mutexes = 1,
+                              const EpsType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value() / 1000.)
     : num_rows_(rr)
     , num_cols_(cc)
     , entries_(std::make_shared<EntriesVectorType>(is_zero(value, eps) ? 0 : num_rows_ * num_cols_, value))
@@ -1154,12 +1154,12 @@ public:
     }
   } // CommonSparseOrDenseMatrix(rr, cc, patt, num_mutexes)
 
-  CommonSparseOrDenseMatrix(const size_t rr = 0,
-                            const size_t cc = 0,
-                            const ScalarType& value = ScalarType(0),
-                            const size_t num_mutexes = 1,
-                            bool use_sparse_if_zero = true,
-                            const EpsType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value() / 1000.)
+  explicit CommonSparseOrDenseMatrix(const size_t rr = 0,
+                                     const size_t cc = 0,
+                                     const ScalarType& value = ScalarType(0),
+                                     const size_t num_mutexes = 1,
+                                     bool use_sparse_if_zero = true,
+                                     const EpsType eps = Common::FloatCmp::DefaultEpsilon<ScalarType>::value() / 1000.)
     : num_rows_(rr)
     , num_cols_(cc)
   {

--- a/dune/xt/la/container/common/vector/dense.hh
+++ b/dune/xt/la/container/common/vector/dense.hh
@@ -56,7 +56,7 @@ struct CommonDenseVectorBackend
   using ThisType = CommonDenseVectorBackend;
 
   // Constructs ss elements with value value.
-  CommonDenseVectorBackend(const size_t ss = 0, const ScalarType& value = ScalarType())
+  explicit CommonDenseVectorBackend(const size_t ss = 0, const ScalarType& value = ScalarType())
     : size_(ss)
     , values_vector_(size_, value)
     , values_ptr_(values_vector_.data())

--- a/dune/xt/la/container/container-interface.hh
+++ b/dune/xt/la/container/container-interface.hh
@@ -34,7 +34,7 @@ namespace internal {
 
 struct VectorLockGuard
 {
-  VectorLockGuard(std::vector<std::mutex>& mutexes)
+  explicit VectorLockGuard(std::vector<std::mutex>& mutexes)
     : mutexes_(mutexes)
   {
     boost::lock(mutexes_.begin(), mutexes_.end());

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -70,7 +70,7 @@ private:
   using MutexesType = typename Traits::MutexesType;
 
 public:
-  EigenBaseVector(size_t num_mutexes = 1)
+  explicit EigenBaseVector(size_t num_mutexes = 1)
     : mutexes_(std::make_unique<MutexesType>(num_mutexes))
   {
   }

--- a/dune/xt/la/container/eigen/dense.hh
+++ b/dune/xt/la/container/eigen/dense.hh
@@ -448,7 +448,7 @@ public:
   }
 
   template <class M>
-  EigenDenseMatrix(const MatrixInterface<M, ScalarType>& other, const size_t num_mutexes = 1)
+  explicit EigenDenseMatrix(const MatrixInterface<M, ScalarType>& other, const size_t num_mutexes = 1)
     : backend_(new BackendType(other.rows(), other.cols()))
     , mutexes_(std::make_unique<MutexesType>(num_mutexes))
   {
@@ -458,7 +458,7 @@ public:
   }
 
   template <class T>
-  EigenDenseMatrix(const DenseMatrix<T>& other, const size_t num_mutexes = 1)
+  explicit EigenDenseMatrix(const DenseMatrix<T>& other, const size_t num_mutexes = 1)
     : backend_(new BackendType(other.rows(), other.cols()))
     , mutexes_(std::make_unique<MutexesType>(num_mutexes))
   {

--- a/dune/xt/la/container/vector-array/list.hh
+++ b/dune/xt/la/container/vector-array/list.hh
@@ -96,7 +96,7 @@ public:
   using reference = typename AnnotatedVectorArrayType::reference;
   using const_reference = typename AnnotatedVectorArrayType::const_reference;
 
-  ListVectorArray(const size_t dm, const size_t lngth = 0, const size_t resrv = 0)
+  explicit ListVectorArray(const size_t dm, const size_t lngth = 0, const size_t resrv = 0)
     : dim_(dm)
     , len_(lngth)
     , vectors_()

--- a/dune/xt/la/eigen-solver.hh
+++ b/dune/xt/la/eigen-solver.hh
@@ -86,7 +86,7 @@ public:
   using RealMatrixType = int;
   using ComplexMatrixType = int;
 
-  EigenSolver(const MatrixType& /*matrix*/, const std::string& /*type*/ = "")
+  explicit EigenSolver(const MatrixType& /*matrix*/, const std::string& /*type*/ = "")
   {
     static_assert(AlwaysFalse<MatrixType>::value,
                   "Please implement for given MatrixType and add the respective include below!");

--- a/dune/xt/la/eigen-solver/fmatrix.hh
+++ b/dune/xt/la/eigen-solver/fmatrix.hh
@@ -198,7 +198,7 @@ class EigenSolver<Dune::XT::Common::FieldMatrix<K, SIZE, SIZE>, true>
 {
 public:
   template <class... Args, typename = Common::require_not_self_t<EigenSolver, Args...>>
-  EigenSolver(Args&&... args)
+  explicit EigenSolver(Args&&... args)
     : EigenSolver<Dune::FieldMatrix<K, SIZE, SIZE>>(std::forward<Args>(args)...)
   {
   }
@@ -216,7 +216,7 @@ class EigenSolver<Dune::XT::Common::FieldVector<K, 1>, true>
 
 public:
   template <class... Args>
-  EigenSolver(const Dune::XT::Common::FieldVector<K, 1>& vector, Args&&... args)
+  explicit EigenSolver(const Dune::XT::Common::FieldVector<K, 1>& vector, Args&&... args)
     : Storage(vector[0])
     , BaseType(Storage::access(), std::forward<Args>(args)...)
   {
@@ -235,7 +235,7 @@ class EigenSolver<Dune::FieldVector<K, 1>, true>
 
 public:
   template <class... Args>
-  EigenSolver(const Dune::FieldVector<K, 1>& vector, Args&&... args)
+  explicit EigenSolver(const Dune::FieldVector<K, 1>& vector, Args&&... args)
     : Storage(vector[0])
     , BaseType(Storage::access(), std::forward<Args>(args)...)
   {

--- a/dune/xt/la/eigen-solver/internal/base.hh
+++ b/dune/xt/la/eigen-solver/internal/base.hh
@@ -94,7 +94,7 @@ public:
   using RealMatrixType = RealMatrixImp;
   using ComplexMatrixType = ComplexMatrixImp;
 
-  EigenSolverBase(const MatrixType& matrix, const std::string& type = "")
+  explicit EigenSolverBase(const MatrixType& matrix, const std::string& type = "")
     : EigenSolverBase(matrix, EigenSolverOptions<MatrixType, true>::options(type))
   {
   }

--- a/dune/xt/la/eigen-solver/internal/lapacke.hh
+++ b/dune/xt/la/eigen-solver/internal/lapacke.hh
@@ -51,7 +51,7 @@ template <class MatrixType>
 class MatrixDataProvider<MatrixType, true>
 {
 public:
-  MatrixDataProvider(MatrixType& matrix)
+  explicit MatrixDataProvider(MatrixType& matrix)
     : matrix_(matrix)
   {
   }
@@ -72,7 +72,7 @@ class MatrixDataProvider<MatrixType, false>
 {
 public:
   // lapacks favorite storage format is column-major, otherwise the matrix would be copied from row-major to col-major
-  MatrixDataProvider(const MatrixType& matrix)
+  explicit MatrixDataProvider(const MatrixType& matrix)
     : serialized_matrix_(Dune::XT::Common::serialize_colwise<double>(matrix))
   {
   }

--- a/dune/xt/la/generalized-eigen-solver.hh
+++ b/dune/xt/la/generalized-eigen-solver.hh
@@ -72,7 +72,7 @@ public:
   using RealMatrixType = int;
   using ComplexMatrixType = int;
 
-  GeneralizedEigenSolver(const MatrixType& /*matrix*/, const std::string& /*type*/ = "")
+  explicit GeneralizedEigenSolver(const MatrixType& /*matrix*/, const std::string& /*type*/ = "")
   {
     static_assert(AlwaysFalse<MatrixType>::value,
                   "Please implement for given MatrixType and add the respective include below!");

--- a/dune/xt/la/matrix-inverter.hh
+++ b/dune/xt/la/matrix-inverter.hh
@@ -79,7 +79,7 @@ class MatrixInverter
                 "Please implement for given MatrixType and add the respective include below!");
 
 public:
-  MatrixInverter(const MatrixType& /*matrix*/, const std::string& /*type*/ = "")
+  explicit MatrixInverter(const MatrixType& /*matrix*/, const std::string& /*type*/ = "")
   {
     static_assert(AlwaysFalse<MatrixType>::value,
                   "Please implement for given MatrixType and add the respective include below!");

--- a/dune/xt/la/matrix-inverter/internal/base.hh
+++ b/dune/xt/la/matrix-inverter/internal/base.hh
@@ -72,7 +72,7 @@ public:
   /**
    * \attention The implementor has to call compute() in the ctor if (delay_computation == true).
    */
-  MatrixInverterBase(const MatrixType& matrix, const std::string& type = "")
+  explicit MatrixInverterBase(const MatrixType& matrix, const std::string& type = "")
     : matrix_(matrix)
     , options_(MatrixInverterOptions<MatrixType, true>::options(type))
     , inverse_(nullptr)

--- a/dune/xt/la/solver.hh
+++ b/dune/xt/la/solver.hh
@@ -86,7 +86,7 @@ public:
                    << Common::Typename<MatrixType>::value() << "'!");
   }
 
-  Solver(const MatrixType& /*matrix*/)
+  explicit Solver(const MatrixType& /*matrix*/)
   {
     DUNE_THROW(NotImplemented,
                "This is the unspecialized version of LA::Solver< ... >. "

--- a/dune/xt/la/solver/common.hh
+++ b/dune/xt/la/solver/common.hh
@@ -62,7 +62,7 @@ public:
   using MatrixType = CommonDenseMatrix<S>;
   using R = typename MatrixType::RealType;
 
-  Solver(const MatrixType& matrix)
+  explicit Solver(const MatrixType& matrix)
     : matrix_(matrix)
   {
   }

--- a/dune/xt/la/solver/dense.hh
+++ b/dune/xt/la/solver/dense.hh
@@ -66,7 +66,7 @@ public:
   using MatrixType = Matrix;
   using CommunicatorType = SequentialCommunication;
 
-  Solver(const MatrixType& matrix)
+  explicit Solver(const MatrixType& matrix)
     : matrix_(matrix)
   {
   }

--- a/dune/xt/la/solver/eigen.hh
+++ b/dune/xt/la/solver/eigen.hh
@@ -88,7 +88,7 @@ public:
   using MatrixType = EigenDenseMatrix<S>;
   using R = typename MatrixType::RealType;
 
-  Solver(const MatrixType& matrix)
+  explicit Solver(const MatrixType& matrix)
     : matrix_(matrix)
   {
   }
@@ -337,7 +337,7 @@ private:
   using EIGEN_size_t = typename MatrixType::BackendType::Index;
 
 public:
-  Solver(const MatrixType& matrix)
+  explicit Solver(const MatrixType& matrix)
     : matrix_(matrix)
   {
   }

--- a/dune/xt/la/solver/istl.hh
+++ b/dune/xt/la/solver/istl.hh
@@ -176,7 +176,7 @@ public:
   using MatrixType = IstlRowMajorSparseMatrix<S>;
   using R = typename MatrixType::RealType;
 
-  Solver(const MatrixType& matrix)
+  explicit Solver(const MatrixType& matrix)
     : matrix_(matrix)
     , communicator_(CommunicatorType())
   {

--- a/dune/xt/la/solver/istl/preconditioners.hh
+++ b/dune/xt/la/solver/istl/preconditioners.hh
@@ -36,7 +36,7 @@ public:
   using field_type = typename range_type::field_type;
   using InverseOperator = O;
 
-  IdentityPreconditioner(const SolverCategory::Category cat)
+  explicit IdentityPreconditioner(const SolverCategory::Category cat)
     : category_(cat)
   {
   }

--- a/dune/xt/la/solver/view.hh
+++ b/dune/xt/la/solver/view.hh
@@ -59,7 +59,7 @@ public:
   using R = typename MatrixType::RealType;
   using ActualSolver = Solver<MatrixImp, CommunicatorType>;
 
-  Solver(const MatrixType& matrix_view)
+  explicit Solver(const MatrixType& matrix_view)
     : matrix_view_(matrix_view)
     , matrix_(matrix_view_.rows(), matrix_view_.cols(), matrix_view_.pattern())
     , actual_solver_(matrix_)

--- a/dune/xt/test/common/algorithm.cc
+++ b/dune/xt/test/common/algorithm.cc
@@ -19,7 +19,7 @@ using namespace Dune::XT::Common;
 
 struct Moveable
 {
-  Moveable(int i)
+  explicit Moveable(int i)
     : v(i)
   {
   }

--- a/python/gdt/dune/gdt/local/bilinear-forms/vectorized_element_integrals.cc
+++ b/python/gdt/dune/gdt/local/bilinear-forms/vectorized_element_integrals.cc
@@ -151,7 +151,7 @@ public:
     return c;
   } // ... bind(...)
 
-  VectorizedLocalElementIntegralBilinearForm(
+  explicit VectorizedLocalElementIntegralBilinearForm(
       IntegrandType integrand,
       const int integrand_order = 0,
       const XT::Common::ParameterType& integrand_parameters = {},

--- a/python/gdt/dune/gdt/local/functionals/vectorized_element_integrals.cc
+++ b/python/gdt/dune/gdt/local/functionals/vectorized_element_integrals.cc
@@ -121,9 +121,9 @@ public:
     return c;
   } // ... bind(...)
 
-  VectorizedLocalElementIntegralFunctional(IntegrandType integrand,
-                                           const int integrand_order = 0,
-                                           const XT::Common::ParameterType& integrand_parameters = {})
+  explicit VectorizedLocalElementIntegralFunctional(IntegrandType integrand,
+                                                    const int integrand_order = 0,
+                                                    const XT::Common::ParameterType& integrand_parameters = {})
     : BaseType(integrand_parameters)
     , integrand_(integrand)
     , integrand_order_(integrand_order)

--- a/python/gdt/dune/gdt/tools/adaptation-helper.cc
+++ b/python/gdt/dune/gdt/tools/adaptation-helper.cc
@@ -52,7 +52,7 @@ public:
   using type = ThisType;
   using bound_type = pybind11::class_<type>;
 
-  AdaptationHelper(G& grd, const std::string& logging_prefix = "")
+  explicit AdaptationHelper(G& grd, const std::string& logging_prefix = "")
     : BaseType(grd, logging_prefix)
     , marker_indices(grd.leafGridView()) // BAD, bad, bad, has to coincide with GV!
     , markers(marker_indices.mapper().size())

--- a/python/xt/dune/xt/common/empty.cc
+++ b/python/xt/dune/xt/common/empty.cc
@@ -26,7 +26,7 @@
 
 struct Pet
 {
-  Pet(std::string name_)
+  explicit Pet(std::string name_)
     : name(std::move(name_))
   {
   }
@@ -43,7 +43,7 @@ struct Pet
 };
 struct Dog : Pet
 {
-  Dog(const std::string& name_)
+  explicit Dog(const std::string& name_)
     : Pet(name_)
   {
   }


### PR DESCRIPTION
## What

Rebase of #233 onto current `main`. #233 (`add explicit to single-argument constructors`, SonarCloud `cpp:S1709`) had drifted behind `main` (`dirty`/conflicting mergeable state) and could not be rebased on the branch it originally used, so this PR carries the same two commits replayed on top of current `main`.

Original PR description (unchanged scope):

> Addresses the **HIGH-impact / MAINTAINABILITY** SonarCloud issues for rule
> [`cpp:S1709`](```''https://sonarcloud.io/project/issues?impactSeverities=HIGH&impactSoftwareQualities=MAINTAINABILITY&rules=cpp%3AS1709&issueStatuses=OPEN%2CCONFIRMED&id=dune-gdt_dune-gdt)''```
> ("Add the `explicit` keyword to this constructor") by marking
> single-argument-callable constructors `explicit`, preventing unintended
> implicit conversions.
>
> **233 constructors across 118 files.** Every hunk is a pure `explicit`
> keyword addition (with `clang-format` reflow of the affected signature only).
>
> ### Scope / what was deliberately *not* changed
>
> SonarCloud flags 321 sites total. A large share are **intentional
> implicit-conversion types** that the API relies on pervasively; making those
> `explicit` would break their convenience-conversion design and many call
> sites. These were left unchanged on purpose (~88 sites):
>
> - the `GridFunction` / `GridFunctionBase` family (`dune/xt/functions/grid-function.hh`)
>   — documented to accept "a function or a value, for convenience";
> - `Parameter` / `ParameterType` value-type ctors (`Parameter(const double&)`,
>   `ParameterType(const std::string&)`, …);
> - the DUNE `FieldVector` / `FieldMatrix` value types (`fvector-2.6.hh`, `fmatrix-2.6.hh`)
>   and all **conversion operators** (`operator X()`);
> - `Configuration`, `MPI_Comm_Wrapper`, `Any`;
> - integrand/function ctors whose single effective argument is an
>   `XT::Functions::GridFunction` (e.g. product/ipdg/div/… `weight`) and the
>   `Constant*` wrappers.
>
> These remaining issues are genuine false positives for this codebase and are
> best resolved as "Won't Fix" in the SonarCloud UI (out of scope for this PR).

## Rebase notes

Two conflicts came up while replaying the commits on current `main` and were resolved as follows:

- `dune/xt/common/localization-study.hh`: this file was deleted on `main` (dead, uncoverable code, see the `coverage: A2/A3 measurement hygiene from issue #314` commit). Kept the deletion; the `explicit` addition to it is moot.
- `dune/xt/la/eigen-solver/fmatrix.hh`: `main` had since added a `Common::require_not_self_t<EigenSolver, Args...>` SFINAE guard to the forwarding constructor (to stop it from hijacking copy/move construction). Kept that guard and added `explicit` to the same constructor, matching the pattern already used elsewhere on `main` (e.g. `dune/xt/common/parallel/threadstorage.hh`).

No other content changes; the diff is otherwise identical in intent to #233.

## Verification

The project can't be compiled in the authoring environment, so correctness is gated by the existing **build + test CI** (`non_docker_build.yml`).

https://claude.ai/code/session_017tYP3x7uUQYZHccEG86tES


---
_Generated by [Claude Code](https://claude.ai/code/session_017tYP3x7uUQYZHccEG86tES)_