### PR TITLE
fix(python): silence -Wunused-parameter in pybind11 bindings via [[maybe_unused]]

### DIFF
--- a/python/gdt/dune/gdt/functionals/interfaces_common.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_common.cc
@@ -15,7 +15,7 @@
 #include "interfaces.hh"
 
 
-PYBIND11_MODULE(_functionals_interfaces_common, m)
+PYBIND11_MODULE(_functionals_interfaces_common, m [[maybe_unused]])
 {
   namespace py = pybind11;
   using namespace Dune;

--- a/python/gdt/dune/gdt/functionals/interfaces_eigen.cc
+++ b/python/gdt/dune/gdt/functionals/interfaces_eigen.cc
@@ -15,7 +15,7 @@
 #include "interfaces.hh"
 
 
-PYBIND11_MODULE(_functionals_interfaces_eigen, m)
+PYBIND11_MODULE(_functionals_interfaces_eigen, m [[maybe_unused]])
 {
   namespace py = pybind11;
   using namespace Dune;

--- a/python/gdt/dune/gdt/operators/interfaces_common.cc
+++ b/python/gdt/dune/gdt/operators/interfaces_common.cc
@@ -18,7 +18,7 @@
 
 /// \todo Split like istl!
 
-PYBIND11_MODULE(_operators_interfaces_common, m)
+PYBIND11_MODULE(_operators_interfaces_common, m [[maybe_unused]])
 {
   namespace py = pybind11;
   using namespace Dune;

--- a/python/gdt/dune/gdt/operators/interfaces_eigen.cc
+++ b/python/gdt/dune/gdt/operators/interfaces_eigen.cc
@@ -18,7 +18,7 @@
 
 /// \todo Split like istl!
 
-PYBIND11_MODULE(_operators_interfaces_eigen, m)
+PYBIND11_MODULE(_operators_interfaces_eigen, m [[maybe_unused]])
 {
   namespace py = pybind11;
   using namespace Dune;

--- a/python/gdt/dune/gdt/operators/laplace_ipdg_flux_reconstruction.cc
+++ b/python/gdt/dune/gdt/operators/laplace_ipdg_flux_reconstruction.cc
@@ -113,7 +113,7 @@ public:
     const auto FactoryName = XT::Common::to_camel_case(class_id);
     m.def(
         FactoryName.c_str(),
-        [](GP& grid,
+        [](GP& grid [[maybe_unused]],
            const RS& range_space,
            const double& symmetry_prefactor,
            const double& inner_penalty,

--- a/python/gdt/dune/gdt/operators/operator_for_all_grids.hh
+++ b/python/gdt/dune/gdt/operators/operator_for_all_grids.hh
@@ -67,12 +67,13 @@ public:
     const auto ClassName = XT::Common::to_camel_case(
         bindings::OperatorInterface<M, GV, s_r, r_r>::class_name(matrix_id, grid_id, layer_id, class_id));
     bound_type c(m, ClassName.c_str(), ClassName.c_str());
-    c.def(py::init([](const GP& grid, const SS& source_space, const RS& range_space, const bool parallel) {
-            // NOTE: GDT::Operator stores the assembly grid view BY REFERENCE, so it must outlive
-            // the operator. grid.leaf_view() returns a temporary (-> dangling ref -> segfault on
-            // apply); use the source space's grid view instead (the space is kept alive below).
-            return new type(source_space.grid_view(), source_space, range_space, parallel);
-          }),
+    c.def(py::init(
+              [](const GP& grid [[maybe_unused]], const SS& source_space, const RS& range_space, const bool parallel) {
+                // NOTE: GDT::Operator stores the assembly grid view BY REFERENCE, so it must outlive
+                // the operator. grid.leaf_view() returns a temporary (-> dangling ref -> segfault on
+                // apply); use the source space's grid view instead (the space is kept alive below).
+                return new type(source_space.grid_view(), source_space, range_space, parallel);
+              }),
           "grid"_a,
           "source_space"_a,
           "range_space"_a,
@@ -130,7 +131,11 @@ public:
     if (std::is_same<MT, XT::LA::bindings::Istl>::value)
       m.def(
           FactoryName.c_str(),
-          [](const GP& grid, const SS& source_space, const RS& range_space, const bool parallel, const MT&) {
+          [](const GP& grid [[maybe_unused]],
+             const SS& source_space,
+             const RS& range_space,
+             const bool parallel,
+             const MT&) {
             // NOTE: GDT::Operator stores the assembly grid view BY REFERENCE, so it must outlive
             // the operator. grid.leaf_view() returns a temporary (-> dangling ref -> segfault on
             // apply); use the source space's grid view instead (the space is kept alive below).
@@ -147,7 +152,11 @@ public:
     else
       m.def(
           FactoryName.c_str(),
-          [](const GP& grid, const SS& source_space, const RS& range_space, const bool parallel, const MT&) {
+          [](const GP& grid [[maybe_unused]],
+             const SS& source_space,
+             const RS& range_space,
+             const bool parallel,
+             const MT&) {
             // NOTE: GDT::Operator stores the assembly grid view BY REFERENCE, so it must outlive
             // the operator. grid.leaf_view() returns a temporary (-> dangling ref -> segfault on
             // apply); use the source space's grid view instead (the space is kept alive below).


### PR DESCRIPTION
## Summary

Fixes #302 (part of #295 — warnings bucket 7): 8 `-Wunused-parameter` locations in hand-written pybind11 binding sources under `python/gdt/`, using the `[[maybe_unused]]` attribute route rather than dropping parameter names.

- **Module `m` unused** (`functionals/interfaces_common.cc`, `functionals/interfaces_eigen.cc`, `operators/interfaces_common.cc`, `operators/interfaces_eigen.cc`): these `PYBIND11_MODULE(..., m)` bodies have their bindings commented out, so `m` is unused. Now written as `PYBIND11_MODULE(..., m [[maybe_unused]])`, keeping the name so re-enabling the bindings later is trivial.
- **Lambda `grid` params** (`operators/laplace_ipdg_flux_reconstruction.cc:116`, plus the constructor/factory lambdas in `operators/operator_for_all_grids.hh`): `grid` is kept in these signatures only for `py::keep_alive` linkage — the grid view is actually taken from the bound space instead (per the existing `NOTE` comments explaining why `grid.leaf_view()` would dangle). Marked `[[maybe_unused]]`.

Note: `python/gdt/dune/gdt/operators/operator.cc` referenced in the issue no longer exists — it was split into `operator_1d.cc`/`operator_2d.cc`/`operator_3d.cc` + a shared `operator_for_all_grids.hh` in a later refactor (commit `32ecfa7`). The fixes were applied at the corresponding locations in the current file layout. Also, on closer inspection the actual unused parameter at those lines is `grid` (the `const MT&` overload-disambiguation tag is already unnamed in the current code), matching the issue's guidance to verify usage before fixing.

## Verification

- Confirmed with a minimal reproduction that `[[maybe_unused]]` passed as a `PYBIND11_MODULE`-style macro argument (`MODULE(name, m [[maybe_unused]])`) expands correctly and suppresses `-Wunused-parameter` under `g++ -Wall -Wextra -Wunused-parameter`.
- `clang-format` applied to all touched files (repo's `.clang-format`, no other formatting changes).

## Test plan

- [ ] Rebuild `bindings` (debug preset, GCC 13) and confirm `-Wunused-parameter` no longer fires for these files
- [ ] Confirm the affected modules still import in Python


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTkbtvnGAfeXVJWPjPgCXx)_