### PR TITLE
build(deps): relock after the clangquill&lt;0.10.0 pin

### DIFF
--- a/python/gdt/uv.lock
+++ b/python/gdt/uv.lock
@@ -916,9 +916,9 @@ visualisation = [
 requires-dist = [
     { name = "bokeh", marker = "extra == 'all'" },
     { name = "bokeh", marker = "extra == 'parallel'" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.6.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0,<0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.6.0,<0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.6.0,<0.10.0" },
     { name = "cmake-format", marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "cmake-format", marker = "extra == 'infrastructure'", specifier = "==0.4.1" },
     { name = "codecov", marker = "extra == 'all'" },

--- a/python/xt/uv.lock
+++ b/python/xt/uv.lock
@@ -907,9 +907,9 @@ test = [
 requires-dist = [
     { name = "bokeh", marker = "extra == 'all'" },
     { name = "bokeh", marker = "extra == 'parallel'" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.6.0" },
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.6.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0,<0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'docs'", specifier = ">=0.6.0,<0.10.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'infrastructure'", specifier = ">=0.6.0,<0.10.0" },
     { name = "cmake-format", marker = "extra == 'all'", specifier = "==0.4.1" },
     { name = "cmake-format", marker = "extra == 'infrastructure'", specifier = "==0.4.1" },
     { name = "codecov", marker = "extra == 'all'" },


### PR DESCRIPTION
Split out of #441, where this rode along as unrelated noise in a lockfile regeneration.

eb2cf1e added an upper bound to the clangquill requirement in `python/xt/pyproject.toml`:

```toml
'clangquill>=0.6.0,<0.10.0; python_version >= "3.13"',
```

but did not regenerate the committed lockfiles, so both `python/xt/uv.lock` and `python/gdt/uv.lock` still record the requirement as `>=0.6.0`.

Nothing is broken today — the resolved clangquill version is already below the bound, and the CI paths use `uv run --frozen`, which assumes the lockfile is current rather than checking it. But the tree does not satisfy `uv lock --locked`, and the drift attaches itself to the next unrelated relock, which is exactly how it turned up in #441.

Regenerated with `python python/update_lockfiles.py`. The whole diff is six lines, three per lockfile — only the recorded specifier changes, no package version moves:

```diff
-    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0" },
+    { name = "clangquill", marker = "python_full_version >= '3.13' and extra == 'all'", specifier = ">=0.6.0,<0.10.0" },
```

---
_Generated by [Claude Code](https://claude.ai/code/session_018m1eLuzw6uevxPYkFEaEPS)_