### PR TITLE
Upgrade to clangquill 0.14.0 and build the docs with -W

### DIFF
--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -790,6 +790,19 @@ jobs:
       if: failure()
       run: sudo dmesg --time-format iso | tail -n 200 || true
 
+    - name: Upload clangquill diagnostics log
+      # Every libclang diagnostic of the C++ API parse, at every severity, with the
+      # note: chains the Sphinx warning stream drops (clangquill_diagnostics_log in
+      # docs/source/conf.py). These are not suppressed, so under -W they fail the
+      # job -- which is exactly when this artifact is wanted, hence always(): the
+      # log survives the failure and carries the context the one-line warnings lack.
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: clangquill_diagnostics
+        path: build/clangquill-diagnostics.log
+        if-no-files-found: warn
+
     - name: Upload built docs HTML
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -658,8 +658,14 @@ jobs:
       # shadow the installed bindings. Notebook execution is the actual test: myst-nb
       # is configured with nb_execution_raise_on_error=False, so a failing notebook
       # writes <out>/reports/<name>.err.log instead of aborting, and we fail the job
-      # on those below. We intentionally do NOT pass sphinx -W, because intersphinx
-      # inventory fetches emit network-dependent warnings unrelated to the docs build.
+      # on those below. -W turns every warning into a build failure; since Sphinx 8 that
+      # no longer aborts on the first one -- the build runs to completion and exits
+      # non-zero at the end -- so the whole warning list is in the log (--keep-going is
+      # a no-op there, kept for an older Sphinx, which would abort on the first
+      # warning without it). Warnings this repository cannot act on are filtered in
+      # conf.py: libclang's diagnostics about the absent external DUNE headers, the
+      # Sphinx C++ domain choking on the generated C++ API pages, and intersphinx's
+      # network-dependent inventory fetches. Everything else fails the job.
       # Sphinx runs single-threaded (-j 1) on purpose: this job's runner is sized for
       # it (4 vCPU / 16 GB GitHub-hosted runner), and the clangquill C++ API now
       # emits one page per class/function (group_by="namespace"), a far larger document
@@ -683,7 +689,7 @@ jobs:
         # --no-project: ignore the repo-root pyproject stub; run in the venv built above
         xvfb-run -a uv run --no-project \
           --python "${GITHUB_WORKSPACE}/.venv/bin/python" \
-          python -m sphinx --keep-going -j 1 -b html \
+          python -m sphinx -W --keep-going -j 1 -b html \
           "${GITHUB_WORKSPACE}/docs/source" "${OUT}"
         if compgen -G "${OUT}/reports/*.err.log" > /dev/null; then
           echo "::error::one or more executed documentation notebooks failed (see dumped reports below)"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,8 +113,10 @@ nb_execution_excludepatterns = []
 # present in the docs environment; libclang reports those as non-fatal
 # diagnostics and still extracts every symbol it can parse (they are filtered
 # out of the -W build via suppress_warnings below). Should the wheel be built
-# without libclang, the extension degrades to a placeholder page rather than
-# failing the build.
+# without libclang, the extension writes a placeholder page and warns
+# (clangquill.libclang); that warning is deliberately left unfiltered, so a
+# build that would silently publish the manual without any C++ API at all fails
+# under -W instead of quietly shipping the placeholder.
 
 # The C++ standard and include dirs the in-tree headers are parsed with. Kept in
 # variables because they feed both the compilation database written below and the
@@ -250,6 +252,18 @@ suppress_warnings = [
     # every `#include <dune/common/...>` in the parsed in-tree headers is reported
     # as unresolved. That is expected and non-fatal -- clangquill still extracts
     # every symbol it can parse.
+    #
+    # This deliberately covers the whole type rather than only the "file not
+    # found" message: a missing external header is not one diagnostic but a
+    # cascade. Parsing 7 of the dune/gdt headers emits 140 diagnostics, of which
+    # only 49 are "file not found" -- the other 91 are its consequences (the base
+    # class is now unknown, so "expected class name"; `Dune::Exception` no longer
+    # resolves; DUNE feature macros are undefined; clang hits -ferror-limit).
+    # Matching on the message would therefore leave the majority of them fatal and
+    # keep the docs build permanently red, while still not distinguishing a real
+    # in-tree parse error from a downstream effect of the absent dependency stack.
+    # The DUNE headers would have to be installed in the docs environment for that
+    # distinction to mean anything.
     "clangquill.parse",
 ]
 
@@ -272,6 +286,26 @@ def _warning_location(record):
     return sphinx.util.logging.get_node_location(location) or ""
 
 
+def _inventories_are_all_remote(mapping):
+    """Whether every configured intersphinx inventory is fetched over the network.
+
+    Guards the inventory-failure rule in :class:`_UnactionableWarningFilter`:
+    Sphinx reports *any* exhausted inventory the same way, so with a local
+    ``objects.inv`` configured that one warning would also cover an unreadable or
+    malformed file -- a real misconfiguration, and one this build should fail on.
+    While every target is a URL, the warning can only mean the network.
+    """
+    for target_uri, inventories in mapping.values():
+        if not isinstance(inventories, tuple):
+            inventories = (inventories,)
+        for location in (target_uri, *inventories):
+            if location is not None and not location.strip().startswith(
+                ("http://", "https://")
+            ):
+                return False
+    return True
+
+
 class _UnactionableWarningFilter(logging.Filter):
     """Drop the warnings this documentation build has no way to act on.
 
@@ -284,22 +318,30 @@ class _UnactionableWarningFilter(logging.Filter):
       or MyST reading braces in C++ code as a substitution. None of that is
       fixable from this repository, and none of it comes from a hand-written
       page -- which keeps failing the build for its own warnings.
-    * intersphinx failing to reach the external inventories, which depends on
-      the network rather than on the documentation. That warning carries no
-      type/subtype, so ``suppress_warnings`` cannot address it; every
-      intersphinx warning that does report a documentation problem (an
-      unresolvable cross-reference) is typed, so dropping only the untyped ones
-      keeps `-W` meaningful here too.
+    * intersphinx exhausting the locations for an inventory, which with the
+      all-remote mapping this project configures means the network was in the
+      way rather than the documentation. That warning carries no type/subtype,
+      so ``suppress_warnings`` cannot address it; every intersphinx warning that
+      does report a documentation problem (an unresolvable cross-reference) is
+      typed, so dropping only the untyped ones keeps `-W` meaningful here too.
+      Should a local inventory ever be configured, the same warning starts
+      covering an unreadable or malformed file as well, and this rule turns
+      itself off rather than hide it.
     """
 
-    def __init__(self, generated_dir):
+    def __init__(self, generated_dir, *, filter_inventory_failures):
         super().__init__()
         self._generated = f"{generated_dir}/"
+        self._filter_inventory_failures = filter_inventory_failures
 
     def filter(self, record):
         if record.levelno < logging.WARNING:
             return True
-        if "intersphinx" in record.name and getattr(record, "type", None) is None:
+        if (
+            self._filter_inventory_failures
+            and "intersphinx" in record.name
+            and getattr(record, "type", None) is None
+        ):
             return False
         location = _warning_location(record).replace(os.sep, "/")
         return not (
@@ -312,7 +354,12 @@ def setup(_app):
     # Sphinx counts a warning -- and, under `-W`, fails the build for it -- in a
     # filter on the handlers of its "sphinx" logger, so ours has to run before
     # those: insert it at the front of each chain rather than appending it.
-    warning_filter = _UnactionableWarningFilter(clangquill_output_dir)
+    # intersphinx_mapping is defined further down; setup() runs after conf.py has
+    # been executed in full, so the module global is there by then.
+    warning_filter = _UnactionableWarningFilter(
+        clangquill_output_dir,
+        filter_inventory_failures=_inventories_are_all_remote(intersphinx_mapping),
+    )
     for handler in logging.getLogger("sphinx").handlers:
         handler.filters.insert(0, warning_filter)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,10 +1,13 @@
 import glob
+import json
+import logging
 import os
 import sys
 from pathlib import Path
 
 import slugify
 import sphinx
+import sphinx.util.logging
 
 import dune.gdt
 
@@ -19,6 +22,9 @@ needs_sphinx = "3.4"
 # -----------------------------------------------------------------------------
 
 this_dir = Path(__file__).resolve().parent
+# repository root: this file lives in docs/source (used for the C++ API parse
+# below and for the linkcode source links at the bottom of this file)
+_repo_root = (this_dir / ".." / "..").resolve()
 src_dir = (this_dir / ".." / ".." / "src").resolve()
 sys.path.insert(0, str(src_dir))
 sys.path.insert(0, str(this_dir))
@@ -105,9 +111,17 @@ nb_execution_excludepatterns = []
 # and the include dir lets the intra-tree `#include <dune/...>` headers resolve.
 # The external DUNE dependency headers (dune-common, dune-grid, ...) are not
 # present in the docs environment; libclang reports those as non-fatal
-# diagnostics and still extracts every symbol it can parse. Should the wheel be
-# built without libclang, the extension degrades to a placeholder page rather
-# than failing the build.
+# diagnostics and still extracts every symbol it can parse (they are filtered
+# out of the -W build via suppress_warnings below). Should the wheel be built
+# without libclang, the extension degrades to a placeholder page rather than
+# failing the build.
+
+# The C++ standard and include dirs the in-tree headers are parsed with. Kept in
+# variables because they feed both the compilation database written below and the
+# clangquill_std / clangquill_include_dirs values, which clangquill falls back to
+# for any input the database holds no entry for.
+_cpp_std = "c++17"
+_cpp_include_dirs = ["../.."]
 
 
 def _clang_resource_dir():
@@ -144,10 +158,71 @@ def _clang_resource_dir():
     return out.stdout.strip() or None
 
 
+def _write_compile_commands(inputs, resource_dir):
+    """Write the compilation database clangquill parses the headers with.
+
+    clangquill >= 0.10 requires one: the Sphinx extension refuses to guess compile
+    flags and aborts the build when ``clangquill_compile_commands`` is unset. The
+    CMake presets do export a database (``CMAKE_EXPORT_COMPILE_COMMANDS=ON``, in
+    ``build/<preset>/``), but it only carries entries for the compiled ``.cc``
+    translation units -- never for the headers parsed here -- and the docs CI job
+    installs pre-built wheels without ever configuring CMake. So we write our own,
+    with one entry per parsed header carrying exactly the flags this documentation
+    build needs, and return the directory holding it (what clangquill expects).
+
+    ``CLANGQUILL_COMPILE_COMMANDS`` overrides this with an existing database (a
+    directory holding a ``compile_commands.json``, or that file itself), e.g. a
+    fully configured local build tree that also resolves the external DUNE
+    dependency headers.
+    """
+    override = os.environ.get("CLANGQUILL_COMPILE_COMMANDS")
+    if override:
+        return override
+
+    arguments = ["clang++", f"-std={_cpp_std}", "-xc++"]
+    arguments += [f"-I{(this_dir / d).resolve()}" for d in _cpp_include_dirs]
+    if resource_dir:
+        arguments.append(f"-resource-dir={resource_dir}")
+
+    # Fully resolved, exactly as clangquill resolves clangquill_input: the database
+    # is looked up by the path of the file being parsed, so an entry keyed by any
+    # other spelling of that path would silently not be found.
+    headers = sorted(
+        {
+            str(Path(match).resolve())
+            for pattern in inputs
+            for match in glob.glob(str(this_dir / pattern), recursive=True)
+            if Path(match).is_file()
+        }
+    )
+    # git-ignored, and outside the Sphinx srcdir so nothing lands next to the
+    # documentation sources
+    out_dir = _repo_root / "build" / "docs_compile_commands"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(_repo_root),
+                    "file": header,
+                    "arguments": [*arguments, "-c", header],
+                }
+                for header in headers
+            ],
+            indent=1,
+        ),
+        encoding="utf-8",
+    )
+    return str(out_dir)
+
+
 clangquill_input = ["../../dune/**/*.hh"]
-clangquill_include_dirs = ["../.."]
-clangquill_std = "c++17"
+clangquill_include_dirs = _cpp_include_dirs
+clangquill_std = _cpp_std
 clangquill_clang_resource_dir = _clang_resource_dir()
+clangquill_compile_commands = _write_compile_commands(
+    clangquill_input, clangquill_clang_resource_dir
+)
 clangquill_output_dir = "cpp_api"
 # Build a browsable namespace hierarchy (clangquill >= 0.6.0): the index lists
 # only the top namespaces, each namespace hub links its sub-namespaces, classes,
@@ -161,6 +236,86 @@ clangquill_group_by = "namespace"
 clangquill_include_undocumented = True
 # Persist the SQLite IR + page hashes so local rebuilds are incremental.
 clangquill_cache_dir = "_clangquill_cache"
+
+# -----------------------------------------------------------------------------
+# Warnings
+# -----------------------------------------------------------------------------
+# The docs are built with `-W` (see the build_docs job in
+# .github/workflows/non_docker_build.yml), so every warning fails the build. Only
+# warnings the documentation itself cannot fix are filtered out -- by type here,
+# and by where they come from in _UnactionableWarningFilter below.
+suppress_warnings = [
+    # One warning per libclang diagnostic. The external DUNE dependency headers
+    # (dune-common, dune-grid, ...) are not installed in a docs environment, so
+    # every `#include <dune/common/...>` in the parsed in-tree headers is reported
+    # as unresolved. That is expected and non-fatal -- clangquill still extracts
+    # every symbol it can parse.
+    "clangquill.parse",
+]
+
+
+def _warning_location(record):
+    """Best-effort source location of a Sphinx log ``record``, as a string.
+
+    ``location=`` is passed as a docname, a ``(docname, lineno)`` pair or a
+    docutils node, depending on who logs the warning; Sphinx normalises all of
+    them, but only in a handler filter that runs after the one counting warnings
+    (see :func:`setup`), so this filter has to do it itself.
+    """
+    location = getattr(record, "location", None)
+    if location is None:
+        return ""
+    if isinstance(location, tuple):
+        return str(location[0] or "")
+    if isinstance(location, str):
+        return location
+    return sphinx.util.logging.get_node_location(location) or ""
+
+
+class _UnactionableWarningFilter(logging.Filter):
+    """Drop the warnings this documentation build has no way to act on.
+
+    Everything else stays fatal under `-W`; the two exceptions are:
+
+    * Warnings about a page under ``clangquill_output_dir``. Those pages are
+      generated from the C++ headers, and the bulk of them are the Sphinx C++
+      domain balking at declarations libclang extracted verbatim (deeply nested
+      DUNE templates it cannot re-parse, specialisations it sees as duplicates)
+      or MyST reading braces in C++ code as a substitution. None of that is
+      fixable from this repository, and none of it comes from a hand-written
+      page -- which keeps failing the build for its own warnings.
+    * intersphinx failing to reach the external inventories, which depends on
+      the network rather than on the documentation. That warning carries no
+      type/subtype, so ``suppress_warnings`` cannot address it; every
+      intersphinx warning that does report a documentation problem (an
+      unresolvable cross-reference) is typed, so dropping only the untyped ones
+      keeps `-W` meaningful here too.
+    """
+
+    def __init__(self, generated_dir):
+        super().__init__()
+        self._generated = f"{generated_dir}/"
+
+    def filter(self, record):
+        if record.levelno < logging.WARNING:
+            return True
+        if "intersphinx" in record.name and getattr(record, "type", None) is None:
+            return False
+        location = _warning_location(record).replace(os.sep, "/")
+        return not (
+            location.startswith(self._generated) or f"/{self._generated}" in location
+        )
+
+
+def setup(app):  # noqa: ARG001
+    """Sphinx entry point for conf.py-local setup."""
+    # Sphinx counts a warning -- and, under `-W`, fails the build for it -- in a
+    # filter on the handlers of its "sphinx" logger, so ours has to run before
+    # those: insert it at the front of each chain rather than appending it.
+    warning_filter = _UnactionableWarningFilter(clangquill_output_dir)
+    for handler in logging.getLogger("sphinx").handlers:
+        handler.filters.insert(0, warning_filter)
+
 
 bibtex_bibfiles = ["bibliography.bib"]
 # Add any paths that contain templates here, relative to this directory.
@@ -373,7 +528,6 @@ try_on_binder_slug = os.environ.get(
 
 # repository hosting both the tutorial sources and the python bindings
 _linkcode_baseurl = "https://github.com/dune-gdt/dune-gdt"
-_repo_root = (this_dir / ".." / "..").resolve()
 
 
 def linkcode_resolve(domain, info):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -286,22 +286,22 @@ def _warning_location(record):
     return sphinx.util.logging.get_node_location(location) or ""
 
 
-def _inventories_are_all_remote(mapping):
-    """Whether every configured intersphinx inventory is fetched over the network.
+def _inventories_are_all_https(mapping):
+    """Whether every configured intersphinx inventory is fetched over HTTPS.
 
     Guards the inventory-failure rule in :class:`_UnactionableWarningFilter`:
     Sphinx reports *any* exhausted inventory the same way, so with a local
     ``objects.inv`` configured that one warning would also cover an unreadable or
     malformed file -- a real misconfiguration, and one this build should fail on.
-    While every target is a URL, the warning can only mean the network.
+    While every target is a URL, the warning can only mean the network. A
+    plain-``http://`` target deliberately does not qualify: this project has none,
+    and the stricter reading (inventory failures stay fatal) is the safe default.
     """
     for target_uri, inventories in mapping.values():
         if not isinstance(inventories, tuple):
             inventories = (inventories,)
         for location in (target_uri, *inventories):
-            if location is not None and not location.strip().startswith(
-                ("http://", "https://")
-            ):
+            if location is not None and not location.strip().startswith("https://"):
                 return False
     return True
 
@@ -319,7 +319,7 @@ class _UnactionableWarningFilter(logging.Filter):
       fixable from this repository, and none of it comes from a hand-written
       page -- which keeps failing the build for its own warnings.
     * intersphinx exhausting the locations for an inventory, which with the
-      all-remote mapping this project configures means the network was in the
+      all-HTTPS mapping this project configures means the network was in the
       way rather than the documentation. That warning carries no type/subtype,
       so ``suppress_warnings`` cannot address it; every intersphinx warning that
       does report a documentation problem (an unresolvable cross-reference) is
@@ -358,7 +358,7 @@ def setup(_app):
     # been executed in full, so the module global is there by then.
     warning_filter = _UnactionableWarningFilter(
         clangquill_output_dir,
-        filter_inventory_failures=_inventories_are_all_remote(intersphinx_mapping),
+        filter_inventory_failures=_inventories_are_all_https(intersphinx_mapping),
     )
     for handler in logging.getLogger("sphinx").handlers:
         handler.filters.insert(0, warning_filter)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -265,6 +265,14 @@ suppress_warnings = [
     # The DUNE headers would have to be installed in the docs environment for that
     # distinction to mean anything.
     "clangquill.parse",
+    # Cosmetic, and only reachable when the notebooks are *not* executed. The
+    # tutorials use IPython shell escapes (`!ls -l f.vtu`), which the plain
+    # "python" pygments lexer cannot tokenise. Executing a notebook records
+    # language_info.pygments_lexer = "ipython3" -- which handles them -- so this
+    # never fires in CI; without execution the lexer falls back to
+    # kernelspec.language ("python") and the escapes fail to lex. Sphinx retries
+    # in relaxed mode either way, so the rendered page is fine.
+    "misc.highlighting_failure",
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,11 +109,12 @@ nb_execution_excludepatterns = []
 # All clangquill paths are resolved relative to this srcdir (docs/source),
 # so "../.." is the repository root: the input glob covers dune/{gdt,xt}/**/*.hh
 # and the include dir lets the intra-tree `#include <dune/...>` headers resolve.
-# The external DUNE dependency headers (dune-common, dune-grid, ...) are not
-# present in the docs environment; libclang reports those as non-fatal
-# diagnostics and still extracts every symbol it can parse (they are filtered
-# out of the -W build via suppress_warnings below). Should the wheel be built
-# without libclang, the extension writes a placeholder page and warns
+# The external dependency headers (dune-common, dune-grid, boost, Eigen, ...)
+# are not present in the docs environment; libclang reports those as errors and
+# still extracts every symbol it can parse. Those diagnostics are deliberately
+# *not* suppressed -- they are real gaps in what the C++ API pages can document,
+# so the -W build surfaces them rather than hiding them. Should the wheel be
+# built without libclang, the extension writes a placeholder page and warns
 # (clangquill.libclang); that warning is deliberately left unfiltered, so a
 # build that would silently publish the manual without any C++ API at all fails
 # under -W instead of quietly shipping the placeholder.
@@ -238,6 +239,15 @@ clangquill_group_by = "namespace"
 clangquill_include_undocumented = True
 # Persist the SQLite IR + page hashes so local rebuilds are incremental.
 clangquill_cache_dir = "_clangquill_cache"
+# Full libclang diagnostics of the run -- every severity, plus the `note:` chain
+# attached to each -- written here (clangquill >= 0.14). The Sphinx warning
+# stream only ever carries the errors, and only their top-level message, so this
+# file is where the context needed to actually fix one lives: which include
+# failed, and the notes explaining what it made unparseable. Written under the
+# git-ignored build/ next to the generated compilation database rather than into
+# the srcdir, and uploaded by the docs CI job (see non_docker_build.yml) so a red
+# build's diagnostics are retrievable instead of only scrollable in the log.
+clangquill_diagnostics_log = "../../build/clangquill-diagnostics.log"
 
 # -----------------------------------------------------------------------------
 # Warnings
@@ -245,26 +255,11 @@ clangquill_cache_dir = "_clangquill_cache"
 # The docs are built with `-W` (see the build_docs job in
 # .github/workflows/non_docker_build.yml), so every warning fails the build. Only
 # warnings the documentation itself cannot fix are filtered out -- by type here,
-# and by where they come from in _UnactionableWarningFilter below.
+# and by where they come from in _UnactionableWarningFilter below. libclang's
+# parse diagnostics (clangquill.parse) are deliberately *not* among them: they
+# mark C++ the API pages could not read, which is fixable by making the missing
+# headers available to the parse, so the build reports them.
 suppress_warnings = [
-    # One warning per libclang diagnostic. The external DUNE dependency headers
-    # (dune-common, dune-grid, ...) are not installed in a docs environment, so
-    # every `#include <dune/common/...>` in the parsed in-tree headers is reported
-    # as unresolved. That is expected and non-fatal -- clangquill still extracts
-    # every symbol it can parse.
-    #
-    # This deliberately covers the whole type rather than only the "file not
-    # found" message: a missing external header is not one diagnostic but a
-    # cascade. Parsing 7 of the dune/gdt headers emits 140 diagnostics, of which
-    # only 49 are "file not found" -- the other 91 are its consequences (the base
-    # class is now unknown, so "expected class name"; `Dune::Exception` no longer
-    # resolves; DUNE feature macros are undefined; clang hits -ferror-limit).
-    # Matching on the message would therefore leave the majority of them fatal and
-    # keep the docs build permanently red, while still not distinguishing a real
-    # in-tree parse error from a downstream effect of the absent dependency stack.
-    # The DUNE headers would have to be installed in the docs environment for that
-    # distinction to mean anything.
-    "clangquill.parse",
     # Cosmetic, and only reachable when the notebooks are *not* executed. The
     # tutorials use IPython shell escapes (`!ls -l f.vtu`), which the plain
     # "python" pygments lexer cannot tokenise. Executing a notebook records

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -307,8 +307,8 @@ class _UnactionableWarningFilter(logging.Filter):
         )
 
 
-def setup(app):  # noqa: ARG001
-    """Sphinx entry point for conf.py-local setup."""
+def setup(_app):
+    """Sphinx entry point for conf.py-local setup (called with the app)."""
     # Sphinx counts a warning -- and, under `-W`, fails the build for it -- in a
     # filter on the handlers of its "sphinx" logger, so ours has to run before
     # those: insert it at the front of each chain rather than appending it.

--- a/docs/source/dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md
+++ b/docs/source/dune_gdt_tutorial_on_cg_fem_for_the_stationary_heat_equation.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/dune_gdt_tutorial_on_data_functions_and_interpolation.md
+++ b/docs/source/dune_gdt_tutorial_on_data_functions_and_interpolation.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__ESV2007_estimates.md
+++ b/docs/source/example__ESV2007_estimates.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__MNS2002_estimates.md
+++ b/docs/source/example__MNS2002_estimates.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__alugrid_variants.md
+++ b/docs/source/example__alugrid_variants.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__custom_python_functions.md
+++ b/docs/source/example__custom_python_functions.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__gmsh_grid.md
+++ b/docs/source/example__gmsh_grid.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__ipdg_heat_equation.md
+++ b/docs/source/example__ipdg_heat_equation.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__ipdg_stationary_heat_equation.md
+++ b/docs/source/example__ipdg_stationary_heat_equation.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__la_eigensolvers.md
+++ b/docs/source/example__la_eigensolvers.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__linear_transport_fv.md
+++ b/docs/source/example__linear_transport_fv.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__mixed_and_prism_grids.md
+++ b/docs/source/example__mixed_and_prism_grids.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__prolongations_products_and_norms.md
+++ b/docs/source/example__prolongations_products_and_norms.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__simple_grid_adaptation.md
+++ b/docs/source/example__simple_grid_adaptation.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__stokes_taylor_hood.md
+++ b/docs/source/example__stokes_taylor_hood.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/docs/source/example__structured_1d_grids.md
+++ b/docs/source/example__structured_1d_grids.md
@@ -14,6 +14,7 @@ jupyter:
       jupytext_version: 1.11.2
 kernelspec:
   display_name: Python 3
+  language: python
   name: python3
 ---
 

--- a/python/gdt/uv.lock
+++ b/python/gdt/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "clangquill"
-version = "0.10.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version >= '3.13'" },
@@ -328,10 +328,11 @@ dependencies = [
     { name = "rich", marker = "python_full_version >= '3.13'" },
     { name = "typer", marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a7/ea5fc876f6463ec652cfbe780ed2e3c0d9b301eab8a56b95b878c52d05c2/clangquill-0.10.0.tar.gz", hash = "sha256:041df075f9fc1e88ab858a8b74b3bb8af5eaad0b576a737414e9d996d5949eaa", size = 1613798, upload-time = "2026-08-04T14:17:10.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ae/78cd9f668a0baa81c2b0ec3c84d426c90d805654ca370f7ac76fa58290e1/clangquill-0.14.0.tar.gz", hash = "sha256:3fc4347ae198260e4aaa56c628288a2583112aed52a178d80653e1ff08e92320", size = 1637812, upload-time = "2026-08-06T09:54:54.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/1c/2031fc9eda7998117d967895aee208d481d3cba149123f51760039d865ac/clangquill-0.10.0-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:4bc8ead8ca44b3b439f224c49eb1c28e2ade4d8675efabc84e1872dc798e356b", size = 56952274, upload-time = "2026-08-04T14:17:04.559Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5a/58d92e0e5974364250cddacbd05cdb05c71e2c87178d15946eace3e181fc/clangquill-0.10.0-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:d4435aaa9fe86c25ee1df1aaa5bbdccd6ce6c33907888d7449170024c87ee216", size = 60606652, upload-time = "2026-08-04T14:17:07.693Z" },
+    { url = "https://files.pythonhosted.org/packages/28/77/d1123237f8a5429fa351316ace0d7ca27565b6195fe05a38005ee8b6c137/clangquill-0.14.0-cp312-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:043176a76a63eedecdbef75ff8008db0dd3e326771767629e1a02d7a8872362f", size = 56959222, upload-time = "2026-08-06T09:54:46.406Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/d37b70d982a28b4c60d94af536c948075bb5416963965a47d01118a1708b/clangquill-0.14.0-cp312-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ed05cea08f03f598a89bdf10b5a2b19159acc8112c0138e30b1278b11250ebd3", size = 60612971, upload-time = "2026-08-06T09:54:49.763Z" },
+    { url = "https://files.pythonhosted.org/packages/24/6b/541a13c24f39fe2bc95e633463732ffed444a523ef282b7bdd3315b5cd2e/clangquill-0.14.0-cp312-abi3-win_amd64.whl", hash = "sha256:39aa772d04dc3875a509657aeae588b15766d00147b3a5cf262da05b783ef6b2", size = 32609918, upload-time = "2026-08-06T09:54:52.564Z" },
 ]
 
 [[package]]
@@ -916,9 +917,9 @@ visualisation = [
 requires-dist = [
     { name = "bokeh", marker = "extra == 'all'" },
     { name = "bokeh", marker = "extra == 'parallel'" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.10.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.10.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.14.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.14.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.14.0" },
     { name = "cmake-format", marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "cmake-format", marker = "extra == 'infrastructure'", specifier = "==0.4.1" },
     { name = "codecov", marker = "extra == 'all'" },

--- a/python/gdt/uv.lock
+++ b/python/gdt/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "clangquill"
-version = "0.8.3"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version >= '3.13'" },
@@ -328,10 +328,10 @@ dependencies = [
     { name = "rich", marker = "python_full_version >= '3.13'" },
     { name = "typer", marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/15/0b9e5c21ff0fb669208257a4a3e560a4175ae29f1c3b4bcbfb80e17da0f8/clangquill-0.8.3.tar.gz", hash = "sha256:a89809f1ddd98bd8f2b413fab54eaf641d91e67dc04776d17a2fce0569cdca09", size = 1606035, upload-time = "2026-07-05T17:09:47.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/a7/ea5fc876f6463ec652cfbe780ed2e3c0d9b301eab8a56b95b878c52d05c2/clangquill-0.10.0.tar.gz", hash = "sha256:041df075f9fc1e88ab858a8b74b3bb8af5eaad0b576a737414e9d996d5949eaa", size = 1613798, upload-time = "2026-08-04T14:17:10.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/f7/8d336f999c869db2650e85bd04ead45836d0ecd484e30a005ec1eb9139ae/clangquill-0.8.3-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:a0134f89c58aecd10c1d56e1f03b9dc6cb0c714b8de28f1c82289f2c0afbf2d4", size = 56947418, upload-time = "2026-07-05T17:09:41.232Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6e/d35e59d669d0643f78e0524eb7dd3403588f9491bf188f5a763ddfdf8197/clangquill-0.8.3-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:da491f8036c501b47372a8254b1494c3909d6ee54e77c7fe8745f8898d2eab44", size = 60601602, upload-time = "2026-07-05T17:09:45.285Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1c/2031fc9eda7998117d967895aee208d481d3cba149123f51760039d865ac/clangquill-0.10.0-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:4bc8ead8ca44b3b439f224c49eb1c28e2ade4d8675efabc84e1872dc798e356b", size = 56952274, upload-time = "2026-08-04T14:17:04.559Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/58d92e0e5974364250cddacbd05cdb05c71e2c87178d15946eace3e181fc/clangquill-0.10.0-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:d4435aaa9fe86c25ee1df1aaa5bbdccd6ce6c33907888d7449170024c87ee216", size = 60606652, upload-time = "2026-08-04T14:17:07.693Z" },
 ]
 
 [[package]]
@@ -916,9 +916,9 @@ visualisation = [
 requires-dist = [
     { name = "bokeh", marker = "extra == 'all'" },
     { name = "bokeh", marker = "extra == 'parallel'" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.6.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.10.0" },
     { name = "cmake-format", marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "cmake-format", marker = "extra == 'infrastructure'", specifier = "==0.4.1" },
     { name = "codecov", marker = "extra == 'all'" },

--- a/python/xt/pyproject.toml
+++ b/python/xt/pyproject.toml
@@ -40,8 +40,9 @@ docs = [
     # clangquill only supports Python >=3.13. Mark it so that resolving the project's extras (which `uv run --group test`
     # does in project mode, see cmake/modules/DuneXTTesting.cmake) stays satisfiable on the Python 3.12 test builds; the
     # docs themselves are built on 3.13. Without the marker the test resolution fails with an unsatisfiable requirement.
-    # >=0.6.0 for the hierarchical group_by="namespace" page layout (docs/source/conf.py).
-    'clangquill>=0.6.0; python_version >= "3.13"',
+    # >=0.10.0 for the required clangquill_compile_commands (the Sphinx extension no longer guesses compile flags) on
+    # top of the hierarchical group_by="namespace" page layout; both are configured in docs/source/conf.py.
+    'clangquill>=0.10.0; python_version >= "3.13"',
     "plotly",
     "meshio>=4.4",
 ]

--- a/python/xt/pyproject.toml
+++ b/python/xt/pyproject.toml
@@ -40,13 +40,14 @@ docs = [
     # clangquill only supports Python >=3.13. Mark it so that resolving the project's extras (which `uv run --group test`
     # does in project mode, see cmake/modules/DuneXTTesting.cmake) stays satisfiable on the Python 3.12 test builds; the
     # docs themselves are built on 3.13. Without the marker the test resolution fails with an unsatisfiable requirement.
-    # >=0.10.0 for the required clangquill_compile_commands (the Sphinx extension no longer guesses compile flags) on
-    # top of the hierarchical group_by="namespace" page layout; both are configured in docs/source/conf.py. This
-    # deliberately drops the `<0.10.0` cap main added as a stopgap: that cap was there because nothing configured
-    # clangquill_compile_commands and the docs build died with "clangquill_compile_commands is not configured" -- true
-    # while the build_docs job only installs the prebuilt wheels and never runs CMake, which is exactly what conf.py now
-    # solves by writing its own compilation database for the parsed headers.
-    'clangquill>=0.10.0; python_version >= "3.13"',
+    # >=0.14.0: 0.10.0 made clangquill_compile_commands required (the Sphinx extension no longer guesses compile flags)
+    # and 0.14.0 is what this configuration is verified against; on top of that comes the hierarchical
+    # group_by="namespace" page layout. All of it is configured in docs/source/conf.py. The floor deliberately drops the
+    # `<0.10.0` cap main added as a stopgap: that cap was there because nothing configured clangquill_compile_commands
+    # and the docs build died with "clangquill_compile_commands is not configured" -- true while the build_docs job only
+    # installs the prebuilt wheels and never runs CMake, which is exactly what conf.py now solves by writing its own
+    # compilation database for the parsed headers.
+    'clangquill>=0.14.0; python_version >= "3.13"',
     "plotly",
     "meshio>=4.4",
 ]

--- a/python/xt/uv.lock
+++ b/python/xt/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "clangquill"
-version = "0.8.3"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version >= '3.13'" },
@@ -328,10 +328,10 @@ dependencies = [
     { name = "rich", marker = "python_full_version >= '3.13'" },
     { name = "typer", marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/15/0b9e5c21ff0fb669208257a4a3e560a4175ae29f1c3b4bcbfb80e17da0f8/clangquill-0.8.3.tar.gz", hash = "sha256:a89809f1ddd98bd8f2b413fab54eaf641d91e67dc04776d17a2fce0569cdca09", size = 1606035, upload-time = "2026-07-05T17:09:47.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/a7/ea5fc876f6463ec652cfbe780ed2e3c0d9b301eab8a56b95b878c52d05c2/clangquill-0.10.0.tar.gz", hash = "sha256:041df075f9fc1e88ab858a8b74b3bb8af5eaad0b576a737414e9d996d5949eaa", size = 1613798, upload-time = "2026-08-04T14:17:10.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/f7/8d336f999c869db2650e85bd04ead45836d0ecd484e30a005ec1eb9139ae/clangquill-0.8.3-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:a0134f89c58aecd10c1d56e1f03b9dc6cb0c714b8de28f1c82289f2c0afbf2d4", size = 56947418, upload-time = "2026-07-05T17:09:41.232Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6e/d35e59d669d0643f78e0524eb7dd3403588f9491bf188f5a763ddfdf8197/clangquill-0.8.3-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:da491f8036c501b47372a8254b1494c3909d6ee54e77c7fe8745f8898d2eab44", size = 60601602, upload-time = "2026-07-05T17:09:45.285Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1c/2031fc9eda7998117d967895aee208d481d3cba149123f51760039d865ac/clangquill-0.10.0-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:4bc8ead8ca44b3b439f224c49eb1c28e2ade4d8675efabc84e1872dc798e356b", size = 56952274, upload-time = "2026-08-04T14:17:04.559Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/58d92e0e5974364250cddacbd05cdb05c71e2c87178d15946eace3e181fc/clangquill-0.10.0-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:d4435aaa9fe86c25ee1df1aaa5bbdccd6ce6c33907888d7449170024c87ee216", size = 60606652, upload-time = "2026-08-04T14:17:07.693Z" },
 ]
 
 [[package]]
@@ -907,9 +907,9 @@ test = [
 requires-dist = [
     { name = "bokeh", marker = "extra == 'all'" },
     { name = "bokeh", marker = "extra == 'parallel'" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.6.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.10.0" },
     { name = "cmake-format", marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "cmake-format", marker = "extra == 'infrastructure'", specifier = "==0.4.1" },
     { name = "codecov", marker = "extra == 'all'" },

--- a/python/xt/uv.lock
+++ b/python/xt/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "clangquill"
-version = "0.10.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version >= '3.13'" },
@@ -328,10 +328,11 @@ dependencies = [
     { name = "rich", marker = "python_full_version >= '3.13'" },
     { name = "typer", marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a7/ea5fc876f6463ec652cfbe780ed2e3c0d9b301eab8a56b95b878c52d05c2/clangquill-0.10.0.tar.gz", hash = "sha256:041df075f9fc1e88ab858a8b74b3bb8af5eaad0b576a737414e9d996d5949eaa", size = 1613798, upload-time = "2026-08-04T14:17:10.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ae/78cd9f668a0baa81c2b0ec3c84d426c90d805654ca370f7ac76fa58290e1/clangquill-0.14.0.tar.gz", hash = "sha256:3fc4347ae198260e4aaa56c628288a2583112aed52a178d80653e1ff08e92320", size = 1637812, upload-time = "2026-08-06T09:54:54.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/1c/2031fc9eda7998117d967895aee208d481d3cba149123f51760039d865ac/clangquill-0.10.0-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:4bc8ead8ca44b3b439f224c49eb1c28e2ade4d8675efabc84e1872dc798e356b", size = 56952274, upload-time = "2026-08-04T14:17:04.559Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5a/58d92e0e5974364250cddacbd05cdb05c71e2c87178d15946eace3e181fc/clangquill-0.10.0-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:d4435aaa9fe86c25ee1df1aaa5bbdccd6ce6c33907888d7449170024c87ee216", size = 60606652, upload-time = "2026-08-04T14:17:07.693Z" },
+    { url = "https://files.pythonhosted.org/packages/28/77/d1123237f8a5429fa351316ace0d7ca27565b6195fe05a38005ee8b6c137/clangquill-0.14.0-cp312-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:043176a76a63eedecdbef75ff8008db0dd3e326771767629e1a02d7a8872362f", size = 56959222, upload-time = "2026-08-06T09:54:46.406Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/d37b70d982a28b4c60d94af536c948075bb5416963965a47d01118a1708b/clangquill-0.14.0-cp312-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ed05cea08f03f598a89bdf10b5a2b19159acc8112c0138e30b1278b11250ebd3", size = 60612971, upload-time = "2026-08-06T09:54:49.763Z" },
+    { url = "https://files.pythonhosted.org/packages/24/6b/541a13c24f39fe2bc95e633463732ffed444a523ef282b7bdd3315b5cd2e/clangquill-0.14.0-cp312-abi3-win_amd64.whl", hash = "sha256:39aa772d04dc3875a509657aeae588b15766d00147b3a5cf262da05b783ef6b2", size = 32609918, upload-time = "2026-08-06T09:54:52.564Z" },
 ]
 
 [[package]]
@@ -907,9 +908,9 @@ test = [
 requires-dist = [
     { name = "bokeh", marker = "extra == 'all'" },
     { name = "bokeh", marker = "extra == 'parallel'" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.10.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.10.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.14.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.14.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.14.0" },
     { name = "cmake-format", marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "cmake-format", marker = "extra == 'infrastructure'", specifier = "==0.4.1" },
     { name = "codecov", marker = "extra == 'all'" },


### PR DESCRIPTION
## What

* bumps the `clangquill` requirement from `>=0.6.0` to `>=0.14.0` (`python/xt/pyproject.toml` plus both `uv.lock`s);
* configures the compilation database clangquill >= 0.10 requires, in `docs/source/conf.py`;
* runs the sphinx docs build with `-W` (warnings as errors) in the `build_docs` job;
* surfaces libclang's parse diagnostics instead of suppressing them, and archives the full diagnostics log as a CI artifact.

## The compilation database

clangquill >= 0.10's Sphinx extension refuses to guess compile flags: it parses with the flags a build system recorded and aborts the build when `clangquill_compile_commands` is unset.

The CMake presets do export a database (`CMAKE_EXPORT_COMPILE_COMMANDS=ON`, `build/<preset>/`), but it only holds entries for the compiled `.cc` translation units — never for the `dune/**/*.hh` headers the C++ API pages are generated from — and the docs job installs pre-built wheels without ever configuring CMake. So `conf.py` writes its own database into the (git-ignored) `build/docs_compile_commands/`: one entry per parsed header, carrying exactly the flags this documentation build needs (`-std=c++17`, the repo-root include dir, the clang resource dir). Entry paths are fully resolved, matching how clangquill resolves `clangquill_input`, so the lookup hits.

`clangquill_std` / `clangquill_include_dirs` stay configured as the fallback clangquill uses for any input the database has no entry for; `CLANGQUILL_COMPILE_COMMANDS` overrides the generated database with an existing one (e.g. a fully configured local build tree).

Verified that a per-header database entry does take precedence over the guessed flags, and that a full docs build generates the same C++ API tree as before (1575 pages from 12487 symbols) — under 0.10.0 originally, and re-verified byte-identical under 0.14.0.

## Warnings as errors

`python -m sphinx -W --keep-going …`. Since Sphinx 8, `-W` no longer aborts on the first warning — the build runs to completion and exits non-zero — so the whole warning list stays in the job log (`--keep-going` is a no-op there, kept for older Sphinx).

Only warnings the documentation itself cannot act on are filtered; everything else fails the job:

* `suppress_warnings = ["misc.highlighting_failure"]` — the tutorials use IPython shell escapes (`!ls -l f.vtu`) that the plain `python` lexer cannot tokenise. Executing a notebook records `language_info.pygments_lexer = "ipython3"`, which handles them, so this never fires in CI; it only occurs in local builds with execution disabled.
* a logging filter dropping warnings located under `cpp_api/` — the Sphinx C++ domain balking at declarations libclang extracted verbatim (~1270 "Too many template argument lists", ~207 "Duplicate C++ declaration") and MyST reading C++ braces as substitutions. Filtering by *location* rather than by type keeps hand-written pages failing the build for their own warnings.
* the same filter drops intersphinx's untyped "failed to reach any of the inventories" warning, which depends on the network rather than on the documentation. Typed intersphinx warnings (unresolvable cross-references) stay fatal.

The filter is installed at the front of the handler filter chain on Sphinx's `sphinx` logger, because Sphinx counts warnings — and fails the build for them — in a handler filter of its own.

## The parse diagnostics are *not* suppressed

`clangquill.parse` — one warning per libclang diagnostic — is deliberately **not** filtered. Each one marks C++ the API pages could not read, i.e. a symbol, base class or member missing from the generated documentation, so suppressing them hid real gaps rather than noise.

To make them fixable rather than merely visible, `clangquill_diagnostics_log` (new in 0.14.0) writes the complete libclang output to the git-ignored `build/clangquill-diagnostics.log`. The Sphinx stream carries only each error's top-level message; the log carries every severity plus the `note: in file included from` chain behind each, which is what identifies the include path that failed. The docs job uploads it as a `clangquill_diagnostics` artifact with `if: always()`, so it survives exactly the failing build that warrants reading it.

## Current CI state

**The `build_docs` job is red on this branch, by design.** It fails with 467 `clangquill.parse` warnings — the external DUNE dependency headers (dune-common, dune-grid, …), boost, Eigen, gtest, tbb, `config.h` and pybind11 are not installed in the docs environment, so their `#include`s are reported unresolved; clangquill still extracts every symbol it can parse.

Of the 467: 382 are a missing include — by top-level directory dune (295), boost (58), Eigen (15), gtest (5), tbb (4), `config.h` (3), pybind11 (2) — and the remaining 85 are their consequences (undeclared identifiers, unknown types, unparseable base classes). The uploaded log holds all 554 diagnostics of the run, including the 86 `note:` lines and 84 include chains.

Clearing them means making those headers reachable by the parse; that is not done here, so this PR should not be merged as-is unless the red docs job is acceptable in the interim.

## Testing

* full `sphinx -W` build of `docs/source` against clangquill 0.14.0 and the published `dune-gdt` wheels: 467 warnings, 100% `clangquill.parse`, no other warning class.
* CI run on this head reproduces it exactly — same 467, all `clangquill.parse`, and confirms the `clangquill_diagnostics` artifact uploads on the failing build. The myst-nb lexer warnings seen in local builds are absent there, as expected, since CI executes the notebooks.
* the warning filter was exercised directly over the location forms Sphinx passes (docname, `(path, line)` tuple, docutils node) plus the intersphinx typed/untyped cases.
* `ruff check` / `ruff format` clean on `conf.py`.
