### PR TITLE
ci: keep a single long-lived ccache slot for main instead of one per run

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -124,8 +124,12 @@ jobs:
     # library, the project, the ~520 test binaries and the Python bindings from
     # scratch; on the 4 vCPU hosted runner with the memory-bounded -j caps above
     # that is slower than the old self-hosted fleet, so the timeout is generous.
-    # Warm runs restore the ccache and finish much faster.
-    timeout-minutes: 240
+    # Warm runs restore the ccache and finish much faster -- though even those vary
+    # widely enough in practice (runner-to-runner performance, not just cache state)
+    # that clang22-release_coverage's "Build test binaries" step alone has been seen
+    # anywhere from ~1h30m to ~2h40m on the same branch, so 240 was cutting it too
+    # close and got cancelled mid-build on a run that wasn't actually stuck.
+    timeout-minutes: 360
     permissions:
       contents: read
       # codecov's GitHub Action authenticates to codecov.io via OpenID Connect

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -133,6 +133,10 @@ jobs:
       # actually exchanges this token, but job-level permissions are shared by the
       # whole matrix, so the scope is declared once here.
       id-token: write
+      # needed by the push-to-main leg to delete the previous "main" ccache
+      # snapshot via `gh cache delete` before re-saving it (see "Refresh the
+      # shared main ccache slot" below). Unused by pull_request/merge_group runs.
+      actions: write
     strategy:
       # one leg's failure must not cancel the other: a broken debug build should
       # still let the release+coverage leg report, and vice versa.
@@ -222,11 +226,24 @@ jobs:
       with:
         path: ${{ github.workspace }}/.ccache
         # run_id makes every save a unique (always-miss) key so each run writes a
-        # fresh cache; the prefix restore-key then pulls the most recent ccache
-        # from any previous run. Keyed per preset because the instrumented release
-        # objects must not pollute the debug leg's cache (different compile flags).
+        # fresh cache; the restore-keys below then pull the best available ccache.
+        # Keyed per preset because the instrumented release objects must not
+        # pollute the debug leg's cache (different compile flags).
         key: ${{ runner.os }}-ccache-${{ matrix.preset }}-${{ github.run_id }}
+        # The "-main" slot is a single long-lived entry kept fresh by every push to
+        # main (see "Refresh/Save the shared main ccache slot" below) and is
+        # readable from any ref (default-branch caches are always in scope). Try it
+        # first: push/merge_group builds run on refs with no history of their own
+        # (a merge-queue ref is created fresh each time), so without this fallback
+        # they restore nothing and silently compile ~520 test binaries plus the
+        # Python bindings from scratch -- which is what blew the coverage leg's
+        # 240-minute timeout on main and in PR #240's repeated merge-queue
+        # attempts (every one of the per-run_id blobs below had already been
+        # evicted from the repo's shared cache quota by the time it was needed).
+        # The per-run_id prefix is kept as a second fallback for same-branch PR
+        # re-runs, where it usually still hits.
         restore-keys: |
+          ${{ runner.os }}-ccache-${{ matrix.preset }}-main
           ${{ runner.os }}-ccache-${{ matrix.preset }}-
 
     - name: Configure CMake
@@ -400,6 +417,29 @@ jobs:
         path: ${{ github.workspace }}/.ccache
         key: ${{ runner.os }}-ccache-${{ matrix.preset }}-${{ github.run_id }}
 
+    - name: Refresh the shared "main" ccache slot
+      # actions/cache has no "overwrite" -- an existing key can only be replaced by
+      # deleting it first -- so this deletes the previous "-main" snapshot right
+      # before the save step below re-creates it under the same fixed key. That
+      # keeps exactly one long-lived entry per preset here instead of growing one
+      # per run (the github.run_id key above), which is what was exhausting the
+      # repo's shared cache storage quota and getting this leg's cache evicted
+      # before push/merge_group builds could ever restore it. Only main's own push
+      # maintains this slot; PRs and the merge queue only ever read it (via the
+      # restore-keys fallback above).
+      if: always() && steps.configure_cmake.outcome == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+      run: gh cache delete "${{ runner.os }}-ccache-${{ matrix.preset }}-main" --repo "${GITHUB_REPOSITORY}"
+
+    - name: Save the shared "main" ccache slot
+      if: always() && steps.configure_cmake.outcome == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ matrix.preset }}-main
+
     - name: Upload error logs (in case of failure)
       if: always() && (steps.configure_cmake.conclusion == 'failure')
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -433,6 +473,10 @@ jobs:
     timeout-minutes: 300
     permissions:
       contents: read
+      # needed by the push-to-main leg to delete the previous "main" wheel-ccache
+      # snapshot via `gh cache delete` before re-saving it (see "Refresh the
+      # shared main wheel-build ccache slot" below).
+      actions: write
     strategy:
       matrix:
         python-version: ["3.13"] #, "3.9", "3.10", "3.11", "3.12"]
@@ -461,9 +505,16 @@ jobs:
       with:
         path: build/wheelhouse/cache
         # Unique per-run key so the save below always writes a fresh cache; the
-        # restore-key falls back to the most recent cache for this Python version.
+        # restore-keys below fall back to the best available cache for this
+        # Python version. Same "-main" slot pattern as build-linux's ccache (see
+        # its "Restore ccache" step for why): try the single long-lived entry kept
+        # fresh by every push to main first, since push/merge_group builds run on
+        # refs with no cache history of their own and the per-run_id blobs churn
+        # through the repo's shared cache quota fast enough to be gone by the time
+        # a later run needs them.
         key: ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-${{ github.run_id }}
         restore-keys: |
+          ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-main
           ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-
 
     # The vcpkg toolchain (.vcpkg-root) and installed packages
@@ -521,6 +572,24 @@ jobs:
       with:
         path: build/wheelhouse/cache
         key: ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-${{ github.run_id }}
+
+    - name: Refresh the shared "main" wheel-build ccache slot
+      # Same delete-then-save pattern as build-linux's "Refresh the shared main
+      # ccache slot" step: keeps exactly one long-lived entry per Python version
+      # here instead of growing one per run, so it survives the repo's shared
+      # cache quota long enough for push/merge_group builds to actually restore it.
+      if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+      run: gh cache delete "${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-main" --repo "${GITHUB_REPOSITORY}"
+
+    - name: Save the shared "main" wheel-build ccache slot
+      if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: build/wheelhouse/cache
+        key: ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-main
 
     - name: Upload wheels
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/python/xt/pyproject.toml
+++ b/python/xt/pyproject.toml
@@ -40,8 +40,11 @@ docs = [
     # clangquill only supports Python >=3.13. Mark it so that resolving the project's extras (which `uv run --group test`
     # does in project mode, see cmake/modules/DuneXTTesting.cmake) stays satisfiable on the Python 3.12 test builds; the
     # docs themselves are built on 3.13. Without the marker the test resolution fails with an unsatisfiable requirement.
-    # >=0.6.0 for the hierarchical group_by="namespace" page layout (docs/source/conf.py).
-    'clangquill>=0.6.0; python_version >= "3.13"',
+    # >=0.6.0 for the hierarchical group_by="namespace" page layout (docs/source/conf.py). <0.10.0: 0.10.0 made
+    # clangquill_compile_commands mandatory instead of optional, and the docs build here never sets it (the build_docs CI
+    # job only installs the prebuilt wheels, it never runs CMake, so there is no compile_commands.json to point at) --
+    # breaking every docs build with "clangquill_compile_commands is not configured".
+    'clangquill>=0.6.0,<0.10.0; python_version >= "3.13"',
     "plotly",
     "meshio>=4.4",
 ]


### PR DESCRIPTION
## Summary

Investigated why PR #240 kept getting yanked from the merge queue. The trigger wasn't a missing `merge_group` hook — `non_docker_build.yml` already runs there and its `ci-gate` job is the single required check, correctly aggregating everything. The actual cause: the `clang22-release_coverage` `build-linux` leg was repeatedly hitting its 240-minute job timeout, and this has been happening on nearly every push to `main` since late July, not just in PR #240's merge-queue attempts.

Pulled the actual run logs for PR #240's two failed merge-queue runs. The `Restore ccache` step reported:

```
Cache not found for input keys: Linux-ccache-clang22-release_coverage-<run_id>, Linux-ccache-clang22-release_coverage-
```

0/603 ccache hits — a fully cold rebuild of ~520 test binaries plus the Python bindings, which blew past the 240-minute timeout. The same commit's `pull_request`-triggered run (warm ccache from the long-lived PR branch) finished the same leg in ~1h38m.

Root cause: the ccache save key ends in `${{ github.run_id }}`, so every run writes a brand-new cache blob instead of reusing one. Across every PR branch × 2 build presets × the wheel-build cache, this piles up against the repository's shared Actions cache storage quota, which evicts oldest-created entries first. By the time a push-to-main or merge-queue build needed a cache, an unrelated branch's churn had usually already evicted it.

## Change

- Add a single, long-lived `-main` cache slot per preset (and per Python version for the wheel-build cache) that push-to-main deletes (`gh cache delete`) and re-saves in place, instead of growing forever.
- Every event's `restore-keys` now tries this `-main` slot first, before falling back to the existing per-run_id prefix match. Any ref can read the default branch's cache, so `merge_group`/`pull_request` builds now have a real shot at a warm ccache instead of starting cold.
- Added the `actions: write` permission needed for `gh cache delete` to the two affected jobs (`build-linux`, `build_wheels`), scoped with a comment explaining why.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/non_docker_build.yml'))"` — valid YAML.
- Not run in CI yet — the fix's actual effect (warm cache on the next push to main, then on the next merge-queue attempt) can only be observed once this merges and a subsequent push to `main` populates the new `-main` slot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lmt17xVboZtvg6iNRug4CQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build cache management to make builds more reliable and efficient.
  * Extended the Linux build timeout to support longer-running builds.
  * Constrained documentation tooling versions for compatibility with Python 3.13 and newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->