### PR TITLE
build: cut the wheel size back under the PyPI 100 MB limit

### DIFF
--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -73,9 +73,32 @@ DUNE_BUILD_DIR="${DUNE_SRC_DIR}/build/wheelbuilder-release"
 # xt is an exact-version dependency of gdt -> needs `--find-links`
 "${PYTHON_BIN}" -m pip install "${TMP_WHEEL_DIR}"/dune_xt*whl
 "${PYTHON_BIN}" -m pip wheel "${DUNE_BUILD_DIR}/python/gdt/" -w "${TMP_WHEEL_DIR}" --find-links "${TMP_WHEEL_DIR}/"
+
+# The wheelbuilder preset builds the dune module libraries and the vcpkg dependencies shared (BUILD_SHARED_LIBS=ON +
+# the x64-linux-shared triplet) so that ALUGrid, boost, dunext & co. are bundled into the wheel *once* instead of
+# being statically linked into each of the ~100 extension modules. auditwheel resolves those NEEDED entries through
+# the dynamic loader, so point it at the build tree: the module .so files carry a build-tree RUNPATH, but relying on
+# it alone breaks as soon as a toolchain strips or rewrites it during packaging.
+VCPKG_LIB_DIRS="$(find "${DUNE_BUILD_DIR}/vcpkg_installed" -mindepth 2 -maxdepth 2 -type d -name lib -printf '%p:' 2>/dev/null || true)"
+export LD_LIBRARY_PATH="${DUNE_BUILD_DIR}/lib:${VCPKG_LIB_DIRS}${LD_LIBRARY_PATH:-}"
+
 # Bundle external shared libraries into the wheels
 "${PYTHON_BIN}" -m auditwheel repair --plat "${PLATFORM}" "${TMP_WHEEL_DIR}"/*xt*.whl -w "${WHEEL_DIR}/final"
 "${PYTHON_BIN}" -m auditwheel repair --plat "${PLATFORM}" "${TMP_WHEEL_DIR}"/*gdt*.whl -w "${WHEEL_DIR}/final"
+
+# Wheels above the PyPI per-file limit cannot be published, and the failure only surfaces at upload time (i.e. on a
+# push to main, long after the change that caused it merged). Fail the build instead, and warn early enough that
+# there is room to react.
+for whl in "${WHEEL_DIR}"/final/*.whl; do
+  size_mb=$(( $(stat -c %s "${whl}") / 1000000 ))
+  echo "wheel size: ${size_mb} MB  $(basename "${whl}")"
+  if [ "${size_mb}" -ge 100 ]; then
+    echo "ERROR: $(basename "${whl}") is ${size_mb} MB, above the 100 MB PyPI per-file limit." >&2
+    exit 1
+  elif [ "${size_mb}" -ge 85 ]; then
+    echo "WARNING: $(basename "${whl}") is ${size_mb} MB, approaching the 100 MB PyPI per-file limit." >&2
+  fi
+done
 
 deactivate
 ccache -s

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -92,10 +92,10 @@ export LD_LIBRARY_PATH="${DUNE_BUILD_DIR}/lib:${VCPKG_LIB_DIRS}${LD_LIBRARY_PATH
 for whl in "${WHEEL_DIR}"/final/*.whl; do
   size_mb=$(( $(stat -c %s "${whl}") / 1000000 ))
   echo "wheel size: ${size_mb} MB  $(basename "${whl}")"
-  if [ "${size_mb}" -ge 100 ]; then
+  if [[ "${size_mb}" -ge 100 ]]; then
     echo "ERROR: $(basename "${whl}") is ${size_mb} MB, above the 100 MB PyPI per-file limit." >&2
     exit 1
-  elif [ "${size_mb}" -ge 85 ]; then
+  elif [[ "${size_mb}" -ge 85 ]]; then
     echo "WARNING: $(basename "${whl}") is ${size_mb} MB, approaching the 100 MB PyPI per-file limit." >&2
   fi
 done

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -79,8 +79,12 @@ DUNE_BUILD_DIR="${DUNE_SRC_DIR}/build/wheelbuilder-release"
 # being statically linked into each of the ~100 extension modules. auditwheel resolves those NEEDED entries through
 # the dynamic loader, so point it at the build tree: the module .so files carry a build-tree RUNPATH, but relying on
 # it alone breaks as soon as a toolchain strips or rewrites it during packaging.
+# Every element is appended conditionally and the trailing separator `find -printf` leaves behind is stripped: an
+# empty element in LD_LIBRARY_PATH means "the current working directory" to the dynamic loader, which would let
+# anything lying around in the build directory shadow a real dependency during the repair.
 VCPKG_LIB_DIRS="$(find "${DUNE_BUILD_DIR}/vcpkg_installed" -mindepth 2 -maxdepth 2 -type d -name lib -printf '%p:' 2>/dev/null || true)"
-export LD_LIBRARY_PATH="${DUNE_BUILD_DIR}/lib:${VCPKG_LIB_DIRS}${LD_LIBRARY_PATH:-}"
+VCPKG_LIB_DIRS="${VCPKG_LIB_DIRS%:}"
+export LD_LIBRARY_PATH="${DUNE_BUILD_DIR}/lib${VCPKG_LIB_DIRS:+:${VCPKG_LIB_DIRS}}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 # Bundle external shared libraries into the wheels
 "${PYTHON_BIN}" -m auditwheel repair --plat "${PLATFORM}" "${TMP_WHEEL_DIR}"/*xt*.whl -w "${WHEEL_DIR}/final"

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -595,6 +595,39 @@ jobs:
         path: build/wheelhouse/cache
         key: ${{ runner.os }}-wheels-ccache-${{ matrix.python-version }}-main
 
+    - name: Report wheel sizes
+      # Surface the size of every built wheel in the job summary. PyPI refuses any
+      # file above 100 MB per project, and that rejection would otherwise only show
+      # up in the publish job on a push to main -- long after the change that caused
+      # it merged. build-wheels.sh already fails the build past that limit; this step
+      # makes the trend visible while there is still headroom.
+      if: always()
+      shell: bash
+      run: |
+        shopt -s nullglob
+        wheels=(build/wheelhouse/final/*.whl)
+        if [ ${#wheels[@]} -eq 0 ]; then
+          echo "no wheels were built" >> "${GITHUB_STEP_SUMMARY}"
+          exit 0
+        fi
+        {
+          echo "### Wheel sizes (Python ${{ matrix.python-version }})"
+          echo
+          echo "| wheel | size | PyPI limit |"
+          echo "| --- | ---: | ---: |"
+        } >> "${GITHUB_STEP_SUMMARY}"
+        for whl in "${wheels[@]}"; do
+          size_mb=$(( $(stat -c %s "${whl}") / 1000000 ))
+          if [ "${size_mb}" -ge 100 ]; then
+            verdict="over"
+          elif [ "${size_mb}" -ge 85 ]; then
+            verdict="close"
+          else
+            verdict="ok"
+          fi
+          echo "| \`$(basename "${whl}")\` | ${size_mb} MB | ${verdict} (100 MB) |" >> "${GITHUB_STEP_SUMMARY}"
+        done
+
     - name: Upload wheels
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/.github/workflows/non_docker_build.yml
+++ b/.github/workflows/non_docker_build.yml
@@ -606,7 +606,7 @@ jobs:
       run: |
         shopt -s nullglob
         wheels=(build/wheelhouse/final/*.whl)
-        if [ ${#wheels[@]} -eq 0 ]; then
+        if [[ ${#wheels[@]} -eq 0 ]]; then
           echo "no wheels were built" >> "${GITHUB_STEP_SUMMARY}"
           exit 0
         fi
@@ -618,9 +618,9 @@ jobs:
         } >> "${GITHUB_STEP_SUMMARY}"
         for whl in "${wheels[@]}"; do
           size_mb=$(( $(stat -c %s "${whl}") / 1000000 ))
-          if [ "${size_mb}" -ge 100 ]; then
+          if [[ "${size_mb}" -ge 100 ]]; then
             verdict="over"
-          elif [ "${size_mb}" -ge 85 ]; then
+          elif [[ "${size_mb}" -ge 85 ]]; then
             verdict="close"
           else
             verdict="ok"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -60,7 +60,9 @@
         "ninja-base"
       ],
       "cacheVariables": {
-        "VCPKG_MANIFEST_FEATURES": ""
+        "VCPKG_MANIFEST_FEATURES": "",
+        "BUILD_SHARED_LIBS": "ON",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-shared"
       }
     },
     {

--- a/cmake/modules/DunePybindxiUtils.cmake
+++ b/cmake/modules/DunePybindxiUtils.cmake
@@ -15,6 +15,37 @@
 # ~~~
 
 # ~~~
+# Keep a single compiled extension module as small as it can be.
+#
+# The wheels ship ~100 of these modules, so anything that is paid per module is paid a hundred times over and the
+# PyPI 100 MB per-file limit is reached quickly (it was, see the 145 MB dune.gdt wheel of 2026-08). Two link-time
+# knobs cut the per-module cost without touching the generated code:
+#
+#   --exclude-libs,ALL  Every symbol pulled in from a *static* archive (ALUGrid, OpenBLAS, boost, the dune module
+#                       libraries) is otherwise re-exported from the module, even though nothing outside the module
+#                       can meaningfully use it -- pybind11 shares its type registry through a Python capsule, not
+#                       through the ELF symbol table, and CPython dlopen()s extension modules with RTLD_LOCAL. Across
+#                       the 102 modules of the 2026.2.0.571 dune.gdt wheel those exports cost 100 MB of symbol
+#                       table, relocation and PLT machinery (16 MB of the 146 MB the wheel compressed down to):
+#                       4264 exported symbols per module, of which only 6989 are distinct in total. Localising them
+#                       also makes the next flag effective.
+#   --gc-sections       With every function and data item in its own section (-ffunction-sections/-fdata-sections)
+#                       and the static-archive symbols no longer exported, the linker can drop what this particular
+#                       module never reaches. Unreferenced archive members are what the exports were pinning.
+#
+# Both are GNU-ld/lld options and are only added for ELF targets. --gc-sections is safe for the static
+# initialisers the dune/ALUGrid singletons rely on: the default linker script wraps .init_array/.fini_array in
+# KEEP(), and the module entry point PyInit_<name> keeps pybind11's own translation unit rooted.
+# ~~~
+function(dune_pybindxi_minimize_module_size target_name)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    return()
+  endif()
+  target_compile_options(${target_name} PRIVATE -ffunction-sections -fdata-sections)
+  target_link_options(${target_name} PRIVATE "-Wl,--exclude-libs,ALL" "-Wl,--gc-sections")
+endfunction()
+
+# ~~~
 # Build a Python extension module:
 # dune_pybindxi_add_module(<name> [MODULE | SHARED] [EXCLUDE_FROM_ALL] [NO_EXTRAS] [THIN_LTO] source1 [source2 ...])
 # Renamed copy of pybind11_add_module, added code blocks are marked with dune-pybindxi START/END.
@@ -29,6 +60,7 @@ macro(DUNE_PYBINDXI_ADD_MODULE target_name)
   dune_target_enable_all_packages(${target_name})
 
   target_include_directories(${target_name} PRIVATE ${PYBIND11_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS})
+  dune_pybindxi_minimize_module_size(${target_name})
   add_dependencies(bindings ${target_name})
 endmacro()
 


### PR DESCRIPTION
Fixes the Test PyPI upload failure in [run 31054402506](https://github.com/dune-gdt/dune-gdt/actions/runs/31054402506/job/92516769236):

```
400 File too large. Limit for project 'dune.gdt' is 100 MB.
INFO wheels/dune_gdt-2026.2.0.571-...whl (145.8 MB)
INFO wheels/dune_xt-2026.2.0.571-...whl  (51.2 MB)
```

**Result: `dune_gdt` 145.8 MB → 65.0 MB, `dune_xt` 51.2 MB → 32.3 MB**, measured on this PR's own wheels (see "Measured effect" at the bottom).

## Where the 145.8 MB goes

I downloaded the rejected `wheels_3.13` artifact and measured it.

The wheel is **102 extension modules, 544 MB of ELF payload**, no single outlier — the largest module is 16.7 MB and the median is ~5 MB. Compressed budget of the 145.8 MB wheel:

| section | raw | compressed | share |
| --- | ---: | ---: | ---: |
| `.text` | 293.5 MB | 114.1 MB | 78% |
| `.eh_frame` + `.eh_frame_hdr` + `.gcc_except_table` | 47.3 MB | 16.2 MB | 11% |
| `.dynstr`/`.dynsym`/`.gnu.hash`/`.rela.dyn`/`.plt` | 100 MB | 15.6 MB | 11% |
| `.rodata` | 14.6 MB | 3.4 MB | 2% |

Two findings explain almost all of it:

**1. Every module is an independent static link of the same code.** No module has a dune library in its `NEEDED` list — the wheelbuilder preset builds everything static, so ALUGrid, OpenBLAS, boost, `libdunext.a` and `libdunegdt.a` are copied into all 102 modules. Across the wheel there are 434918 defined dynamic symbols resolving to **6989 distinct names** — a 62× duplication factor. Attributing the exported bytes by origin:

| origin | duplicated bytes |
| --- | ---: |
| ALUGrid | 71.2 MB |
| BLAS/LAPACK (OpenBLAS) | 49.4 MB |
| dune-xt | 13.6 MB |
| dune core (common/grid/istl/geometry) | 9.2 MB |
| boost | 6.4 MB |

Compressing the modules jointly with a window wide enough to see across files (`xz --lzma2=dict=512MiB` over a 20-module, 92 MB sample) yields 9.6 MB against 18.9 MB for the same modules compressed individually: **~50% of the compressed payload is literally duplicated bytes**.

**2. Those static dependencies re-export everything.** 4264 exported symbols per module, essentially the same set each time, none of them reachable or useful from outside the module (pybind11 shares its type registry through a Python capsule, and CPython `dlopen`s extension modules `RTLD_LOCAL`). That is the 100 MB / 15.6 MB compressed row above, and it also pins archive members `--gc-sections` would otherwise drop.

For reference, the size history on Test PyPI: 82 MB in June, 87.5 MB through mid-July, then 92.5 → 96.8 MB on 2026-07-14 (the last successful upload), and 145.8 MB now. The growth tracks the dependency surface widening (grid-glue re-enabled, Eigen3/TBB/LAPACKE made mandatory) — with static linking each addition is paid 102 times.

## What this PR changes

**Build the wheel's dependencies shared** (`CMakePresets.json`). `wheelbuilder-base` now sets `BUILD_SHARED_LIBS=ON` and `VCPKG_TARGET_TRIPLET=x64-linux-shared`, the same pair the `release` preset already uses. ALUGrid, boost, TBB, the dune modules and `libdunext`/`libdunegdt` become shared objects that `auditwheel` bundles into `dune_gdt.libs/` once instead of being linked into every module. This configuration is not new to the project — the `clang22-release_coverage` CI leg inherits from `release`, so it already builds the bindings and runs the Python test suite against exactly this linkage.

`build-wheels.sh` exports `LD_LIBRARY_PATH` over the build tree before `auditwheel repair`, so the newly shared libraries resolve even if the build-tree `RUNPATH` does not survive packaging.

**Drop the per-module export and dead-code cost** (`DunePybindxiUtils.cmake`). Every binding module is now compiled with `-ffunction-sections -fdata-sections` and linked with `-Wl,--exclude-libs,ALL -Wl,--gc-sections`. `--gc-sections` is safe for the static initialisers the dune/ALUGrid singletons rely on: the default linker script wraps `.init_array`/`.fini_array` in `KEEP()`, and `PyInit_` roots the module's own translation unit.

**Enforce the limit where it is actionable** (`build-wheels.sh`, workflow). The build now fails when a wheel exceeds 100 MB and warns from 85 MB, and the workflow writes the sizes into the job summary. Until now the limit was enforced only by PyPI, at upload time on `main`, long after the responsible change had merged — which is why this went unnoticed for three weeks.

## Measured effect

From this PR's `build_wheels` job on [run 31128529368](https://github.com/dune-gdt/dune-gdt/actions/runs/31128529368), artifact downloaded and measured against the rejected 2026.2.0.571 build:

| wheel | before | after | |
| --- | ---: | ---: | ---: |
| `dune_gdt` | 145.8 MB | **65.0 MB** | −55% |
| `dune_xt` | 51.2 MB | **32.3 MB** | −37% |

The mechanism, not just the total, across the 102 modules:

| | before | after |
| --- | ---: | ---: |
| modules on disk | 544 MB | 163 MB |
| `.text` | 293.5 MB | 116.2 MB |
| defined dynamic symbols | 434918 (6989 distinct) | 4393 (204 distinct) |
| exported symbols per module | 4264 | 43 |
| `.dynstr` | 41.8 MB | 1.3 MB |
| `.dynsym` | 11.5 MB | 0.8 MB |
| `.rela.dyn` | 26.4 MB | 8.4 MB |

`dune_gdt.libs/` now carries one copy of each dependency — `libdunealugrid`, `libdunecommon`, `libdunegeometry`, `libdunegrid`, `libdunegridglue`, `libdunext`, boost, TBB, LAPACK/LAPACKE, SuiteSparse — 48 MB in total, against the ~120 MB of ALUGrid and OpenBLAS code that used to be copied into every module.

Both `build-linux` legs built all bindings and passed the full CTest suite with the new link flags in place, and `build_docs` executed the documentation notebooks against the resulting wheels, so the shrunken wheels are exercised end to end.

Headroom is now comfortable, but if the wheel creeps back up the remaining levers are, roughly in order of return per unit of risk: making OpenBLAS shared in a wheel-specific triplet (it is still statically linked — the `x64-linux-shared` triplet keeps it static because its DYNAMIC_ARCH AVX512 kernels failed to build shared under gcc-13, worth re-checking on the current toolchain); `-Wl,--icf=all` with lld or gold, which folds identical template instantiations; `-Os` for the binding translation units; and reducing the instantiation surface itself (the 1d/2d/3d × grid-type product behind those 102 modules).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package builds to better resolve shared-library dependencies.
  * Reduced extension package sizes by removing unused compiled content.
  * Standardized shared-library packaging for Linux distributions.

* **Tests**
  * Added automated package-size checks against the 100 MB publishing limit.
  * Build reports now identify packages that are within the limit, approaching it, or over it.
  * Builds provide clear feedback when no packages are produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->